### PR TITLE
[com32] Fix iPXE stack pointer retrieval after COM32 binary returns.

### DIFF
--- a/src/arch/x86/image/com32.c
+++ b/src/arch/x86/image/com32.c
@@ -110,7 +110,7 @@ static int com32_exec_loop ( struct image *image ) {
 			/* Disable interrupts */
 			"cli\n\t"
 			/* Restore stack pointer */
-			"movl 24(%%esp), %%esp\n\t"
+			"movl 28(%%esp), %%esp\n\t"
 			/* Restore registers */
 			"popal\n\t" )
 			:


### PR DESCRIPTION
This change fixes the offset used when retrieving the iPXE stack pointer
after a COM32 binary returns. The iPXE stack pointer is saved at the top
of the available memory then the the top of the stack for the COM32
binary is set just below it. However seven more items are pushed on the
COM32 stack before the entry point is invoked so when the COM32 binary
returns the location of the iPXE stack pointer is 28 (and not 24) bytes
above the current stack pointer.