### PR TITLE
[efi] Add support for ${boot-vlan} setting

### DIFF
--- a/src/include/ipxe/efi/efi_utils.h
+++ b/src/include/ipxe/efi/efi_utils.h
@@ -16,6 +16,9 @@ struct device;
 extern EFI_DEVICE_PATH_PROTOCOL *
 efi_devpath_end ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern size_t efi_devpath_len ( EFI_DEVICE_PATH_PROTOCOL *path );
+extern EFI_STATUS efi_devpath_find_node ( EFI_DEVICE_PATH_PROTOCOL *path,
+					  UINT8 type, UINT8 sub_type,
+					  EFI_DEVICE_PATH_PROTOCOL **node );
 extern int efi_locate_device ( EFI_HANDLE device, EFI_GUID *protocol,
 			       EFI_HANDLE *parent );
 extern int efi_child_add ( EFI_HANDLE parent, EFI_HANDLE child );

--- a/src/interface/efi/efi_utils.c
+++ b/src/interface/efi/efi_utils.c
@@ -63,6 +63,36 @@ size_t efi_devpath_len ( EFI_DEVICE_PATH_PROTOCOL *path ) {
 }
 
 /**
+ * Find device path node provided Type and SubType identifiers
+ *
+ * @v path		Path to device
+ * @v node		Device path node if found
+ * @ret efirc		EFI return status code
+ */
+EFI_STATUS efi_devpath_find_node ( EFI_DEVICE_PATH_PROTOCOL *path,
+				   UINT8 type, UINT8 sub_type,
+				   EFI_DEVICE_PATH_PROTOCOL **node )
+{
+	UINT16 length;
+
+	DBGC2 ( path, "EFI devpath looking for Type: %x, SubType: %x\n",
+		type, sub_type );
+
+	while ( path->Type != END_DEVICE_PATH_TYPE ) {
+		if ( path->Type == type && path->SubType == sub_type ) {
+			*node = path;
+			return EFI_SUCCESS;
+		}
+
+		length = path->Length[0] | ( path->Length[1] << 8 );
+		path = ( EFI_DEVICE_PATH_PROTOCOL * )
+			( ( void * ) path + length );
+	}
+
+	return EFI_NOT_FOUND;
+}
+
+/**
  * Locate parent device supporting a given protocol
  *
  * @v device		EFI device handle


### PR DESCRIPTION
Introduce ${boot-vlan} setting exposing the VLAN from the EFI loaded
image device path for iPXE. This setting enables iPXE-boot on UEFI based
machines using the VLAN configured for the PXE adapter.

An example usage of the new setting is presented in the following iPXE
script:

      #!ipxe
      iseq ${boot-vlan} 0 || vcreate -t ${boot-vlan} net0
      autoboot