### PR TITLE
Expose DHCPv6 server-id, client-id and ia_na

### DIFF
--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -444,6 +444,12 @@ len6_setting __setting ( SETTING_IP6, len6 );
 extern const struct setting
 gateway6_setting __setting ( SETTING_IP6, gateway6 );
 extern const struct setting
+server6_id_setting __setting ( SETTING_IP6_EXTRA, server-identifier);
+extern const struct setting
+client6_id_setting __setting ( SETTING_IP6_EXTRA, client-identifier);
+extern const struct setting
+client6_iana_setting __setting ( SETTING_IP6_EXTRA, client-iana);
+extern const struct setting
 hostname_setting __setting ( SETTING_HOST, hostname );
 extern const struct setting
 domain_setting __setting ( SETTING_IP_EXTRA, domain );

--- a/src/net/udp/dhcpv6.c
+++ b/src/net/udp/dhcpv6.c
@@ -1015,3 +1015,33 @@ const struct setting dnssl6_setting __setting ( SETTING_IP_EXTRA, dnssl ) = {
 	.type = &setting_type_dnssl,
 	.scope = &dhcpv6_scope,
 };
+
+/** Server ID setting */
+const struct setting server6_id_setting __setting ( SETTING_IP6_EXTRA,
+                                                    server_duid ) = {
+	.name = "server-id",
+	.description = "DHCPv6 Server identifier",
+	.tag = DHCPV6_SERVER_ID,
+	.type = &setting_type_hex,
+	.scope = &dhcpv6_scope,
+};
+
+/** Client ID setting */
+const struct setting client6_id_setting __setting ( SETTING_IP6_EXTRA,
+                                                    client_duid ) = {
+	.name = "client-id",
+	.description = "DHCPv6 Client identifier",
+	.tag = DHCPV6_CLIENT_ID,
+	.type = &setting_type_hex,
+	.scope = &dhcpv6_scope,
+};
+
+/** Identity association identifier (IAID) setting */
+const struct setting client6_iana_setting __setting ( SETTING_IP6_EXTRA,
+                                                      client_iana ) = {
+	.name = "iana",
+	.description = "Identity association for non-temporary address (IA_NA)",
+	.tag = DHCPV6_IA_NA,
+	.type = &setting_type_hex,
+	.scope = &dhcpv6_scope,
+};


### PR DESCRIPTION
These values and the ip6 address can be useful for chainloaded
OS to take over DHCP lease or do a DHCPRELEASE to ensure the
DHCP server does not return "no address available" if/when the
chainloaded OS attempts to configure the inerface using DHCPv6.

Signed-off-by: Harald Jensås <hjensas@redhat.com>