### PR TITLE
[efi] Enable NET_PROTO_IPV6 by default

### DIFF
--- a/src/config/defaults/efi.h
+++ b/src/config/defaults/efi.h
@@ -23,6 +23,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define REBOOT_EFI
 #define ACPI_EFI
 
+#define	NET_PROTO_IPV6		/* IPv6 protocol */
+
 #define DOWNLOAD_PROTO_FILE	/* Local filesystem access */
 
 #define	IMAGE_EFI		/* EFI image support */

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -35,7 +35,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 
 #define	NET_PROTO_IPV4		/* IPv4 protocol */
-#undef	NET_PROTO_IPV6		/* IPv6 protocol */
+//#define	NET_PROTO_IPV6		/* IPv6 protocol */
 #undef	NET_PROTO_FCOE		/* Fibre Channel over Ethernet protocol */
 #define	NET_PROTO_STP		/* Spanning Tree protocol */
 #define	NET_PROTO_LACP		/* Link Aggregation control protocol */


### PR DESCRIPTION
IPv6 PXE was included in the UEFI specification over eight years ago, specifically in [version 2.3 (Errata D)](http://www.uefi.org/sites/default/files/resources/UEFI_Spec_2_3_D.pdf).

When iPXE is being chainloaded from a UEFI firmware performing a PXE boot in an IPv6 network, it is essential that iPXE supports IPv6 as well.

I understand that the reason for `NET_PROTO_IPV6` being disabled by default (in `src/config/general.h`) is that it would cause certain space-constrained build targets to become too large. However, this should not be an issue for EFI builds.

It is also worth noting that [RFC 6540](https://tools.ietf.org/html/rfc6540) makes a clear recommendation that IPv6 support should not be considered optional.

Signed-off-by: Tore Anderson <tore@fud.no>