### PR TITLE
Fix a GNUism that FreeBSD's sed(1) cannot deal with

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -850,7 +850,7 @@ define deps_template_parts
 	@$(MKDIR) -p $(BIN)/deps/$(dir $(1))
 	$(Q)$(CPP) $(CFLAGS) $(CFLAGS_$(2)) $(CFLAGS_$(3)) -DOBJECT=$(3) \
 		-Wno-error -M $(1) -MG -MP | \
-		sed 's/\.o\s*:/_DEPS +=/' > $(BIN)/deps/$(1).d
+		sed 's/\.o[[:blank:]]*:/_DEPS +=/' > $(BIN)/deps/$(1).d
 endef
 
 # rules_template : generate rules for a given source file


### PR DESCRIPTION
At the moment '\s*' is silently interpreted as just 's*', but in the
future it will be an error:

sed: 1: "s/\.o\s*:/_DEPS +=/": RE error: trailing backslash (\)

cf. https://bugs.freebsd.org/229925

Signed-off-by: Tobias Kortkamp <t@tobik.me>