### PR TITLE
Change __divmoddi4 from int64 [unknown] to int64_t

### DIFF
--- a/src/libgcc/__divmoddi4.c
+++ b/src/libgcc/__divmoddi4.c
@@ -1,6 +1,6 @@
 #include "libgcc.h"
 
-__libgcc int64_t __divmoddi4(int64_t num, int64_t den, int64 *rem_p)
+__libgcc int64_t __divmoddi4(int64_t num, int64_t den, int64_t *rem_p)
 {
   int minus = 0;
   int64_t v;


### PR DESCRIPTION
Also matches the header file [libgcc.h]

and solves __divmoddi4.c:3:56: error: unknown type name ‘int64’