### PR TITLE
[util] Fix a potential problem in ROM.pm.

### DIFF
--- a/src/util/Option/ROM.pm
+++ b/src/util/Option/ROM.pm
@@ -282,7 +282,7 @@ sub set {
   my $hash = shift;
   my $self = tied(%$hash);
   my $data = shift;
-  my $file_offset = shift // 0x0;
+  my $file_offset = scalar @_ ? shift : 0x0;
 
   # Store data
   $self->{data} = \$data;


### PR DESCRIPTION
This change replaces "my $file_offset = shift // 0x0;" (which results in a
build failure in some environments) with "my $file_offset = scalar @_ ? shift : 0x0;" where
the intention is 0x0 to be the default value used if the optional
file_offset parameter is not provided.