### PR TITLE
[build] fix elf2efi with glibc 2.24 and newer

### DIFF
--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -18,6 +18,7 @@
  */
 
 #define FILE_LICENCE(...) extern void __file_licence ( void )
+#define USING_LTO
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
Since f796d5b6b63d3b the elf2efi utility does not compile on machines
using glibc 2.24 or newer. This is a hack to disable the hidden
visibility for GCC. This was originally reported in
http://forum.ipxe.org/showthread.php?tid=8285