### PR TITLE
tftp booting from a windows TFTP server gives issues.

### DIFF
--- a/src/net/udp/tftp.c
+++ b/src/net/udp/tftp.c
@@ -323,7 +323,7 @@ void tftp_set_mtftp_port ( unsigned int port ) {
  * @ret rc		Return status code
  */
 static int tftp_send_rrq ( struct tftp_request *tftp ) {
-	const char *path = tftp->uri->path;
+	const char *path = tftp->uri->path+1;
 	struct tftp_rrq *rrq;
 	size_t len;
 	struct io_buffer *iobuf;


### PR DESCRIPTION
PXE sends a leading / that needs to be removed.

e.g. chain tftp://ip.of.server/boot\x64\wdsbnp.com

PXE send TFTP Request /Boot\x64\wdsnbp.com
That first "/" must be removed.

Original fix from
http://forum.ipxe.org/archive/index.php/thread-7242.html