### PR TITLE
[efi] Check the status code from AllocatePool()

### DIFF
--- a/src/interface/efi/efi_snp_hii.c
+++ b/src/interface/efi/efi_snp_hii.c
@@ -247,16 +247,17 @@ static int efi_snp_hii_append ( struct efi_snp_device *snpdev __unused,
 				const char *key, const char *value,
 				wchar_t **results ) {
 	EFI_BOOT_SERVICES *bs = efi_systab->BootServices;
+	EFI_STATUS efirc;
 	size_t len;
 	void *new;
 
 	/* Allocate new string */
 	len = ( ( *results ? ( wcslen ( *results ) + 1 /* "&" */ ) : 0 ) +
 		strlen ( key ) + 1 /* "=" */ + strlen ( value ) + 1 /* NUL */ );
-	bs->AllocatePool ( EfiBootServicesData, ( len * sizeof ( wchar_t ) ),
-			   &new );
-	if ( ! new )
-		return -ENOMEM;
+	if ( ( efirc = bs->AllocatePool ( EfiBootServicesData,
+					  ( len * sizeof ( wchar_t ) ),
+					  &new ) ) != EFI_SUCCESS )
+		return -EEFI ( efirc );
 
 	/* Populate string */
 	efi_snprintf ( new, len, "%ls%s%s=%s", ( *results ? *results : L"" ),


### PR DESCRIPTION
According to the latest UEFI specification (Version 2.8 Errata B) p. 7.2:

"Buffer: A pointer to a pointer to the allocated buffer if the call succeeds;
undefined otherwise."

So implementations are obliged neither to return NULL, if the allocation fails,
nor to preserve the contents of the pointer.

Make the logic more reliable by checking the status code from AllocatePool()
instead of checking the returned pointer for NULL

Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>