### PR TITLE
[build] Fix building on older versions of gcc

### DIFF
--- a/src/include/ipxe/asn1.h
+++ b/src/include/ipxe/asn1.h
@@ -313,22 +313,27 @@ struct asn1_algorithm {
 #define __asn1_algorithm __table_entry ( ASN1_ALGORITHMS, 01 )
 
 /* ASN.1 OID-identified algorithms */
-extern struct asn1_algorithm rsa_encryption_algorithm;
-extern struct asn1_algorithm md5_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm sha1_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm sha256_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm sha384_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm sha512_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm sha224_with_rsa_encryption_algorithm;
-extern struct asn1_algorithm oid_md4_algorithm;
-extern struct asn1_algorithm oid_md5_algorithm;
-extern struct asn1_algorithm oid_sha1_algorithm;
-extern struct asn1_algorithm oid_sha256_algorithm;
-extern struct asn1_algorithm oid_sha384_algorithm;
-extern struct asn1_algorithm oid_sha512_algorithm;
-extern struct asn1_algorithm oid_sha224_algorithm;
-extern struct asn1_algorithm oid_sha512_224_algorithm;
-extern struct asn1_algorithm oid_sha512_256_algorithm;
+extern struct asn1_algorithm rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm md5_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm
+sha1_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm
+sha256_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm
+sha384_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm
+sha512_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm
+sha224_with_rsa_encryption_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_md4_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_md5_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha1_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha256_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha384_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha512_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha224_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha512_224_algorithm __asn1_algorithm;
+extern struct asn1_algorithm oid_sha512_256_algorithm __asn1_algorithm;
 
 /** An ASN.1 bit string */
 struct asn1_bit_string {


### PR DESCRIPTION
Older versions of gcc (observed with gcc 4.5.3) require attributes to
be specified on the first declaration of a symbol, and will silently
ignore attributes specified after the initial declaration.  This
causes the ASN.1 OID-identified algorithms to end up misaligned.

Fix by adding __asn1_algorithm to the initial declarations in asn1.h.

Debugged-by: Dentcho Bankov <dbankov@vmware.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>