### PR TITLE
enable bin/ipxe.iso target to build on FreeBSD

### DIFF
--- a/src/arch/i386/Makefile
+++ b/src/arch/i386/Makefile
@@ -95,6 +95,7 @@ SYSLINUX_DIR_LIST	:= \
 	/usr/share/syslinux/modules/bios \
 	/usr/local/share/syslinux \
 	/usr/local/share/syslinux/bios \
+	/usr/local/share/syslinux/bios/core \
 	/usr/local/share/syslinux/modules/bios \
 	/usr/lib/ISOLINUX
 ISOLINUX_BIN_LIST	:= \

--- a/src/arch/i386/Makefile
+++ b/src/arch/i386/Makefile
@@ -96,6 +96,7 @@ SYSLINUX_DIR_LIST	:= \
 	/usr/local/share/syslinux \
 	/usr/local/share/syslinux/bios \
 	/usr/local/share/syslinux/bios/core \
+	/usr/local/share/syslinux/bios/com32/elflink/ldlinux \
 	/usr/local/share/syslinux/modules/bios \
 	/usr/lib/ISOLINUX
 ISOLINUX_BIN_LIST	:= \

--- a/src/arch/i386/Makefile.pcbios
+++ b/src/arch/i386/Makefile.pcbios
@@ -58,19 +58,19 @@ NON_AUTO_MEDIA	+= iso
 %iso:	%lkrn util/geniso
 	$(QM)$(ECHO) "  [GENISO] $@"
 	$(Q)ISOLINUX_BIN=$(ISOLINUX_BIN) LDLINUX_C32=$(LDLINUX_C32) \
-	    VERSION="$(VERSION)" bash util/geniso -o $@ $<
+	    VERSION="$(VERSION)" bash -e util/geniso -o $@ $<
 
 # rule to make a floppy emulation ISO boot image
 NON_AUTO_MEDIA	+= liso
 %liso:	%lkrn util/geniso
 	$(QM)$(ECHO) "  [GENISO] $@"
-	$(Q)VERSION="$(VERSION)" bash util/geniso -l -o $@ $<
+	$(Q)VERSION="$(VERSION)" bash -e util/geniso -l -o $@ $<
 
 # rule to make a syslinux floppy image (mountable, bootable)
 NON_AUTO_MEDIA	+= sdsk
 %sdsk:	%lkrn util/gensdsk
 	$(QM)$(ECHO) "  [GENSDSK] $@"
-	$(Q)bash util/gensdsk $@ $<
+	$(Q)bash -e util/gensdsk $@ $<
 
 # rule to write disk images to /dev/fd0
 NON_AUTO_MEDIA	+= fd0

--- a/src/util/geniso
+++ b/src/util/geniso
@@ -120,7 +120,7 @@ case "${LEGACY}" in
 		;;
 	0)
 		# copy isolinux bootloader
-		cp ${ISOLINUX_BIN} ${dir}
+		install -m 644 ${ISOLINUX_BIN} ${dir}
 
 		# syslinux 6.x needs a file called ldlinux.c32
 		if [ -n "${LDLINUX_C32}" -a -s "${LDLINUX_C32}" ]; then


### PR DESCRIPTION
```
o add a search path to isolinux.bin as installed by syslinux port
o use "install" instead of "cp" to copy isolinux.bin in place
   - isolinux.bin could be installed as 444. When using "cp", it may
     preserve these permissions, which will cause an error for mkisofs
     when mkisofs attempts to modify isolinux.bin. This potentially makes
     the script more robust on other systems as well.
```
