### PR TITLE
[build] Avoid using embedded script in VirtualBox named configuration

### DIFF
--- a/src/config/vbox/README
+++ b/src/config/vbox/README
@@ -1,16 +1,18 @@
 Build using this command line:
 
-make CONFIG=vbox EMBED=config/vbox/embedded.ipxe bin/intel--virtio-net--pcnet32.rom
+make CONFIG=vbox bin/intel--virtio-net--pcnet32.isarom
 
 Max size of a VirtualBox ROM is 56KB, 57344 bytes. There should be no need
 to pad the image as long as the binary is smaller or equal to this size.
-
-The embedded script is required because VirtualBox uses the ROM as an ISA
-ROM, which will not perform any autoboot behavior.  The bundled embedded
-script reproduces the default autoboot behavior.
 
 To use the ROM in VirtualBox you need to enable it using this command:
 
 vboxmanage setextradata global \
     VBoxInternal/Devices/pcbios/0/Config/LanBootRom \
-    path/to/intel--virtio-net--pcnet32.rom
+    /absolute/path/to/intel--virtio-net--pcnet32.isarom
+
+NB: If you build the ROM using the .rom prefix then it'll be built as a PCI
+ROM, which won't work properly in VirtualBox.  The error message you'll see
+is "No more network devices", which is somewhat confusing.  If you enter the
+shell and use the "autoboot" command things will work as intended.  Remember
+to always build as a .isarom to avoid this issue.

--- a/src/config/vbox/embedded.ipxe
+++ b/src/config/vbox/embedded.ipxe
@@ -1,5 +1,0 @@
-#!ipxe
-prompt --key 0x02 --timeout 2000 Press Ctrl-B to enter the iPXE shell... && shell || goto auto
-exit
-:auto
-autoboot

--- a/src/config/vbox/general.h
+++ b/src/config/vbox/general.h
@@ -1,7 +1,6 @@
 /* Disabled from config/defaults/pcbios.h */
 
 #undef IMAGE_ELF
-#undef IMAGE_MULTIBOOT
 #undef SANBOOT_PROTO_ISCSI
 #undef SANBOOT_PROTO_AOE
 #undef SANBOOT_PROTO_IB_SRP


### PR DESCRIPTION
With the new build support for the .isarom prefix it is now possible to avoid the embedded script completely and still get the normal autoboot behavior.

As we now have more space it was possible to re-enable the support for MULTIBOOT images.
