### PR TITLE
[build] Fix asm argument modifiers for aarch64 build

### DIFF
--- a/src/include/errno.h
+++ b/src/include/errno.h
@@ -262,10 +262,10 @@ static inline void eplatform_discard ( int dummy __unused, ... ) {}
 		  ".align 8\n\t"					\
 		  "\n1:\n\t"						\
 		  ".long ( 4f - 1b )\n\t"				\
-		  ".long %a0\n\t"					\
+		  ".long %c0\n\t"					\
 		  ".long ( 2f - 1b )\n\t"				\
 		  ".long ( 3f - 1b )\n\t"				\
-		  ".long %a1\n\t"					\
+		  ".long %c1\n\t"					\
 		  "\n2:\t.asciz \"" __einfo_desc ( einfo ) "\"\n\t"	\
 		  "\n3:\t.asciz \"" __FILE__ "\"\n\t"			\
 		  ".align 8\n\t"					\


### PR DESCRIPTION
When building bin-arm64-efi/snp.efi using the gcc8 compiler, the following error occurs:

    In file included from core/xferbuf.c:28:
    core/xferbuf.c: In function 'xferbuf_malloc_realloc':
    include/errno.h:261:2: error: invalid 'asm': invalid address mode
      __asm__ ( ".section \".einfo\", \"\", " PROGBITS_OPS "\n\t" \
      ^~~~~~~
    include/errno.h:549:16: note: in expansion of macro '__einfo_error'
     #define ENOSPC __einfo_error ( EINFO_ENOSPC )
                    ^~~~~~~~~~~~~
    core/xferbuf.c:192:11: note: in expansion of macro 'ENOSPC'
       return -ENOSPC;
               ^~~~~~

The 'a' address mode is invalid for aarch64. Simply changing this to
the constant operand type 'c' seems to resolve the issue on aarch64 and
does not appear to affect x86_64 or i586.

Signed-off-by: John L. Jolly <jjolly@suse.com>