### PR TITLE
Fixed bug in intel 10M/100M/1G NIC driver. 

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -290,7 +290,12 @@ static int intel_reset ( struct intel_nic *intel ) {
 	mdelay ( INTEL_RESET_DELAY_MS );
 
 	/* Set a sensible default configuration */
-	ctrl |= ( INTEL_CTRL_SLU | INTEL_CTRL_ASDE );
+    ctrl |= ( INTEL_CTRL_SLU | INTEL_CTRL_ASDE );
+    if(intel->flags & INTEL_NO_CTRL_ASDE)
+    {
+        /* Oliver Nie: CTRL_ASDE is reserved bit and must be set to 0b according intel 82576EB datasheet. */
+        ctrl &= ~(INTEL_CTRL_ASDE);
+    }
 	ctrl &= ~( INTEL_CTRL_LRST | INTEL_CTRL_FRCSPD | INTEL_CTRL_FRCDPLX );
 	writel ( ctrl, intel->regs + INTEL_CTRL );
 	mdelay ( INTEL_RESET_DELAY_MS );
@@ -1015,7 +1020,7 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x10c3, "82562gt-2", "82562GT-2", 0 ),
 	PCI_ROM ( 0x8086, 0x10c4, "82562gt", "82562GT", INTEL_PBS_ERRATA ),
 	PCI_ROM ( 0x8086, 0x10c5, "82562g", "82562G", INTEL_PBS_ERRATA ),
-	PCI_ROM ( 0x8086, 0x10c9, "82576", "82576", 0 ),
+	PCI_ROM ( 0x8086, 0x10c9, "82576", "82576", INTEL_NO_CTRL_ASDE ),
 	PCI_ROM ( 0x8086, 0x10cb, "82567v", "82567V", 0 ),
 	PCI_ROM ( 0x8086, 0x10cc, "82567lm-2", "82567LM-2", 0 ),
 	PCI_ROM ( 0x8086, 0x10cd, "82567lf-2", "82567LF-2", 0 ),

--- a/src/drivers/net/intel.h
+++ b/src/drivers/net/intel.h
@@ -303,6 +303,8 @@ enum intel_flags {
 	INTEL_VMWARE = 0x0002,
 	/** PHY reset is broken */
 	INTEL_NO_PHY_RST = 0x0004,
+    /** no CTRL.ASDE bit */
+    INTEL_NO_CTRL_ASDE = 0x0005,
 };
 
 /**


### PR DESCRIPTION
Bit CTRL_ASDE is reserved and must be set to 0b according intel 82576EB datasheet.