### PR TITLE
successful wpa handshake (memcmp polarity)

### DIFF
--- a/src/core/string.c
+++ b/src/core/string.c
@@ -101,7 +101,7 @@ int memcmp ( const void *first, const void *second, size_t len ) {
 	int diff;
 
 	while ( len-- ) {
-		diff = ( *(second_bytes++) - *(first_bytes++) );
+		diff = ( *(first_bytes++) - *(second_bytes++) );
 		if ( diff )
 			return diff;
 	}

--- a/src/net/80211/wpa.c
+++ b/src/net/80211/wpa.c
@@ -304,8 +304,13 @@ static void wpa_derive_ptk ( struct wpa_common_ctx *ctx )
 		memcpy ( ptk_data.nonce2, ctx->Anonce, WPA_NONCE_LEN );
 	}
 
-	DBGC2 ( ctx, "WPA %p A1 %s, A2 %s\n", ctx, eth_ntoa ( ptk_data.mac1 ),
-	       eth_ntoa ( ptk_data.mac2 ) );
+	{ /* need a spare buffer since we call eth_ntoa() twice */
+		char buf[18];
+		strcpy(buf, eth_ntoa ( ptk_data.mac1 ));
+		DBGC2 ( ctx, "WPA %p A1 %s, A2 %s\n", ctx, buf,
+		       eth_ntoa ( ptk_data.mac2 ) );
+	}
+
 	DBGC2 ( ctx, "WPA %p Nonce1, Nonce2:\n", ctx );
 	DBGC2_HD ( ctx, ptk_data.nonce1, WPA_NONCE_LEN );
 	DBGC2_HD ( ctx, ptk_data.nonce2, WPA_NONCE_LEN );


### PR DESCRIPTION
Fix memcmp() to return proper standard positive/negative
values for unequal comparisons. Similar to commit 3946aa9. The 
current implementation is backwards (i.e. the functions are returning
negative when they should be positive and vice-versa).

Currently all other consumers of these functions only check the return value
for ==0 or !=0 and so we can safely change the implementation without
breaking things.

However, there is one call that checks the polarity of
`memcmp()`, and that is [wpa_derive_ptk()](https://github.com/ipxe/ipxe/blob/8f1514a00450119b04b08642c55aa674bdf5a4ef/src/net/80211/wpa.c#L290-L305) during the wireless WPA 4-way
handshake. Due to the incorrect memcmp polarity, the WPA handshake
creates an incorrect PTK, and the handshake would fail after step 2.
Undoubtedly, the AP noticed the supplicant failed the mic check. This
commit fixes that issue.

Signed-off-by: Michael Bazzinotti <bazz@bazz1.com>

P.S. This wpa handshake bug is believed to have been longstanding for several years, and based on my current understanding, it possibly dates back to the release of the ipxe wpa feature itself. That makes no sense, but let's look at what I have uncovered. It seems a user encountered the exact same issue in [iPXE forums in 2016](https://forum.ipxe.org/showthread.php?tid=7943): a mic check failure. I realize net booting wirelessly is not popular nor well supported, and in that way bugs can live for a long time without being addressed. HOWEVER!

`wpa_derive_ptk()` would never run successfully unless with a different `memcmp()` function, due to the reversed polarity. How could a single person have ever successfully joined a WPA network using ipxe's `memcmp()`? I assume the code was ran successfully in the past, right? In those cases, was some other `memcmp()` somehow being used? For example, could the system's native memcmp() accidently have been superceding ipxe's?

 In any case, it seems a properly built ipxe that uses its internal `memcmp` could never generate a correct wpa ptk using `wpa_derive_ptk()` ? If you have any additional information to explain why, please by all means. Or join me in a state of wonder. Thanks