### PR TITLE
[build] Do not use random build_ids

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1162,7 +1162,7 @@ blib : $(BLIB)
 # Command to generate build ID.  Must be unique for each $(BIN)/%.tmp,
 # even within the same build run.
 #
-BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
+BUILD_ID_CMD	:= sh -c 'printf 0x%s $$(cat "$$@" | sha1sum - | cut -c-8)' --
 
 # Build timestamp
 #
@@ -1186,7 +1186,7 @@ $(BIN)/version.%.o : core/version.c $(MAKEDEPS) $(GIT_INDEX)
 $(BIN)/%.tmp : $(BIN)/version.%.o $(BLIB) $(MAKEDEPS) $(LDSCRIPT)
 	$(QM)$(ECHO) "  [LD] $@"
 	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT) $(TGT_LD_FLAGS) $< $(BLIB) -o $@ \
-		--defsym _build_id=`$(BUILD_ID_CMD)` \
+		--defsym _build_id=`$(BUILD_ID_CMD) $^` \
 		--defsym _build_timestamp=$(BUILD_TIMESTAMP) \
 		-Map $(BIN)/$*.tmp.map
 	$(Q)$(OBJDUMP) -ht $@ | $(PERL) $(SORTOBJDUMP) >> $(BIN)/$*.tmp.map


### PR DESCRIPTION
Do not use random build_ids
to allow for reproducible builds of .rom files
and xen hvmloader (which embeds those)

See https://reproducible-builds.org/ for why this matters.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.com>