### PR TITLE
[intel] Add PCI_ROM entry for Intel i354 NIC

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -1127,6 +1127,7 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x1522, "i350-f", "I350 Fiber", 0 ),
 	PCI_ROM ( 0x8086, 0x1523, "i350-b", "I350 Backplane", INTEL_NO_ASDE ),
 	PCI_ROM ( 0x8086, 0x1524, "i350-2", "I350", 0 ),
+	PCI_ROM ( 0x8086, 0x1f41, "i354", "I354", INTEL_NO_ASDE ),
 	PCI_ROM ( 0x8086, 0x1525, "82567v-4", "82567V-4", 0 ),
 	PCI_ROM ( 0x8086, 0x1526, "82576-5", "82576", 0 ),
 	PCI_ROM ( 0x8086, 0x1527, "82580-f2", "82580 Fiber", 0 ),


### PR DESCRIPTION
Have tested on a [SuperMicro A1Sri](http://www.supermicro.com/products/motherboard/atom/x10/a1sri-2758f.cfm?gclid=EAIaIQobChMI57SXw8_s2QIVllmGCh380gdFEAAYASAAEgIAffD_BwE) with this NIC.

Functions properly provided ASDE is disabled as those bits are reserved for this chipset. My observation was that without ASDE disabled, the adapter appears to function properly, not reporting errors or dropped packets in statistics, but not reporting successful transmission of packets either. Transmitted packets get processed but never actually make it onto the network.