### PR TITLE
[settings] Parse ${name:offset:length} in setting values

### DIFF
--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -47,6 +47,12 @@ struct setting {
 	 * indicates a DHCPv4 option setting.
 	 */
 	const struct settings_scope *scope;
+	/**
+	 * Offset and length for substring-ing a setting
+	 * When length is 0, assume to the end of the buffer
+	 */
+	size_t offset;
+	size_t length;
 };
 
 /** Configuration setting table */


### PR DESCRIPTION
This emulates the bash `${varname:offset:length}` syntax allowing substring manipulation of settings values. It operates during the `fetchf_setting` stage so should work for show, echo and any form of setting substitution.

It extends the existing syntax like name:type:offset:length, e.g.

```
show smbios/product:string:0:8
show smbios/uuid::0:24
echo ${ifname::3:4}
```