### PR TITLE
[hci] Add timeout arg to ifconf

### DIFF
--- a/src/hci/commands/ifmgmt_cmd.c
+++ b/src/hci/commands/ifmgmt_cmd.c
@@ -193,6 +193,8 @@ static int ifstat_exec ( int argc, char **argv ) {
 
 /** "ifconf" options */
 struct ifconf_options {
+	/** Configuration timeout **/
+	unsigned long timeout;
 	/** Configurator */
 	struct net_device_configurator *configurator;
 };
@@ -202,6 +204,9 @@ static struct option_descriptor ifconf_opts[] = {
 	OPTION_DESC ( "configurator", 'c', required_argument,
 		      struct ifconf_options, configurator,
 		      parse_netdev_configurator ),
+	OPTION_DESC ( "timeout", 't', required_argument,
+		      struct ifconf_options, timeout,
+		      parse_timeout ),
 };
 
 /**
@@ -216,7 +221,7 @@ static int ifconf_payload ( struct net_device *netdev,
 	int rc;
 
 	/* Attempt configuration */
-	if ( ( rc = ifconf ( netdev, opts->configurator ) ) != 0 ) {
+	if ( ( rc = ifconf ( netdev, opts->configurator, opts->timeout ) ) != 0 ) {
 
 		/* Close device on failure, to avoid memory exhaustion */
 		netdev_close ( netdev );

--- a/src/include/usr/ifmgmt.h
+++ b/src/include/usr/ifmgmt.h
@@ -14,7 +14,8 @@ struct net_device_configurator;
 
 extern int ifopen ( struct net_device *netdev );
 extern int ifconf ( struct net_device *netdev,
-		    struct net_device_configurator *configurator );
+		    struct net_device_configurator *configurator,
+		    unsigned long timeout );
 extern void ifclose ( struct net_device *netdev );
 extern void ifstat ( struct net_device *netdev );
 extern int iflinkwait ( struct net_device *netdev, unsigned long timeout );

--- a/src/usr/autoboot.c
+++ b/src/usr/autoboot.c
@@ -396,7 +396,7 @@ int netboot ( struct net_device *netdev ) {
 	ifstat ( netdev );
 
 	/* Configure device */
-	if ( ( rc = ifconf ( netdev, NULL ) ) != 0 )
+	if ( ( rc = ifconf ( netdev, NULL, 0 ) ) != 0 )
 		goto err_dhcp;
 	route();
 

--- a/src/usr/ifmgmt.c
+++ b/src/usr/ifmgmt.c
@@ -267,7 +267,8 @@ static int ifconf_progress ( struct ifpoller *ifpoller ) {
  * @ret rc		Return status code
  */
 int ifconf ( struct net_device *netdev,
-	     struct net_device_configurator *configurator ) {
+	     struct net_device_configurator *configurator,
+	     unsigned long timeout ) {
 	int rc;
 
 	/* Ensure device is open and link is up */
@@ -296,5 +297,5 @@ int ifconf ( struct net_device *netdev,
 		 ( configurator ? configurator->name : "" ),
 		 ( configurator ? "] " : "" ),
 		 netdev->name, netdev->ll_protocol->ntoa ( netdev->ll_addr ) );
-	return ifpoller_wait ( netdev, configurator, 0, ifconf_progress );
+	return ifpoller_wait ( netdev, configurator, timeout, ifconf_progress );
 }


### PR DESCRIPTION
Useful for performing address configuration in situations where it really shouldn't take very long.

```
iPXE> ifconf --help
Usage:

  ifconf [-c|--configurator <configurator>] [-t|--timeout <timeout>] [<interface>...]

See http://ipxe.org/cmd/ifconf for further information
iPXE> time ifconf -t100 net0
Configuring (net0 aa:bb:cc:dd:ee:ff)... Connection timed out (http://ipxe.org/4c072092)
time: 0.1s
iPXE> time ifconf -t1000 net0
Configuring (net0 aa:bb:cc:dd:ee:ff)... Connection timed out (http://ipxe.org/4c072092)
time: 1.0s
iPXE> time ifconf -t5000 net0
Configuring (net0 aa:bb:cc:dd:ee:ff)....... Connection timed out (http://ipxe.org/4c072092)
time: 4.9s
```