### PR TITLE
Updated digest commands to include SHA-2 support, hash strings, perfo…

### DIFF
--- a/src/hci/commands/digest_cmd.c
+++ b/src/hci/commands/digest_cmd.c
@@ -29,6 +29,9 @@ FILE_LICENCE ( GPL2_OR_LATER );
 #include <ipxe/crypto.h>
 #include <ipxe/md5.h>
 #include <ipxe/sha1.h>
+#include <ipxe/sha256.h>
+#include <ipxe/sha512.h>
+#include <ipxe/settings.h>
 #include <usr/imgmgmt.h>
 
 /** @file
@@ -38,15 +41,25 @@ FILE_LICENCE ( GPL2_OR_LATER );
  */
 
 /** "digest" options */
-struct digest_options {};
+struct digest_options { 
+	/** String to digest */
+	char *str;
+	/** Rounds to rehash */
+	unsigned int rounds;
+};
 
 /** "digest" option list */
-static struct option_descriptor digest_opts[] = {};
+static struct option_descriptor digest_opts[] = {
+	OPTION_DESC ( "rounds", 'r', required_argument,
+		struct digest_options, rounds, parse_integer),
+	OPTION_DESC ( "str", 's', required_argument,
+		struct digest_options, str, parse_string ),
+};
 
 /** "digest" command descriptor */
 static struct command_descriptor digest_cmd =
-	COMMAND_DESC ( struct digest_options, digest_opts, 1, MAX_ARGUMENTS,
-		       "<image> [<image>...]" );
+	COMMAND_DESC ( struct digest_options, digest_opts, 0, MAX_ARGUMENTS,
+		       "[<image>] [<image>...]" );
 
 /**
  * The "digest" command
@@ -60,45 +73,88 @@ static int digest_exec ( int argc, char **argv,
 			 struct digest_algorithm *digest ) {
 	struct digest_options opts;
 	struct image *image;
+	struct named_setting setting;
 	uint8_t digest_ctx[digest->ctxsize];
 	uint8_t digest_out[digest->digestsize];
 	uint8_t buf[128];
 	size_t offset;
 	size_t len;
 	size_t frag_len;
+	unsigned long origlen;
 	int i;
-	unsigned j;
+	unsigned j, r;
 	int rc;
+	char hashstr[130];
+
+	if ( argc < 2 ) {
+		print_usage ( &digest_cmd, argv );
+		return 0;
+	}
 
 	/* Parse options */
 	if ( ( rc = parse_options ( argc, argv, &digest_cmd, &opts ) ) != 0 )
 		return rc;
 
-	for ( i = optind ; i < argc ; i++ ) {
+	for ( i = optind ; i < argc || opts.str ; i++ ) {
+
+		hashstr[0] = '\0';
 
 		/* Acquire image */
-		if ( ( rc = imgacquire ( argv[i], 0, &image ) ) != 0 )
+		if ( ( ! opts.str ) && 
+			( ( rc = imgacquire ( argv[i], 0, &image ) ) != 0 ) )
 			continue;
-		offset = 0;
-		len = image->len;
 
 		/* calculate digest */
 		digest_init ( digest, digest_ctx );
-		while ( len ) {
-			frag_len = len;
-			if ( frag_len > sizeof ( buf ) )
-				frag_len = sizeof ( buf );
-			copy_from_user ( buf, image->data, offset, frag_len );
-			digest_update ( digest, digest_ctx, buf, frag_len );
-			len -= frag_len;
-			offset += frag_len;
+		if ( opts.str ) {
+			origlen = strlen( opts.str );
+			digest_update ( digest, digest_ctx, opts.str,
+				origlen );
+		} else {
+			offset = 0;
+			len = image->len;
+			origlen = image->len;
+			while ( len ) {
+				frag_len = len;
+				if ( frag_len > sizeof ( buf ) )
+					frag_len = sizeof ( buf );
+				copy_from_user ( buf, image->data, offset, frag_len );
+				digest_update ( digest, digest_ctx, buf, frag_len );
+				len -= frag_len;
+				offset += frag_len;
+			}
 		}
 		digest_final ( digest, digest_ctx, digest_out );
 
-		for ( j = 0 ; j < sizeof ( digest_out ) ; j++ )
-			printf ( "%02x", digest_out[j] );
+		for ( r = 1 ; r < opts.rounds ; r++ ) {
+			digest_init ( digest, digest_ctx );
+			digest_update ( digest, digest_ctx, digest_out,
+				sizeof ( digest_out ) );
+			digest_final ( digest, digest_ctx, digest_out );
+		}
 
-		printf ( "  %s\n", image->name );
+		if ( sizeof( hashstr ) >= sizeof ( digest_out ) )
+			for ( j = 0 ; j < sizeof ( digest_out ) ; j++ )
+				sprintf ( hashstr + j*2, "%02x", digest_out[j] );
+
+		if ( parse_autovivified_setting ( "hash", &setting ) == 0 ) {
+			setting.setting.type = &setting_type_string;
+			storef_setting ( setting.settings, &setting.setting,
+				hashstr );
+		}
+
+		if ( parse_autovivified_setting ( "hashlen", &setting ) == 0 ) {
+			setting.setting.type = &setting_type_int32;
+			storen_setting ( setting.settings, &setting.setting,
+				origlen );
+		}
+
+		if ( opts.str ) {
+			printf( "%s\n", hashstr );
+			break;
+		}
+
+		printf ( "%s  %s\n", hashstr, image->name );
 	}
 
 	return 0;
@@ -112,6 +168,22 @@ static int sha1sum_exec ( int argc, char **argv ) {
 	return digest_exec ( argc, argv, &sha1_algorithm );
 }
 
+static int sha224sum_exec ( int argc, char **argv ) {
+	return digest_exec ( argc, argv, &sha224_algorithm );
+}
+
+static int sha256sum_exec ( int argc, char **argv ) {
+	return digest_exec ( argc, argv, &sha256_algorithm );
+}
+
+static int sha384sum_exec ( int argc, char **argv ) {
+	return digest_exec ( argc, argv, &sha384_algorithm );
+}
+
+static int sha512sum_exec ( int argc, char **argv ) {
+	return digest_exec ( argc, argv, &sha512_algorithm );
+}
+
 struct command md5sum_command __command = {
 	.name = "md5sum",
 	.exec = md5sum_exec,
@@ -121,3 +193,24 @@ struct command sha1sum_command __command = {
 	.name = "sha1sum",
 	.exec = sha1sum_exec,
 };
+
+struct command sha224sum_command __command = {
+	.name = "sha224sum",
+	.exec = sha224sum_exec,
+};
+
+struct command sha256sum_command __command = {
+	.name = "sha256sum",
+	.exec = sha256sum_exec,
+};
+
+struct command sha384sum_command __command = {
+	.name = "sha384sum",
+	.exec = sha384sum_exec,
+};
+
+struct command sha512sum_command __command = {
+	.name = "sha512sum",
+	.exec = sha512sum_exec,
+};
+


### PR DESCRIPTION
This PR adds the following:

- SHA-2 family of digests (sha224sum, sha256sum, sha384sum and sha512sum)
- Multi-round rehashing support
- Hashing of strings (instead of only images)
- Apply result of the data last hashed to the configuration settings as hash:string
- Apply the length of the data last hashed to the configuration settings as hashlen:int32

It is also backward compatible with hashing one or more images as have been available in md5sum and sha1sum previous to the PR.  The major difference is it will write or overwrite hash and hashlen with the last of the multiple images successfully hashed.

Without this PR, the hash functions seem to only provide a way to manually verify the digest results.  With this the resulting digest string and the length of the image can both automatically be confirmed by the ipxe script.

Also consider the following situation, a company creates an ipxe efi module were they want it to go to an ipxe shell when DHCP fails.  However, the company policy requires a password be verified to provide the shell access and also requires the password not be easy to extract even if the efi module is examined with a debugger.

This PR would allow a script such as this to be used:

#!ipxe
dhcp || goto dhcpfail
# continue normal tasks
:dhcpfail
prompt DHCP has failed, press a key to login for shell access
:loginshell
login
iseq ${username:string} ipxeadmin || goto loginshell
set salt:string 3cbc63d0c64482c666d4dfb0516eed35
md5sum --rounds 1000000 --str ${salt:string}${password:string}
iseq ${hash:string} 1577df1969a3b8f0188496804645c406 || goto loginshell
shell

Please feel free to let me know if there is problem with my code or even if there is problems with the concept I am trying to achieve with the code.

Thanks