### PR TITLE
Add space after "echo -n" for nicer-looking prompts

### DIFF
--- a/src/core/exec.c
+++ b/src/core/exec.c
@@ -400,7 +400,7 @@ static int echo_exec ( int argc, char **argv ) {
 		return -ENOMEM;
 
 	/* Print text */
-	printf ( "%s%s", text, ( opts.no_newline ? "" : "\n" ) );
+	printf ( "%s%s", text, ( opts.no_newline ? " " : "\n" ) );
 
 	free ( text );
 	return 0;


### PR DESCRIPTION
Small change to make interactive prompts look a bit nicer.  e.g.:

Enter IP address for foo: 1.2.3.4

instead of 

Enter IP address for foo:1.2.3.4
