### PR TITLE
[dhcp/ipv4] Support for DHCP option 121: Classless static route option

### DIFF
--- a/src/include/ipxe/dhcp.h
+++ b/src/include/ipxe/dhcp.h
@@ -323,6 +323,12 @@ struct dhcp_client_uuid {
 /** DNS domain search list */
 #define DHCP_DOMAIN_SEARCH 119
 
+/** DHCP 121 - Classless Static Route Option  */
+#define DHCP_CLASSLESS_STATIC_ROUTE 121
+
+/** DHCP 121 - Classless Static Route Option for Microsoft DHCP-server  */
+#define DHCP_CLASSLESS_STATIC_ROUTE_MS 249
+
 /** Etherboot-specific encapsulated options
  *
  * This encapsulated options field is used to contain all options

--- a/src/include/ipxe/dhcpopts.h
+++ b/src/include/ipxe/dhcpopts.h
@@ -39,5 +39,9 @@ extern void dhcpopt_init ( struct dhcp_options *options,
 					       size_t len ) );
 extern void dhcpopt_update_used_len ( struct dhcp_options *options );
 extern int dhcpopt_no_realloc ( struct dhcp_options *options, size_t len );
+extern int find_dhcp_option_with_encap ( struct dhcp_options *options,
+				unsigned int tag, int *encap_offset );
+extern struct dhcp_option * dhcp_option ( struct dhcp_options *options,
+				unsigned int offset );
 
 #endif /* _IPXE_DHCPOPTS_H */

--- a/src/include/ipxe/netdevice.h
+++ b/src/include/ipxe/netdevice.h
@@ -426,6 +426,12 @@ struct net_device {
 
 	/** Network device configurations (variable length) */
 	struct net_device_configuration configs[0];
+
+	/** Static routes from DHCP option 121 */
+	uint8_t * static_routes;
+
+	/** DHCP option 121 length */
+	uint8_t static_routes_len;
 };
 
 /** Network device is open */

--- a/src/net/dhcpopts.c
+++ b/src/net/dhcpopts.c
@@ -64,8 +64,8 @@ static inline char * dhcp_tag_name ( unsigned int tag ) {
  * @v offset		Offset within options block
  * @ret option		DHCP option
  */
-static inline __attribute__ (( always_inline )) struct dhcp_option *
-dhcp_option ( struct dhcp_options *options, unsigned int offset ) {
+struct dhcp_option * dhcp_option ( struct dhcp_options *options,
+			unsigned int offset ) {
 	return ( ( struct dhcp_option * ) ( options->data + offset ) );
 }
 
@@ -116,7 +116,7 @@ static unsigned int dhcp_option_len ( struct dhcp_option *option ) {
  * such as options missing a @c DHCP_END terminator, or options whose
  * length would take them beyond the end of the data block.
  */
-static int find_dhcp_option_with_encap ( struct dhcp_options *options,
+int find_dhcp_option_with_encap ( struct dhcp_options *options,
 					 unsigned int tag,
 					 int *encap_offset ) {
 	unsigned int original_tag __attribute__ (( unused )) = tag;

--- a/src/net/ipv4.c
+++ b/src/net/ipv4.c
@@ -337,9 +337,12 @@ static int ipv4_tx ( struct io_buffer *iobuf,
 	if ( ( next_hop.s_addr != INADDR_BROADCAST ) &&
 	     ( ( miniroute = ipv4_route ( sin_dest->sin_scope_id,
 					  &next_hop ) ) != NULL ) ) {
-		iphdr->src = miniroute->address;
 		netmask = miniroute->netmask;
 		netdev = miniroute->netdev;
+
+		struct settings *settings = netdev_settings ( netdev );
+		fetch_ipv4_setting ( settings, &ip_setting, &iphdr->src );
+		next_hop = miniroute->gateway;
 	}
 	if ( ! netdev ) {
 		DBGC ( sin_dest->sin_addr, "IPv4 has no route to %s\n",
@@ -448,15 +451,13 @@ int ipv4_has_any_addr ( struct net_device *netdev ) {
  * @ret has_addr	Network device has this IPv4 address
  */
 static int ipv4_has_addr ( struct net_device *netdev, struct in_addr addr ) {
-	struct ipv4_miniroute *miniroute;
+	struct in_addr address;
+	struct settings *settings = netdev_settings ( netdev );
+	fetch_ipv4_setting ( settings, &ip_setting, &address );
 
-	list_for_each_entry ( miniroute, &ipv4_miniroutes, list ) {
-		if ( ( miniroute->netdev == netdev ) &&
-		     ( miniroute->address.s_addr == addr.s_addr ) ) {
-			/* Found matching address */
-			return 1;
-		}
-	}
+	if ( address.s_addr == addr.s_addr )
+		return 1;
+
 	return 0;
 }
 
@@ -845,6 +846,36 @@ static int ipv4_gratuitous_arp ( struct net_device *netdev,
 }
 
 /**
+ * Convert netmask from CIDR notation to the common x.x.x.x notation
+ */
+static inline uint8_t cidr_to_mask ( uint8_t cidr, char * buf ) {
+	uint8_t addr_len = 0;
+	uint8_t n_octet = ( cidr % 8 == 0 ? 255 :
+			( 255 - ( ( 256 >> ( cidr % 8 ) ) - 1 ) ) );
+
+	if (cidr > 24 && cidr <= 32) {
+		sprintf(buf, "255.255.255.%d", n_octet);
+		addr_len = 4;
+	} else if (cidr > 16) {
+		sprintf(buf, "255.255.%d.0", n_octet);
+		addr_len = 3;
+	} else if (cidr > 8) {
+		sprintf(buf, "255.%d.0.0", n_octet);
+		addr_len = 2;
+	} else if (cidr > 0) {
+		sprintf(buf, "%d.0.0.0", n_octet);
+		addr_len = 1;
+	} else if (cidr == 0) {
+		sprintf(buf, "0.0.0.0");
+		addr_len = 0;
+	} else {
+		DBGC(cidr, "Unknown netmask descriptor /%d.\n", cidr);
+	}
+
+	return addr_len;
+}
+
+/**
  * Process IPv4 network device settings
  *
  * @v apply		Application method
@@ -890,9 +921,51 @@ static int ipv4_settings ( int ( * apply ) ( struct net_device *netdev,
 		/* Get default gateway, if present */
 		fetch_ipv4_setting ( settings, &gateway_setting, &gateway );
 
-		/* Apply settings */
-		if ( ( rc = apply ( netdev, address, netmask, gateway ) ) != 0 )
-			return rc;
+		/* Configure route (-s) */
+		uint8_t * raw_data = netdev->static_routes;
+		uint8_t option_len = netdev->static_routes_len;
+
+		/* Check if static routes available
+		 * The minimum length for DHCP option 121 is 5 bytes */
+		if ( option_len >= 5 ) {
+			char buf[16];
+			uint8_t uaddr[4];
+			uint8_t i = 0, j, addr_octets_len;
+
+			/* Extract routes and add them to routing table */
+			while ( i < option_len ) {
+				uint8_t c = raw_data[i];
+				i++;
+
+				/* Netmask */
+				addr_octets_len = cidr_to_mask ( c, buf );
+				inet_aton( buf, &netmask );
+
+				/* Address */
+				memset ( uaddr, 0, 4 * sizeof ( uint8_t ) );
+				for ( j = 0; j < addr_octets_len; j++ )
+					uaddr[j] = raw_data[i + j];
+
+				sprintf( buf, "%d.%d.%d.%d", uaddr[0], uaddr[1], uaddr[2], uaddr[3] );
+				inet_aton( buf, &address );
+
+				/* Gateway */
+				i += j;
+				for ( j = 0; j < 4; j++ )
+					uaddr[j] = raw_data[i + j];
+
+				sprintf( buf, "%d.%d.%d.%d", uaddr[0], uaddr[1], uaddr[2], uaddr[3] );
+				inet_aton( buf, &gateway );
+
+				i += j;
+
+				if ( ( rc = apply ( netdev, address, netmask, gateway ) ) != 0 )
+					return rc;
+			}
+		} else {
+			if ( ( rc = apply ( netdev, address, netmask, gateway ) ) != 0 )
+				return rc;
+		}
 	}
 
 	return 0;

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -635,6 +635,7 @@ static void process_reloc ( struct elf_file *elf, const Elf_Shdr *shdr,
 		case ELF_MREL ( EM_ARM, R_ARM_THM_JUMP24 ) :
 		case ELF_MREL ( EM_ARM, R_ARM_V4BX ):
 		case ELF_MREL ( EM_X86_64, R_X86_64_PC32 ) :
+		case ELF_MREL ( EM_X86_64, R_X86_64_PLT32 ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_CALL26 ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_JUMP26 ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_ADR_PREL_LO21 ) :


### PR DESCRIPTION
This PR adds support for classless static route option (https://tools.ietf.org/rfc/rfc3442.txt).

I appreciate your comments and feedback, since it is my first contribution to an open-source project.