### PR TITLE
set INTEL_NO_PHY_RST on I218-V

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -1134,7 +1134,7 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x1539, "i211", "I211", 0 ),
 	PCI_ROM ( 0x8086, 0x153a, "i217lm", "I217-LM", INTEL_NO_PHY_RST ),
 	PCI_ROM ( 0x8086, 0x153b, "i217v", "I217-V", 0 ),
-	PCI_ROM ( 0x8086, 0x1559, "i218v", "I218-V", 0),
+	PCI_ROM ( 0x8086, 0x1559, "i218v", "I218-V", INTEL_NO_PHY_RST ),
 	PCI_ROM ( 0x8086, 0x155a, "i218lm", "I218-LM", 0),
 	PCI_ROM ( 0x8086, 0x156f, "i219lm", "I219-LM", INTEL_I219 ),
 	PCI_ROM ( 0x8086, 0x1570, "i219v", "I219-V", INTEL_I219 ),


### PR DESCRIPTION
I'm using Intel D34010WYK NUCs which have the I218-V onboard. Prior to this change they always negotiate at 10mbps. After this change they will negotiate at 1gbps.

I... have no idea what I'm doing here, so please let me know if there are further changes or tests or whatever that I need to address!