### PR TITLE
Fixed hang on rtl8139 initialization

### DIFF
--- a/src/drivers/net/realtek.c
+++ b/src/drivers/net/realtek.c
@@ -531,6 +531,7 @@ static int realtek_create_buffer ( struct realtek_nic *rtl ) {
 
 	/* Program buffer address */
 	writel ( address, rtl->regs + RTL_RBSTART );
+	udelay ( 1 );
 	DBGC ( rtl, "REALTEK %p receive buffer is at [%08llx,%08llx,%08llx)\n",
 	       rtl, ( ( unsigned long long ) address ),
 	       ( ( unsigned long long ) address + RTL_RXBUF_LEN ),


### PR DESCRIPTION
On my old Pentium 4 PC the initialization of the rtl8139 network interface (either via ifopen or dhcp) would hang in most situations, requiring a hard reset. The added delay appears to fix this reliably.

I am not entirely sure whether a delay is required here, or whether it's a side effect of the delay call that actually eliminates the problem. The problem also went away when I enabled debugging for the realtek module, likely because of the delay introduced by the subsequent debug log statement. The problem did not occur with the default configuration when using the dhcp command in the beginning of the script with error suppression, but did occur each time without error suppression, when used later in the script, or when both HTTPS and image verification were enabled.