### PR TITLE
[wip][freebsd] Initial support freebsd boot

### DIFF
--- a/src/arch/i386/image/amd64_tramp.S
+++ b/src/arch/i386/image/amd64_tramp.S
@@ -1,0 +1,140 @@
+/*-
+ * Copyright (c) 2003  Peter Wemm <peter@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+
+
+
+
+#define MSR_EFER	0xc0000080
+#define EFER_LME	0x00000100
+#define CR4_PAE		0x00000020
+#define CR4_PSE		0x00000010
+#define CR0_PG		0x80000000
+
+#define VPBASE	0xa000
+#define VTOP(x)	((x) + VPBASE)
+
+
+
+	.data
+
+/* Loader pagetable */
+/* During early boot, kernel will construct an equivalent mapping 
+   (sys/amd64/amd64/pmap.c) */
+
+/* Align on the next 4096 (2^12) page, and pad with 0x40 */
+	.p2align 12,0x40
+
+	.globl	PT4
+PT4:
+	.space	0x1000
+	.globl	PT3
+PT3:
+	.space	0x1000
+	.globl	PT2
+PT2:
+	.space	0x1000
+
+
+gdtdesc:
+	.word	gdtend - gdt
+	.long	VTOP(gdt)		# low
+	.long	0			# high
+
+gdt:
+	.long	0			# null descriptor
+	.long	0
+	.long	0x00000000		# %cs
+	.long	0x00209800
+	.long	0x00000000		# %ds
+	.long	0x00008000
+
+gdtend:
+	.text
+
+
+
+
+	.code32
+
+
+	.global __exec
+
+	.set INT_SYS,0x30		# Interrupt number
+
+__exec:
+	/* move jumppoint atop of the stack */
+	movl $0x1,%eax			# BTX system
+	/* FAR_JUMP */
+	int $INT_SYS			#  call 0x1
+
+	.globl	amd64_tramp
+amd64_tramp:
+	/* Be sure that interrupts are disabled */
+	cli
+
+	/* Turn on EFER.LME */
+	movl	$MSR_EFER, %ecx
+	rdmsr
+	orl	$EFER_LME, %eax
+	wrmsr
+
+	/* Turn on PAE */
+	movl	%cr4, %eax
+	orl	$CR4_PAE, %eax
+	movl	%eax, %cr4
+
+	/* Set %cr3 for PT4 */
+	/* setup paging */
+	movl	$VTOP(PT4), %eax
+	movl	%eax, %cr3
+
+	/* Turn on paging (implicitly sets EFER.LMA) */
+	movl	%cr0, %eax
+	orl	$CR0_PG, %eax
+	movl	%eax, %cr0
+
+	/* Now we're in compatability mode. set %cs for long mode */
+	movl	$VTOP(gdtdesc), %eax
+	movl	VTOP(entry_hi), %esi
+	movl	VTOP(entry_lo), %edi
+	lgdt	(%eax)
+	ljmp	$0x8, $VTOP(longmode)
+
+	.code64
+longmode:
+	/* We're still running V=P, jump to entry point */
+	movl	%esi, %eax
+	salq	$32, %rax
+	orq	%rdi, %rax
+	pushq	%rax
+	ret
+
+
+
+

--- a/src/arch/i386/image/freebsd.c
+++ b/src/arch/i386/image/freebsd.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2008 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <errno.h>
+#include <elf.h>
+#include <stdio.h>
+#include <ipxe/image.h>
+#include <ipxe/elf.h>
+#include <ipxe/features.h>
+#include <ipxe/init.h>
+#include <ipxe/io.h>
+
+typedef uint64_t p4_entry_t;
+typedef uint64_t p3_entry_t;
+typedef uint64_t p2_entry_t;
+extern p4_entry_t PT4[];
+extern p3_entry_t PT3[];
+extern p2_entry_t PT2[];
+extern char * BLAH;
+
+uint32_t entry_hi;
+uint32_t entry_lo;
+
+extern void amd64_tramp();
+#define	VTOP(va)	virt_to_phys(va)
+typedef char * caddr_t;
+void __exec(caddr_t, ...);
+
+#define ALIGN_UP(value, align)  (((value) & (align-1)) ?                \
+                                (((value) + (align-1)) & ~(align-1)) : \
+                                (value))
+#define ALIGN_PAGE(a)           ALIGN_UP (a, 4096)
+
+#define PG_V	0x001
+#define PG_RW	0x002
+#define PG_U	0x004
+#define PG_PS	0x080
+
+/**
+ * @file
+ *
+ * ELF bootable image
+ *
+ */
+
+FEATURE ( FEATURE_IMAGE, "ELF64", DHCP_EB_FEATURE_ELF, 1 );
+
+/**
+ * Prepare segment for loading
+ *
+ * @v segment		Segment start
+ * @v filesz		Size of the "allocated bytes" portion of the segment
+ * @v memsz		Size of the segment
+ * @ret rc		Return status code
+ */
+static int allocate_segment ( physaddr_t * segment, size_t sz ) {
+	struct memory_map memmap;
+	unsigned int i;
+
+	get_memmap ( &memmap );
+
+	/* Look for a suitable memory region */
+	for ( i = 0 ; i < memmap.count ; i++ ) {
+		if ( (memmap.regions[i].end - memmap.regions[i].start) > sz) {
+			*segment = memmap.regions[i].start;
+			memset_user ( *segment, 0, 0, sz);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * Execute ELF image
+ *
+ * @v image		ELF image
+ * @ret rc		Return status code
+ */
+static int elfboot64_exec ( struct image *image ) {
+	int i;
+
+	size_t size = 0;
+	physaddr_t buffer = 0;
+
+	unsigned long kern_end, modulep = 0;
+	struct image *module_image;
+	Elf64_Ehdr ehdr;
+
+	// Get total size
+	for_each_image ( module_image ) {
+		size += ALIGN_PAGE(image->len);
+	}
+	//XXX: size += ALIGN_PAGE(params)
+	//XXX: size += ALIGN_PAGE(env)
+
+	if (allocate_segment(&buffer, size) != 0) {
+		DBG ( "Couldn't allocate enough memory to fit kernel, needed %d bytes", size);
+		return -1;
+	}
+
+
+	modulep = buffer;
+
+	// Copy kernel
+	memcpy_user(phys_to_user(buffer), 0, image->data, 0, image->len);
+	buffer += ALIGN_PAGE(image->len);
+	copy_from_user ( &ehdr, image->data, 0, sizeof ( ehdr ) );
+
+	// Copy image
+	for_each_image ( module_image ) {
+		if (image == module_image) continue;
+		memcpy_user(phys_to_user(buffer), 0, module_image->data, 0, module_image->len);
+		buffer += ALIGN_PAGE(module_image->len);
+	}
+
+	kern_end = buffer;
+
+	entry_lo = ehdr.e_entry & 0xffffffff;
+	entry_hi = (ehdr.e_entry >> 32) & 0xffffffff;
+
+	for (i = 0; i < 512; i++) {
+		/* Each slot of the level 4 pages points to the same level 3 page */
+		PT4[i] = (p4_entry_t)VTOP((void *)&PT3[0]);
+		PT4[i] |= PG_V | PG_RW | PG_U;
+
+		/* Each slot of the level 3 pages points to the same level 2 page */
+		PT3[i] = (p3_entry_t)VTOP((void *)&PT2[0]);
+		PT3[i] |= PG_V | PG_RW | PG_U;
+
+		/* The level 2 page slots are mapped with 2MB pages for 1GB. */
+		PT2[i] = i * (2 * 1024 * 1024);
+		PT2[i] |= PG_V | PG_RW | PG_PS | PG_U;
+	}
+
+	/*
+	  stack[0] = VTOP(amd64_tramp)
+	  stack[1] = modulep
+	  stack[2] = kern_end
+	*/
+	__exec((void *)VTOP(amd64_tramp), modulep, kern_end);
+
+	DBG("exec returned, this is wrong, very wrong\n");
+
+	return -1;  /* -EIMPOSSIBLE, anyone? */
+}
+
+/**
+ * Probe ELF image
+ *
+ * @v image		ELF file
+ * @ret rc		Return status code
+ */
+static int elfboot64_probe ( struct image *image ) {
+	Elf64_Ehdr ehdr;
+	static const uint8_t e_ident[] = {
+		[EI_MAG0]	= ELFMAG0,
+		[EI_MAG1]	= ELFMAG1,
+		[EI_MAG2]	= ELFMAG2,
+		[EI_MAG3]	= ELFMAG3,
+		[EI_CLASS]	= ELFCLASS64,
+		[EI_DATA]	= ELFDATA2LSB,
+		[EI_VERSION]	= EV_CURRENT,
+	};
+
+	/* Read ELF header */
+	copy_from_user ( &ehdr, image->data, 0, sizeof ( ehdr ) );
+	if ( memcmp ( ehdr.e_ident, e_ident, sizeof ( e_ident ) ) != 0 ) {
+		DBG ( "Invalid ELF identifier\n" );
+		return -1;
+	}
+
+	return 0;
+}
+
+/** ELF image type */
+struct image_type freebsd_image_type __image_type ( PROBE_NORMAL ) = {
+	.name = "ELF64",
+	.probe = elfboot64_probe,
+	.exec = elfboot64_exec,
+};

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -158,6 +158,7 @@ REQUIRE_OBJECT ( nbi );
 #endif
 #ifdef IMAGE_ELF
 REQUIRE_OBJECT ( elfboot );
+REQUIRE_OBJECT ( freebsd );
 #endif
 #ifdef IMAGE_MULTIBOOT
 REQUIRE_OBJECT ( multiboot );

--- a/src/include/elf.h
+++ b/src/include/elf.h
@@ -18,6 +18,17 @@ typedef uint32_t Elf32_Off;
 typedef int32_t Elf32_Sword;
 typedef uint32_t Elf32_Word;
 
+
+typedef uint16_t Elf64_Half;
+typedef uint32_t Elf64_Word;
+typedef int32_t  Elf64_Sword;
+typedef uint64_t Elf64_Xword;
+typedef int64_t  Elf64_Sxword;
+typedef uint64_t Elf64_Addr;
+typedef uint64_t Elf64_Off;
+typedef uint16_t Elf64_Section;
+typedef Elf64_Half Elf64_Versym;
+
 /** Length of ELF identifier */
 #define EI_NIDENT 16
 
@@ -39,6 +50,25 @@ typedef struct {
 	Elf32_Half e_shstrndx;
 } Elf32_Ehdr;
 
+typedef struct
+{
+	unsigned char e_ident[EI_NIDENT];     /* Magic number and other info */
+	Elf64_Half    e_type;                 /* Object file type */
+	Elf64_Half    e_machine;              /* Architecture */
+	Elf64_Word    e_version;              /* Object file version */
+	Elf64_Addr    e_entry;                /* Entry point virtual address */
+	Elf64_Off     e_phoff;                /* Program header table file offset */
+	Elf64_Off     e_shoff;                /* Section header table file offset */
+	Elf64_Word    e_flags;                /* Processor-specific flags */
+	Elf64_Half    e_ehsize;               /* ELF header size in bytes */
+	Elf64_Half    e_phentsize;            /* Program header table entry size */
+	Elf64_Half    e_phnum;                /* Program header table entry count */
+	Elf64_Half    e_shentsize;            /* Section header table entry size */
+	Elf64_Half    e_shnum;                /* Section header table entry count */
+	Elf64_Half    e_shstrndx;             /* Section header string table index */
+} Elf64_Ehdr;
+
+
 /* ELF identifier indexes */
 #define EI_MAG0 0
 #define EI_MAG1 1
@@ -56,6 +86,7 @@ typedef struct {
 
 /* ELF classes */
 #define ELFCLASS32 1
+#define ELFCLASS64 2
 
 /* ELF data encodings */
 #define ELFDATA2LSB 1
@@ -74,6 +105,18 @@ typedef struct {
 	Elf32_Word p_flags;
 	Elf32_Word p_align;
 } Elf32_Phdr;
+
+typedef struct
+{
+  Elf64_Word    p_type;                 /* Segment type */
+  Elf64_Word    p_flags;                /* Segment flags */
+  Elf64_Off     p_offset;               /* Segment file offset */
+  Elf64_Addr    p_vaddr;                /* Segment virtual address */
+  Elf64_Addr    p_paddr;                /* Segment physical address */
+  Elf64_Xword   p_filesz;               /* Segment size in file */
+  Elf64_Xword   p_memsz;                /* Segment size in memory */
+  Elf64_Xword   p_align;                /* Segment alignment */
+} Elf64_Phdr;
 
 /* ELF segment types */
 #define PT_LOAD 1


### PR DESCRIPTION
Hi,

As this, this code does not work. I'm sending out this pull request to get feedback, and understand a bit better how memory is managed by ipxe.

The freebsd64 kernel is an elf64 kernel. The entry is an absolute virtual address. And the kernel expects to be placed at a specific address when booting. For that purpose, the freebsd loader relies on MMU to map destination virtual address to the physical address where the kernel has been allocated by the loader.
This mechanism is handled in the amd64_tramp.S and permits 32bit code to load 64bit kernel.

To perform this mapping, we need to allocate a PT4/3/2 pagetables and provide physical address to it. I'm unsure how to use the memory library in ipxe.

my comments are inline and feedback more than welcome :)

Thanks