### PR TITLE
[romprefix] Allow to enforce PnP BIOSes to be detected as non-PnP

### DIFF
--- a/src/arch/i386/prefix/romprefix.S
+++ b/src/arch/i386/prefix/romprefix.S
@@ -295,6 +295,7 @@ no_pci3:
 	popl	%edx
 	popl	%ebx
 
+#ifndef NONPNP_FORCE
 	/* Check for PnP BIOS.  Although %es:di should point to the
 	 * PnP BIOS signature on entry, some BIOSes fail to do this.
 	 */
@@ -317,6 +318,7 @@ pnp_scan:
 	xorw	%di, %di
 	call	print_message
 	jmp	pnp_done
+#endif /* NONPNP_FORCE */
 no_pnp:	/* Not PnP-compliant - hook INT 19 */
 #ifdef NONPNP_HOOK_INT19
 	movw	$init_message_int19, %si

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -139,7 +139,12 @@ FILE_LICENCE ( GPL2_OR_LATER );
  * ROM-specific options
  *
  */
+/* Some BIOSes do not allow to be configured to boot from option ROMs.
+ * The first option below enables hooking of INT19 on non-PnP BIOSes
+ * to allow iPXE to hijack the boot process. The second option allows
+ * this even for PnP BIOSes by enforcing the detection of a non-PnP BIOS. */
 #undef	NONPNP_HOOK_INT19	/* Hook INT19 on non-PnP BIOSes */
+#undef	NONPNP_FORCE		/* Force non-PnP BIOS */
 
 /*
  * Error message tables to include


### PR DESCRIPTION
Add a define NONPNP_FORCE that controls building of the PnP detection
routine. Together with the existing NONPNP_HOOK_INT19 hook this enables
booting iPXE on PnP BIOSes that can not be persuaded to boot iPXE by
BIOS menu configuration alone (e.g. my abit BX6 2.0).

Signed-off-by: Stefan Tauner stefan.tauner@gmx.at
