### PR TITLE
Reverts changes to src/net/udp/tftp.c made in commit 76675365271291beb9d...

### DIFF
--- a/src/net/udp/tftp.c
+++ b/src/net/udp/tftp.c
@@ -323,11 +323,23 @@ void tftp_set_mtftp_port ( unsigned int port ) {
  * @ret rc		Return status code
  */
 static int tftp_send_rrq ( struct tftp_request *tftp ) {
-	const char *path = tftp->uri->path;
 	struct tftp_rrq *rrq;
+	const char *path;	
 	size_t len;
 	struct io_buffer *iobuf;
 	size_t blksize;
+
+	/* Strip initial '/' if present. If we were opened via the
+	* URI interface, then there will be an initial '/', since a
+	* full tftp:// URI provides no way to specify a non-absolute
+	* path. However, many TFTP servers (particularly Windows
+	* TFTP servers) complain about having an initial '/', and it
+	* violates user expectations to have a '/' silently added to
+	* the DHCP-specified filename.
+	*/
+	path = tftp->uri->path;
+	if ( *path == '/' )
+		path++;
 
 	DBGC ( tftp, "TFTP %p requesting \"%s\"\n", tftp, path );
 


### PR DESCRIPTION
...daeec10da14f4faa55ecc on 02/27/14.

This allows tftp to load from a Windows/Microsoft TFTP server.
This should also fix pull request #31: https://github.com/ipxe/ipxe/pull/31
Without this, when you try to load from a Windows/Microsoft TFTP server,
you get error 3d1260 "Inappropriate I/O control operation", as there is a leading "/".