### PR TITLE
Add an option to disable TLS fragmentation

### DIFF
--- a/src/config/tls.h
+++ b/src/config/tls.h
@@ -1,0 +1,26 @@
+#ifndef CONFIG_TLS_H
+#define CONFIG_TLS_H
+
+/** @file
+ *
+ * TLS configuration
+ *
+ * These options affect the operation of the behaviour of the
+ * TLS implementation.
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER );
+
+#define	TLS_FRAGMENTATION_ENABLED	/* If the TLS implementation should
+					 * request a maximum fragment length */
+#define TLS_REQUESTED_MAX_FRAGMENT_LENGTH TLS_MAX_FRAGMENT_LENGTH_4096 /* Which fragment 
+									* length should 
+									* be requested */
+
+#include <config/named.h>
+#include NAMED_CONFIG(tls.h)
+#include <config/local/tls.h>
+#include LOCAL_NAMED_CONFIG(tls.h)
+
+#endif /* CONFIG_TLS_H */

--- a/src/net/tls.c
+++ b/src/net/tls.c
@@ -49,6 +49,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
 #include <ipxe/validator.h>
 #include <ipxe/job.h>
 #include <ipxe/tls.h>
+#include <config/tls.h>
 
 /* Disambiguate the various error causes */
 #define EINVAL_CHANGE_CIPHER __einfo_error ( EINFO_EINVAL_CHANGE_CIPHER )
@@ -1036,11 +1037,13 @@ static int tls_send_client_hello ( struct tls_connection *tls ) {
 					uint8_t name[name_len];
 				} __attribute__ (( packed )) list[1];
 			} __attribute__ (( packed )) server_name;
+#ifdef TLS_FRAGMENTATION_ENABLED
 			uint16_t max_fragment_length_type;
 			uint16_t max_fragment_length_len;
 			struct {
 				uint8_t max;
 			} __attribute__ (( packed )) max_fragment_length;
+#endif
 			uint16_t signature_algorithms_type;
 			uint16_t signature_algorithms_len;
 			struct {
@@ -1091,12 +1094,14 @@ static int tls_send_client_hello ( struct tls_connection *tls ) {
 		= htons ( sizeof ( hello.extensions.server_name.list[0].name ));
 	memcpy ( hello.extensions.server_name.list[0].name, session->name,
 		 sizeof ( hello.extensions.server_name.list[0].name ) );
+#ifdef TLS_FRAGMENTATION_ENABLED
 	hello.extensions.max_fragment_length_type
 		= htons ( TLS_MAX_FRAGMENT_LENGTH );
 	hello.extensions.max_fragment_length_len
 		= htons ( sizeof ( hello.extensions.max_fragment_length ) );
 	hello.extensions.max_fragment_length.max
-		= TLS_MAX_FRAGMENT_LENGTH_4096;
+		= TLS_REQUESTED_MAX_FRAGMENT_LENGTH;
+#endif
 	hello.extensions.signature_algorithms_type
 		= htons ( TLS_SIGNATURE_ALGORITHMS );
 	hello.extensions.signature_algorithms_len


### PR DESCRIPTION
iPXE currently does not support TLS connections with large certificate chains because it can not handle TLS handshake record fragmentation. So i think there should be an option to disable the request for fragmentation. Hence i would add a `confg/tls.h` to make changes to the behaviour of the tls implementation. By default the request for fragmentation is enabled, so nothing changes here, but if desired it can be turned of by undefining `TLS_FRAGMENTATION_ENABLED`
I also added the option `TLS_REQUESTED_MAX_FRAGMENT_LENGTH` for defining, if fragmentation is enabled, the requested maximum fragment length.

I appreciate your comments and feedback.
