### PR TITLE
Fixed hang on rtl8139 initialization

### DIFF
--- a/src/core/image.c
+++ b/src/core/image.c
@@ -481,3 +481,13 @@ int image_set_trust ( int require_trusted, int permanent ) {
 
 	return 0;
 }
+
+/**
+ * Get image trust requirement
+ *
+ * @ret require_trusted		Whether images are required to be trusted
+ */
+int image_get_require_trust ( ) {
+
+	return require_trusted_images;
+}

--- a/src/drivers/net/realtek.c
+++ b/src/drivers/net/realtek.c
@@ -531,6 +531,7 @@ static int realtek_create_buffer ( struct realtek_nic *rtl ) {
 
 	/* Program buffer address */
 	writel ( address, rtl->regs + RTL_RBSTART );
+	udelay ( 1 );
 	DBGC ( rtl, "REALTEK %p receive buffer is at [%08llx,%08llx,%08llx)\n",
 	       rtl, ( ( unsigned long long ) address ),
 	       ( ( unsigned long long ) address + RTL_RXBUF_LEN ),

--- a/src/include/ipxe/image.h
+++ b/src/include/ipxe/image.h
@@ -183,6 +183,7 @@ extern int image_replace ( struct image *replacement );
 extern int image_select ( struct image *image );
 extern struct image * image_find_selected ( void );
 extern int image_set_trust ( int require_trusted, int permanent );
+extern int image_get_require_trust ( );
 extern int image_pixbuf ( struct image *image, struct pixel_buffer **pixbuf );
 extern int image_asn1 ( struct image *image, size_t offset,
 			struct asn1_cursor **cursor );


### PR DESCRIPTION
On my old Pentium 4 PC the initialization of the rtl8139 network interface (either via ifopen or dhcp) would hang in most situations, requiring a hard reset. The added delay appears to fix this reliably.

I am not entirely sure whether a delay is required here, or whether it's a side effect of the delay call that actually eliminates the problem. The problem also went away when I enabled debugging for the realtek module, likely because of the delay introduced by the subsequent debug log statement. The problem did not occur with the default configuration when using the dhcp command in the beginning of the script with error suppression, but did occur each time without error suppression, when used later in the script, or when both HTTPS and image verification were enabled.