### PR TITLE
[efi] Add options to set console to native monitor resolution

### DIFF
--- a/src/hci/commands/console_cmd.c
+++ b/src/hci/commands/console_cmd.c
@@ -70,6 +70,10 @@ static struct option_descriptor console_opts[] = {
 		      struct console_options, picture, parse_string ),
 	OPTION_DESC ( "keep", 'k', no_argument,
 		      struct console_options, keep, parse_flag ),
+	OPTION_DESC ( "auto", 'a', no_argument,
+		      struct console_options, config.automode, parse_flag ),
+	OPTION_DESC ( "max-width", 'w', no_argument,
+		      struct console_options, config.maxwidth, parse_flag ),
 };
 
 /** "console" command descriptor */

--- a/src/include/ipxe/console.h
+++ b/src/include/ipxe/console.h
@@ -38,6 +38,10 @@ struct console_configuration {
 	unsigned int bottom;
 	/** Background picture, if any */
 	struct pixel_buffer *pixbuf;
+	/** Automatically choose optimal mode */
+	int automode;
+	/** Automatically choose widest mode */
+	int maxwidth;
 };
 
 /**


### PR DESCRIPTION
Currently, there's no way to change the screen mode to the optimum mode for the monitor.  This patch adds two options to rectify that.  The first option, '-a' or '--auto', chooses the first EFI graphics mode, which on most systems is the native mode.

However, on some systems the first mode is the mode the BIOS interface is designed to use, and may not actually be the native resolution of the monitor (i.e. the monitor resolution is 1600x900, while the first mode is 1280x1024).  So the second option, '-w' or '--max-width', chooses the widest EFI graphics mode, on the assumption that that is the native monitor resolution.

In this patch, -w takes precedence over -a and both override the sizes given by -x, -y and -p.