### PR TITLE
[intelx] Added PCI_ROM entry for Intel x553/x557-AT and x553 (SFP+) NICs

### DIFF
--- a/src/drivers/net/intelx.c
+++ b/src/drivers/net/intelx.c
@@ -475,6 +475,8 @@ static struct pci_device_id intelx_nics[] = {
 	PCI_ROM ( 0x8086, 0x1560, "x540t1", "X540-AT2/X540-BT2 (with single port NVM)", 0 ),
 	PCI_ROM ( 0x8086, 0x1563, "x550t2", "X550-T2", 0 ),
 	PCI_ROM ( 0x8086, 0x15ab, "x552", "X552", 0 ),
+	PCI_ROM ( 0x8086, 0x15c8, "x553t", "X553/X557-AT", 0),
+	PCI_ROM ( 0x8086, 0x15ce, "x553-sfp", "X553 (SFP+)", 0),
 	PCI_ROM ( 0x8086, 0x15e5, "x553", "X553", 0 ),
 };
 


### PR DESCRIPTION
Tested on [SuperMicro A2SDi-H-TP4F](https://www.supermicro.com/products/motherboard/atom/A2SDi-H-TP4F.cfm) which has these NICs