### PR TITLE
Wrong UUID on (some) Dell systems

### DIFF
--- a/src/interface/smbios/smbios_settings.c
+++ b/src/interface/smbios/smbios_settings.c
@@ -137,12 +137,14 @@ static int smbios_fetch ( struct settings *settings __unused,
 		 */
 		raw = &buf[tag_offset];
 		if ( ( setting->type == &setting_type_uuid ) &&
-		     ( tag_len == sizeof ( uuid ) ) &&
-		     ( smbios_version() >= SMBIOS_VERSION ( 2, 6 ) ) ) {
-			DBG ( "SMBIOS detected mangled UUID\n" );
+		     ( tag_len == sizeof ( uuid ) ) )  {
 			memcpy ( &uuid, &buf[tag_offset], sizeof ( uuid ) );
-			uuid_mangle ( &uuid );
-			raw = &uuid;
+			DBG ( "SMBIOS detected mangled UUID\n" );
+            if ( ( smbios_version() >= SMBIOS_VERSION ( 2, 6 ) ) ||
+                 ( uuid.canonical.a == 0x4c4c4544 ) ) {
+                uuid_mangle ( &uuid );
+                raw = &uuid;
+            }
 		}
 
 		/* Return data */


### PR DESCRIPTION
Seems like some Dell desktops/laptops with older SMBIOS (2.4 in my tests)

have also UUIDs in little-endian, those need to be mangled also to be
correct. (if not, it seems to give issues with SCCM/WDS)

Explicitly check on 0x4c4c4544 for DELL
