### PR TITLE
[snp] try to enable promiscuous multicast receive filter if the regular one fails

### DIFF
--- a/src/drivers/net/efi/snpnet.c
+++ b/src/drivers/net/efi/snpnet.c
@@ -300,6 +300,9 @@ static int snpnet_rx_filters ( struct net_device *netdev ) {
 		  EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST |
 		  EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST ),
 		( EFI_SIMPLE_NETWORK_RECEIVE_UNICAST |
+		  EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST |
+		  EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST ),
+		( EFI_SIMPLE_NETWORK_RECEIVE_UNICAST |
 		  EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST ),
 		( EFI_SIMPLE_NETWORK_RECEIVE_UNICAST ),
 	};
@@ -310,7 +313,7 @@ static int snpnet_rx_filters ( struct net_device *netdev ) {
 	/* Try possible receive filters in turn */
 	for ( i = 0; i < ( sizeof ( filters ) / sizeof ( filters[0] ) ); i++ ) {
 		efirc = snp->snp->ReceiveFilters ( snp->snp, filters[i],
-						   0, TRUE, 0, NULL );
+				EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, TRUE, 0, NULL );
 		if ( efirc == 0 )
 			return 0;
 		rc = -EEFI ( efirc );


### PR DESCRIPTION
Currently, if the snp driver for whatever reason fails to enable receive filters
for multicast frames, it falls back to enabling just unicast and broadcast
filters. This breaks some IPv6 functionality as the network card does not
respond to neighbour solicitation requests.

Some cards refuse to enable EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST filter, but
support enabling EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST, so try it
before falling back to just unicast+broadcast.

Additionally, according to UEFI specification 2.8 p 24.1 we must set
EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST bit in the "Disable" mask, when
"ResetMCastFilter" is TRUE.

Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>