### PR TITLE
[settings] Add ability to get interface name

### DIFF
--- a/src/net/netdev_settings.c
+++ b/src/net/netdev_settings.c
@@ -65,6 +65,11 @@ const struct setting chip_setting __setting ( SETTING_NETDEV, chip ) = {
 	.description = "Chip",
 	.type = &setting_type_string,
 };
+const struct setting ifname_setting __setting ( SETTING_NETDEV, ifname ) = {
+	.name = "ifname",
+	.description = "Interface name",
+	.type = &setting_type_string,
+};
 
 /**
  * Store MAC address setting
@@ -199,6 +204,22 @@ static int netdev_fetch_chip ( struct net_device *netdev, void *data,
 	return strlen ( chip );
 }
 
+/**
+ * * Fetch ifname setting
+ * *
+ * * @v netdev        	Network device
+ * * @v data        	Buffer to fill with setting data
+ * * @v len        	Length of buffer
+ * * @ret len        	Length of setting data, or negative error
+ * */
+static int netdev_fetch_ifname ( struct net_device *netdev, void *data,
+			      size_t len ) {
+	const char *ifname = netdev->name;
+
+	strncpy ( data, ifname, len );
+	return strlen ( ifname );
+}
+
 /** A network device setting operation */
 struct netdev_setting_operation {
 	/** Setting */
@@ -229,6 +250,7 @@ static struct netdev_setting_operation netdev_setting_operations[] = {
 	{ &busloc_setting, NULL, netdev_fetch_busloc },
 	{ &busid_setting, NULL, netdev_fetch_busid },
 	{ &chip_setting, NULL, netdev_fetch_chip },
+	{ &ifname_setting, NULL, netdev_fetch_ifname},
 };
 
 /**


### PR DESCRIPTION
Having the ability to get the interface name makes doing things like the
following quite a bit easier:

iPXE> echo ${netX/ifname}
net0
iPXE> dhcp ${netX/ifname}
Configuring (net0 00:50:56:a6:30:ca)..... ok

Signed-off-by: Andrew Widdersheim <amwiddersheim@gmail.com>