### PR TITLE
[efi_snp] Fix error handling path in efi_snp_probe

### DIFF
--- a/src/interface/efi/efi_snp.c
+++ b/src/interface/efi/efi_snp.c
@@ -1829,12 +1829,12 @@ static int efi_snp_probe ( struct net_device *netdev ) {
 		efi_snp_hii_uninstall ( snpdev );
 	efi_child_del ( efidev->device, snpdev->handle );
  err_efi_child_add:
-	bs->CloseProtocol ( snpdev->handle, &efi_nii_protocol_guid,
-			    efi_image_handle, snpdev->handle );
- err_open_nii:
 	bs->CloseProtocol ( snpdev->handle, &efi_nii31_protocol_guid,
 			    efi_image_handle, snpdev->handle );
  err_open_nii31:
+	bs->CloseProtocol ( snpdev->handle, &efi_nii_protocol_guid,
+			    efi_image_handle, snpdev->handle );
+ err_open_nii:
 	bs->UninstallMultipleProtocolInterfaces (
 			snpdev->handle,
 			&efi_simple_network_protocol_guid, &snpdev->snp,


### PR DESCRIPTION
Current (simplified):

1. InstallMultipleProtocolInterfaces
       if err goto err_install_protocol_interface;
2. OpenProtocol(efi_nii_protocol_guid)
       if err goto err_open_nii;
3. OpenProtocol(efi_nii31_protocol_guid)
       if err goto err_open_nii31;
4. efi_child_add
       if err goto err_efi_child_add;
...
err_efi_child_add:
   CloseProtocol(efi_nii_protocol_guid) <= should be efi_nii31_protocol_guid
err_open_nii: <= should be err_open_nii31
   CloseProtocol(efi_nii31_protocol_guid) <= should be efi_nii_protocol_guid
err_open_nii31: <= should be err_open_nii
   UninstallMultipleProtocolInterfaces

Make it release the resources in the reverse order of obtaining them

Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>