### PR TITLE
Allow to add trusted certificates at run time

### DIFF
--- a/src/core/image.c
+++ b/src/core/image.c
@@ -481,3 +481,13 @@ int image_set_trust ( int require_trusted, int permanent ) {
 
 	return 0;
 }
+
+/**
+ * Get image trust requirement
+ *
+ * @ret require_trusted		Whether images are required to be trusted
+ */
+int image_get_require_trust ( ) {
+
+	return require_trusted_images;
+}

--- a/src/include/ipxe/image.h
+++ b/src/include/ipxe/image.h
@@ -183,6 +183,7 @@ extern int image_replace ( struct image *replacement );
 extern int image_select ( struct image *image );
 extern struct image * image_find_selected ( void );
 extern int image_set_trust ( int require_trusted, int permanent );
+extern int image_get_require_trust ( );
 extern int image_pixbuf ( struct image *image, struct pixel_buffer **pixbuf );
 extern int image_asn1 ( struct image *image, size_t offset,
 			struct asn1_cursor **cursor );


### PR DESCRIPTION
This patch allows to mark certificates imported by the certstore command as trusted. This allows the user to load trusted certificates  at runtime in an existing build using the `certstore --trusted ...` command, rather than having to compile certificates into a new build or managing cross-signed certificates.

I don't think this (technically) reduces security. If an attacker is in a position where iPXE commands can be entered, the attacker can also chainload an insecure binary, unless the imgtrust option is enabled, in which case loaded certificates can no longer be marked as trusted via this patch.