### PR TITLE
virtio changes 12/2016

### DIFF
--- a/src/drivers/bus/virtio-pci.c
+++ b/src/drivers/bus/virtio-pci.c
@@ -391,7 +391,7 @@ int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
             off * notify_offset_multiplier, 2,
             &vq->notification);
         if (err) {
-            goto err_map_notify;
+            return err;
         }
     }
 
@@ -405,11 +405,4 @@ int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
         vpm_iowrite16(vdev, &vdev->common, 1, COMMON_OFFSET(queue_enable));
     }
     return 0;
-
-err_map_notify:
-    /* Undo the virtio_pci_map_capability calls. */
-    while (i-- > 0) {
-        virtio_pci_unmap_capability(&vqs[i].notification);
-    }
-    return err;
 }

--- a/src/drivers/bus/virtio-pci.c
+++ b/src/drivers/bus/virtio-pci.c
@@ -358,12 +358,18 @@ int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
             return -EINVAL;
         }
 
+        if (size > MAX_QUEUE_NUM) {
+            /* iPXE networking tends to be not perf critical so there's no
+             * need to accept large queue sizes.
+             */
+            size = MAX_QUEUE_NUM;
+        }
+
         vq = &vqs[i];
         vq->queue_index = i;
 
         /* get offset of notification word for this vq */
         off = vpm_ioread16(vdev, &vdev->common, COMMON_OFFSET(queue_notify_off));
-        vq->vring.num = size;
 
         vring_init(&vq->vring, size, (unsigned char *)vq->queue);
 

--- a/src/drivers/net/virtio-net.c
+++ b/src/drivers/net/virtio-net.c
@@ -185,6 +185,7 @@ static void virtnet_free_virtqueues ( struct net_device *netdev ) {
 
 	for ( i = 0; i < QUEUE_NB; i++ ) {
 		virtio_pci_unmap_capability ( &virtnet->virtqueue[i].notification );
+		vp_free_vq ( &virtnet->virtqueue[i] );
 	}
 
 	free ( virtnet->virtqueue );

--- a/src/include/ipxe/virtio-pci.h
+++ b/src/include/ipxe/virtio-pci.h
@@ -196,8 +196,10 @@ static inline void vp_del_vq(unsigned int ioaddr, int queue_index)
 
 struct vring_virtqueue;
 
+void vp_free_vq(struct vring_virtqueue *vq);
 int vp_find_vq(unsigned int ioaddr, int queue_index,
                struct vring_virtqueue *vq);
+
 
 /* Virtio 1.0 I/O routines abstract away the three possible HW access
  * mechanisms - memory, port I/O, and PCI cfg space access. Also built-in

--- a/src/include/ipxe/virtio-ring.h
+++ b/src/include/ipxe/virtio-ring.h
@@ -71,14 +71,12 @@ struct vring {
          + PAGE_MASK) & ~PAGE_MASK) + \
          (sizeof(struct vring_used) + sizeof(struct vring_used_elem) * num))
 
-typedef unsigned char virtio_queue_t[PAGE_MASK + vring_size(MAX_QUEUE_NUM)];
-
 struct vring_virtqueue {
-   virtio_queue_t queue;
+   unsigned char *queue;
    struct vring vring;
    u16 free_head;
    u16 last_used_idx;
-   void *vdata[MAX_QUEUE_NUM];
+   void **vdata;
    /* PCI */
    int queue_index;
    struct virtio_pci_region notification;

--- a/src/include/ipxe/virtio-ring.h
+++ b/src/include/ipxe/virtio-ring.h
@@ -95,7 +95,7 @@ static inline void vring_init(struct vring *vr,
    unsigned int i;
    unsigned long pa;
 
-        vr->num = num;
+   vr->num = num;
 
    /* physical address of desc must be page aligned */
 
@@ -103,13 +103,13 @@ static inline void vring_init(struct vring *vr,
    pa = (pa + PAGE_MASK) & ~PAGE_MASK;
    vr->desc = phys_to_virt(pa);
 
-        vr->avail = (struct vring_avail *)&vr->desc[num];
+   vr->avail = (struct vring_avail *)&vr->desc[num];
 
    /* physical address of used must be page aligned */
 
    pa = virt_to_phys(&vr->avail->ring[num]);
    pa = (pa + PAGE_MASK) & ~PAGE_MASK;
-        vr->used = phys_to_virt(pa);
+   vr->used = phys_to_virt(pa);
 
    for (i = 0; i < num - 1; i++)
            vr->desc[i].next = i + 1;


### PR DESCRIPTION
Three patches discussed and reviewed on the ipxe-devel list. Fixes issues with virtqueue sizes >256. To reproduce, run QEMU with:

-device virtio-net, ..., disable-modern=off,disable-legacy=on,rx_queue_size=1024

for modern virtio and

-device virtio-net, ..., disable-modern=on,disable-legacy=off,rx_queue_size=1024

for legacy virtio.

Thank you,
Ladi