### PR TITLE
Add support for Intel X552 NIC.

### DIFF
--- a/src/drivers/net/intelx.c
+++ b/src/drivers/net/intelx.c
@@ -474,6 +474,7 @@ static struct pci_device_id intelx_nics[] = {
 	PCI_ROM ( 0x8086, 0x1557, "82599en-sfp", "82599 (Single Port SFI Only)", 0 ),
 	PCI_ROM ( 0x8086, 0x1560, "x540t1", "X540-AT2/X540-BT2 (with single port NVM)", 0 ),
 	PCI_ROM ( 0x8086, 0x1563, "x550t2", "X550-T2", 0 ),
+	PCI_ROM ( 0x8086, 0x15ab, "x552", "X552", 0 ),
 	PCI_ROM ( 0x8086, 0x15e5, "x553", "X553", 0 ),
 };
 


### PR DESCRIPTION
Tested on... you guessed it... an Intel X552 NIC. Everything works fine; just needed the PCI ID in the driver.