### PR TITLE
[http] recognize status code 303 as valid

### DIFF
--- a/src/net/tcp/http.c
+++ b/src/net/tcp/http.c
@@ -203,6 +203,7 @@ static int http_response_to_rc ( unsigned int response ) {
 	case 206:
 	case 301:
 	case 302:
+	case 303:
 		return 0;
 	case 404:
 		return -ENOENT;


### PR DESCRIPTION
According to RFC 2616 10.3.4, a 303 status is the proper http 1.1
behavior for what most http 1.0 clients did with code 302. Since ipxe's
http client advertises itself as http 1.1, it should recognize both.

Signed-off-by: Jason Lunz lunz@acm.org
