### PR TITLE
[efi_snp] Subtract link-layer header length from MaxPacketSize

### DIFF
--- a/src/interface/efi/efi_snp.c
+++ b/src/interface/efi/efi_snp.c
@@ -123,7 +123,7 @@ static void efi_snp_set_mode ( struct efi_snp_device *snpdev ) {
 
 	mode->HwAddressSize = ll_addr_len;
 	mode->MediaHeaderSize = ll_protocol->ll_header_len;
-	mode->MaxPacketSize = netdev->max_pkt_len;
+	mode->MaxPacketSize = netdev->max_pkt_len - ll_protocol->ll_header_len;
 	mode->ReceiveFilterMask = ( EFI_SIMPLE_NETWORK_RECEIVE_UNICAST |
 				    EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST |
 				    EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST );


### PR DESCRIPTION
It seems that the EDK network stack expects this to be 1500, not 1514.

As-is, in the case of fragmentation, the UEFI UDP layer will compute fragment sizes larger than the MTU which typically get dropped.