### PR TITLE
Add set option to prompt to save the input key as a variable

### DIFF
--- a/src/image/script.c
+++ b/src/image/script.c
@@ -366,6 +366,8 @@ struct prompt_options {
 	unsigned int key;
 	/** Timeout */
 	unsigned long timeout;
+        /** Set */
+        struct named_setting set;
 };
 
 /** "prompt" option list */
@@ -374,6 +376,9 @@ static struct option_descriptor prompt_opts[] = {
 		      struct prompt_options, key, parse_key ),
 	OPTION_DESC ( "timeout", 't', required_argument,
 		      struct prompt_options, timeout, parse_timeout ),
+        OPTION_DESC ( "set", 's', required_argument,
+                      struct prompt_options, set,
+                      parse_autovivified_setting ),
 };
 
 /** "prompt" command descriptor */
@@ -391,6 +396,7 @@ static struct command_descriptor prompt_cmd =
 static int prompt_exec ( int argc, char **argv ) {
 	struct prompt_options opts;
 	char *text;
+        int key;
 	int rc;
 
 	/* Parse options */
@@ -405,14 +411,42 @@ static int prompt_exec ( int argc, char **argv ) {
 	}
 
 	/* Display prompt and wait for key */
-	if ( ( rc = prompt ( text, opts.timeout, opts.key ) ) != 0 )
+        key = prompt ( text, opts.timeout );
+        if ( key < 0 ) {
+                rc = key;
 		goto err_prompt;
+        }
+
+        /* Check for correct key, if specified */
+        if ( opts.key && ( key != ( ( int ) opts.key ) ) ) {
+                rc = -ECANCELED;
+                goto err_wrong_key;
+        }
+
+        /* Store key, if specified */
+        if ( opts.set.settings ) {
+
+                /* Apply default type if necessary */
+                if ( ! opts.set.setting.type )
+                        opts.set.setting.type = &setting_type_uint16;
+
+                /* Store setting */
+                if ( ( rc = storen_setting ( opts.set.settings,
+                                             &opts.set.setting,
+                                             key ) ) != 0 ) {
+                        printf ( "Could not store \"%s\": %s\n",
+                                 opts.set.setting.name, strerror ( rc ) );
+                        goto err_store;
+                }
+        }
 
 	/* Free prompt text */
 	free ( text );
 
 	return 0;
 
+ err_store:
+ err_wrong_key:
  err_prompt:
 	free ( text );
  err_concat:

--- a/src/include/usr/prompt.h
+++ b/src/include/usr/prompt.h
@@ -9,6 +9,6 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
-extern int prompt ( const char *text, unsigned long timeout, int key );
+extern int prompt ( const char *text, unsigned long timeout );
 
 #endif /* _USR_PROMPT_H */

--- a/src/usr/autoboot.c
+++ b/src/usr/autoboot.c
@@ -501,6 +501,7 @@ static int autoboot ( void ) {
  * @ret	enter_shell	User wants to enter shell
  */
 static int shell_banner ( void ) {
+        int key;
 
 	/* Skip prompt if timeout is zero */
 	if ( BANNER_TIMEOUT <= 0 )
@@ -508,10 +509,17 @@ static int shell_banner ( void ) {
 
 	/* Prompt user */
 	printf ( "\n" );
-	return ( prompt ( "Press Ctrl-B for the " PRODUCT_SHORT_NAME
+	key = prompt ( "Press Ctrl-B for the " PRODUCT_SHORT_NAME
 			  " command line...",
-			  ( ( BANNER_TIMEOUT * TICKS_PER_SEC ) / 10 ),
-			  CTRL_B ) == 0 );
+			  ( ( BANNER_TIMEOUT * TICKS_PER_SEC ) / 10 ) );
+        if ( key < 0 )
+                return key;
+
+        /* Check for correct keypress */
+        if ( key != CTRL_B )
+                return -ECANCELED;
+
+        return 0;
 }
 
 /**

--- a/src/usr/prompt.c
+++ b/src/usr/prompt.c
@@ -44,27 +44,24 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *
  * Returns success if the specified key was pressed within the
  * specified timeout period.
+ * @ret key             Key pressed, or negative error
  */
-int prompt ( const char *text, unsigned long timeout, int key ) {
-	int key_pressed;
+int prompt ( const char *text, unsigned long timeout ) {
+	int key;
 
 	/* Display prompt */
 	printf ( "%s", text );
 
 	/* Wait for key */
-	key_pressed = getkey ( timeout );
+        key = getkey ( timeout );
 
 	/* Clear the prompt line */
 	while ( *(text++) )
 		printf ( "\b \b" );
 
 	/* Check for timeout */
-	if ( key_pressed < 0 )
+	if ( key < 0 )
 		return -ETIMEDOUT;
 
-	/* Check for correct key pressed */
-	if ( key && ( key_pressed != key ) )
-		return -ECANCELED;
-
-	return 0;
+	return key;
 }


### PR DESCRIPTION
Ability to save the input key when using 'prompt' as a variable.
With this you are able to use this in the script further on, for example:

prompt --set keycombo --timeout 5000 Press Ctrl-B for the menu... && goto keypress || goto exit
:keypress
isset ${keycombo} || set keycombo 0x2
iseq ${keycombo} 0x1 && goto ctrla ||
iseq ${keycombo} 0x2 && goto ctrlb ||
iseq ${keycombo} 0x11 && goto ctrlq ||
echo You pressed: ${keycombo}
goto exit