### PR TITLE
implement api to convert pci address to host address

### DIFF
--- a/src/include/ipxe/pci_io.h
+++ b/src/include/ipxe/pci_io.h
@@ -122,4 +122,14 @@ int pci_write_config_word ( struct pci_device *pci, unsigned int where,
 int pci_write_config_dword ( struct pci_device *pci, unsigned int where,
 			     uint32_t value );
 
+/**
+ * retrieve Host Address corresponding to pci bus address
+ *
+ * @v pci		PCI device
+ * @v bus_addr		PCI Bus address
+ * @v len		Length of region
+ * @ret io_addr		Host address
+ */
+uint64_t pci_ioremap ( struct pci_device *pci, uint64_t bus_addr, size_t len );
+
 #endif /* _IPXE_PCI_IO_H */


### PR DESCRIPTION
The PCI device address may not be same as host address (CPU view address)
To read/write directly to PCI device's BARs (without using
EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Read() and
EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Mem.Write()) we need to convert PCI
device address to host address.

The UEFI specifications 2.7 provide a method to translate the PCI device
address to host address and vice versa.

device address = host address + translation offset

EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.Configuration() method can provide us with
the translation offset and host address range.

Using this we can convert the PCI device address to host address.

Signed-off-by: Pankaj Bansal <pankaj.bansal@nxp.com>