### PR TITLE
[intelx] Add PCI_ROM entry for Intel x553 NIC

### DIFF
--- a/src/drivers/net/intelx.c
+++ b/src/drivers/net/intelx.c
@@ -474,6 +474,7 @@ static struct pci_device_id intelx_nics[] = {
 	PCI_ROM ( 0x8086, 0x1557, "82599en-sfp", "82599 (Single Port SFI Only)", 0 ),
 	PCI_ROM ( 0x8086, 0x1560, "x540t1", "X540-AT2/X540-BT2 (with single port NVM)", 0 ),
 	PCI_ROM ( 0x8086, 0x1563, "x550t2", "X550-T2", 0 ),
+	PCI_ROM ( 0x8086, 0x15e5, "x553", "X553", 0 )
 };
 
 /** PCI driver */


### PR DESCRIPTION
Have tested on a [SuperMicro A2SDi](https://www.supermicro.com/products/motherboard/atom/A2SDi-2C-HLN4F.cfm) with this NIC.

Works properly as-is, just needs the PCI_ROM entry.