### PR TITLE
[infiniband] fix a memory leak in ib_refill_recv

### DIFF
--- a/src/net/infiniband.c
+++ b/src/net/infiniband.c
@@ -568,10 +568,11 @@ void ib_refill_recv ( struct ib_device *ibdev, struct ib_queue_pair *qp ) {
 		}
 
 		/* Post I/O buffer */
-		if ( ( rc = ib_post_recv ( ibdev, qp, iobuf ) ) != 0 ) {
+		rc = ib_post_recv ( ibdev, qp, iobuf );
+		free_iob ( iobuf );
+		if ( rc != 0 ) {
 			DBGC ( ibdev, "IBDEV %s could not refill: %s\n",
 			       ibdev->name, strerror ( rc ) );
-			free_iob ( iobuf );
 			/* Give up */
 			return;
 		}


### PR DESCRIPTION
While debugging another issue (my UEFI firmware continuously polling the iPXE
option ROM on a Mellanox ConnectX-4 Lx) I noticed that iPXE quickly runs out of
memory. Tracing the code led me to ib_refill_recv. We can see that
ib_refill_recv allocates an iobuf and hands it over to a driver-specific
post-receive hook. However, ib_refill_recv free's the iobuf only, when the hook
returns an error and none of the implementations free the iobuf on success.

So it seems that ib_refill_recv should unconditionally free the iobuf before
processing the error code from the hook (this patch fixed the leak for me at
least).