### PR TITLE
[serial] Allow serial port configuration at runtime

### DIFF
--- a/src/config/serial.h
+++ b/src/config/serial.h
@@ -5,27 +5,21 @@
  *
  * Serial port configuration
  *
- * These options affect the operation of the serial console.  They
- * take effect only if the serial console is included using the
- * CONSOLE_SERIAL option.
+ * These options affect the operation of the serial console. They take effect
+ * only if the serial console is included using the CONSOLE_SERIAL option.
+ * These settings only the default settings, and can all be set (or overriden)
+ * at runtime.
  *
  */
 
 FILE_LICENCE ( GPL2_OR_LATER );
 
-#define	COMCONSOLE	COM1		/* I/O port address */
-
-/* Keep settings from a previous user of the serial port (e.g. lilo or
- * LinuxBIOS), ignoring COMSPEED, COMDATA, COMPARITY and COMSTOP.
- */
-#undef	COMPRESERVE
-
-#ifndef COMPRESERVE
-#define	COMSPEED	115200		/* Baud rate */
-#define	COMDATA		8		/* Data bits */
-#define	COMPARITY	0		/* Parity: 0=None, 1=Odd, 2=Even */
-#define	COMSTOP		1		/* Stop bits */
-#endif
+//#define COMCONSOLE	COM1	/* I/O port address */
+#define COMPRESERVE	0	/* Preserve settings by another bootloader */
+#define COMSPEED	115200	/* Baud rate */
+#define COMDATA		8	/* Data bits */
+#define COMPARITY	0	/* Parity: 0=None, 1=Odd, 2=Even */
+#define COMSTOP		1	/* Stop bits */
 
 #include <config/named.h>
 #include NAMED_CONFIG(serial.h)

--- a/src/include/ipxe/dhcp.h
+++ b/src/include/ipxe/dhcp.h
@@ -400,6 +400,10 @@ struct dhcp_client_uuid {
 /** Cross-signed certificate source */
 #define DHCP_EB_CROSS_CERT DHCP_ENCAP_OPT ( DHCP_EB_ENCAP, 0x5d )
 
+/** Serial port configuration */
+#define DHCP_EB_SERIAL_PORT DHCP_ENCAP_OPT ( DHCP_EB_ENCAP, 0x60 )
+#define DHCP_EB_SERIAL_OPTIONS DHCP_ENCAP_OPT ( DHCP_EB_ENCAP, 0x61 )
+
 /** Skip PXE DHCP protocol extensions such as ProxyDHCP
  *
  * If set to a non-zero value, iPXE will not wait for ProxyDHCP offers

--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -98,6 +98,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define ERRFILE_spi_bit		     ( ERRFILE_DRIVER | 0x00130000 )
 #define ERRFILE_nvsvpd		     ( ERRFILE_DRIVER | 0x00140000 )
 #define ERRFILE_uart		     ( ERRFILE_DRIVER | 0x00150000 )
+#define ERRFILE_serial		     ( ERRFILE_DRIVER | 0x00160000 )
 
 #define ERRFILE_3c509		     ( ERRFILE_DRIVER | 0x00200000 )
 #define ERRFILE_bnx2		     ( ERRFILE_DRIVER | 0x00210000 )


### PR DESCRIPTION
Add configuration variables for the serial port and its options,
allowing the configuration of a serial port at runtime via either "set",
or DHCP options.

The new "serial-port" option accepts values of "1" through "4" for COM1
to COM4 respectively. For the serial options, rather than adding a
configuration variable for each of them (baud, parity etc.) and
complicate both the code and the configuration unncessarily, add a
single, generic "serial-options" setting that accepts string values such
as "115200" or "38400n81". It also accepts the special value "preserve"
to preserve the previous configuration of the serial port.

Note that this commit does _not_ enable CONSOLE_SERIAL by default,
although that could potentially follow in a subsequent commit, given
this would be now a no-op unless a port is explicitly configured.