### PR TITLE
Check if git index actually exists

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -686,7 +686,9 @@ CFLAGS_version += -DVERSION_MAJOR=$(VERSION_MAJOR) \
 		  -DVERSION="\"$(VERSION)\""
 # Make sure the version number gets updated on every git checkout
 ifneq ($(GITVERSION),)
+ifneq ($(wildcard ../.git/index),)
 $(BIN)/version.o : ../.git/index
+endif
 endif
 
 # We automatically generate rules for any file mentioned in AUTO_SRCS


### PR DESCRIPTION
We should check if ../.git/index actually exists before relying on it. In case of using ipxe as a git submodule that's not true, and we shouldn't disallow bulding ipxe.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
