### PR TITLE
[image] Implicitly trust first embedded image 

### DIFF
--- a/src/image/embedded.c
+++ b/src/image/embedded.c
@@ -83,6 +83,9 @@ static void embedded_init ( void ) {
 		      image->name, strerror ( rc ) );
 		return;
 	}
+
+	/* Trust the selected image implicitly */
+	image_trust ( image );
 }
 
 /** Embedded image initialisation function */


### PR DESCRIPTION
iPXE when used as a NIC option ROM can sometimes be reloaded by the
UEFI/BIOS and any pre-initialised memory will remain loaded. When the
imgtrust command is run it sets `require_trusted_images'. Upon
reloading, iPXE tries to load the embedded script but fails as it is not
marked trusted. Setting this flag ensures that imgtrust with embedded
scripts is reentrant.