### PR TITLE
[efi] Restore the TPL to the original one

### DIFF
--- a/src/interface/efi/efi_timer.c
+++ b/src/interface/efi/efi_timer.c
@@ -129,13 +129,12 @@ static unsigned long efi_currticks ( void ) {
 	if ( efi_shutdown_in_progress ) {
 		efi_jiffies++;
 	} else {
-			Efi_OldTPL = bs->RaiseTPL( TPL_CALLBACK);
-			bs->RestoreTPL ( TPL_APPLICATION );
-			bs->RaiseTPL ( TPL_CALLBACK );
-			if ( Efi_OldTPL != 0 ) {
-				bs->RestoreTPL(Efi_OldTPL);
-			}
-
+		Efi_OldTPL = bs->RaiseTPL( TPL_CALLBACK);
+		bs->RestoreTPL ( TPL_APPLICATION );
+		bs->RaiseTPL ( TPL_CALLBACK );
+		if ( Efi_OldTPL != 0 ) {
+			bs->RestoreTPL(Efi_OldTPL);
+		}
 	}
 
 	return ( efi_jiffies * ( TICKS_PER_SEC / EFI_JIFFIES_PER_SEC ) );

--- a/src/interface/efi/efi_timer.c
+++ b/src/interface/efi/efi_timer.c
@@ -131,8 +131,8 @@ static unsigned long efi_currticks ( void ) {
 	} else {
 			Efi_OldTPL = bs->RaiseTPL( TPL_CALLBACK);
 			bs->RestoreTPL ( TPL_APPLICATION );
-            bs->RaiseTPL ( TPL_CALLBACK );
-            if ( Efi_OldTPL != 0 ) {
+			bs->RaiseTPL ( TPL_CALLBACK );
+			if ( Efi_OldTPL != 0 ) {
 				bs->RestoreTPL(Efi_OldTPL);
 			}
 

--- a/src/interface/efi/efi_timer.c
+++ b/src/interface/efi/efi_timer.c
@@ -124,11 +124,18 @@ static unsigned long efi_currticks ( void ) {
 	 * EFI's violation of this assumption by falling back to a
 	 * simple free-running monotonic counter during shutdown.
 	 */
+	 EFI_TPL Efi_OldTPL;
+	 Efi_OldTPL=0;
 	if ( efi_shutdown_in_progress ) {
 		efi_jiffies++;
 	} else {
-		bs->RestoreTPL ( TPL_APPLICATION );
-		bs->RaiseTPL ( TPL_CALLBACK );
+			Efi_OldTPL = bs->RaiseTPL( TPL_CALLBACK);
+			bs->RestoreTPL ( TPL_APPLICATION );
+            bs->RaiseTPL ( TPL_CALLBACK );
+            if ( Efi_OldTPL != 0 ) {
+				bs->RestoreTPL(Efi_OldTPL);
+			}
+
 	}
 
 	return ( efi_jiffies * ( TICKS_PER_SEC / EFI_JIFFIES_PER_SEC ) );


### PR DESCRIPTION
iPXE added a workaround to raise TPL to TPL_CALLBACK always, but it
would cause UEFI firmware exit boot service callback with the same TPL
level cannot be executed. Worse, some UEFI modules set a pointer at exit
boot service callback and use later, then will encounter exception /
hang for invalid pointer which is not set to a correct one since the
exit boot service callback is not executed.

The solution is to restore the TPL to the original one but not always
set it to TPL_CALLBACK.