### PR TITLE
Expose board-serial and board-product through SMBios

### DIFF
--- a/src/include/ipxe/smbios.h
+++ b/src/include/ipxe/smbios.h
@@ -116,6 +116,23 @@ struct smbios_system_information {
 /** SMBIOS system information structure type */
 #define SMBIOS_TYPE_SYSTEM_INFORMATION 1
 
+/** SMBIOS base board information structure */
+struct smbios_base_board_information {
+	/** SMBIOS structure header */
+	struct smbios_header header;
+	/** Manufacturer string */
+	uint8_t manufacturer;
+	/** Product string */
+	uint8_t board_product;
+	/** Version string */
+	uint8_t version;
+	/** Serial number string */
+	uint8_t board_serial;
+} __attribute__ (( packed ));
+
+/** SMBIOS base board information structure type */
+#define SMBIOS_TYPE_BASE_BOARD_INFORMATION 2
+
 /** SMBIOS enclosure information structure */
 struct smbios_enclosure_information {
 	/** SMBIOS structure header */

--- a/src/interface/smbios/smbios_settings.c
+++ b/src/interface/smbios/smbios_settings.c
@@ -241,3 +241,14 @@ const struct setting asset_setting __setting ( SETTING_HOST_EXTRA, asset ) = {
 	.type = &setting_type_string,
 	.scope = &smbios_settings_scope,
 };
+
+/** Board serial setting - may differ from chassis serial*/
+const struct setting board_serial_setting __setting ( SETTING_HOST_EXTRA, board_serial ) = {
+	.name = "board-serial",
+	.description = "Base board serial",
+	.tag = SMBIOS_STRING_TAG ( SMBIOS_TYPE_BASE_BOARD_INFORMATION,
+				   struct smbios_base_board_information,
+				   board_serial ),
+	.type = &setting_type_string,
+	.scope = &smbios_settings_scope,
+};


### PR DESCRIPTION
This change exposes the SMBios attributes for the board serial and board product.

This enables for unique identification of Blade nodes, where the chassis serial will be the same as all other blades in the chassis.

We currently use these attributes at Shopify to uniquely identify nodes at boot time, where we can't depend on other attributes such as UUID to exist.

It's a relatively minor change, and expands the existing functionality by exposing additional standard SMBios attributes, which are particularly useful on blade nodes / where there are multiple nodes per chassis.
