### PR TITLE
gensdsk: fix default target

### DIFF
--- a/src/util/gensdsk
+++ b/src/util/gensdsk
@@ -48,7 +48,7 @@ do
 	g=${g:0:8}.krn
 	case "$first" in
 	"")
-		echo DEFAULT $g
+		echo DEFAULT $b
 		;;
 	esac
 	first=$g


### PR DESCRIPTION
gensdsk creates a syslinux.cfg file that is invalid if the filename ends in lkrn, to fix this point default target to label($b) not filename($g)