### PR TITLE
[efi_pci] Elevate TPL around pci_probe

### DIFF
--- a/src/interface/efi/efi_pci.c
+++ b/src/interface/efi/efi_pci.c
@@ -383,6 +383,7 @@ static int efipci_supported ( EFI_HANDLE device ) {
  * @ret rc		Return status code
  */
 static int efipci_start ( struct efi_device *efidev ) {
+	EFI_BOOT_SERVICES *bs = efi_systab->BootServices;
 	EFI_HANDLE device = efidev->device;
 	struct pci_device *pci;
 	int rc;
@@ -416,7 +417,10 @@ static int efipci_start ( struct efi_device *efidev ) {
 	list_add ( &pci->dev.siblings, &efidev->dev.children );
 
 	/* Probe driver */
-	if ( ( rc = pci_probe ( pci ) ) != 0 ) {
+	EFI_TPL saved_tpl = bs->RaiseTPL ( TPL_CALLBACK );
+	rc = pci_probe ( pci );
+	bs->RestoreTPL ( saved_tpl );
+	if ( rc != 0 ) {
 		DBGC ( device, "EFIPCI " PCI_FMT " could not probe driver "
 		       "\"%s\": %s\n", PCI_ARGS ( pci ), pci->id->name,
 		       strerror ( rc ) );


### PR DESCRIPTION
This resolves a case where my system would hang on the UEFI call to StartImage.

When a PCI NIC gets probed successfully, it calls register_netdev() which in turn uses the least significant bits of the MAC to seed the random number generator. This calls into random() which uses currticks() for the initial seed. On EFI builds, this restores the TPL level to TPL_APPLICATION to allow tick events to fire, and then raises it back to TPL_CALLBACK. Not matching calls to RaiseTPL with calls to RestoreTPL causes undefined behavior, in this case a system hang. Adding the matching calls around pci_probe resolves this issue.