### PR TITLE
Fix typo in comment describing length codes

### DIFF
--- a/src/crypto/deflate.c
+++ b/src/crypto/deflate.c
@@ -56,7 +56,7 @@ static uint8_t deflate_reverse[256];
  * does not fit the pattern (it represents a length of 258; following
  * the pattern from the earlier codes would give a length of 259), and
  * has no extra bits.  Codes 286-287 are invalid, but can occur.  We
- * treat any code greater than 284 as meaning "length 285, no extra
+ * treat any code greater than 284 as meaning "length 258, no extra
  * bits".
  */
 static uint8_t deflate_litlen_base[28];


### PR DESCRIPTION
It now matches the value actually used in code at https://github.com/ipxe/ipxe/blob/366206517e9974dea62d0df313bdd59595c89f52/src/crypto/deflate.c#L868