### PR TITLE
[net] Fallback to cross-signed cert if self-signed

### DIFF
--- a/src/net/validator.c
+++ b/src/net/validator.c
@@ -588,13 +588,12 @@ static void validator_step ( struct validator *validator ) {
 		return;
 	}
 
-	/* If chain ends with a self-issued certificate, then there is
-	 * nothing more to do.
-	 */
 	last = x509_last ( validator->chain );
 	if ( asn1_compare ( &last->issuer.raw, &last->subject.raw ) == 0 ) {
-		validator_finished ( validator, rc );
-		return;
+		DBGC ( validator,
+		       "VALIDATOR %p \"%s\" is self-signed. Searching for "
+		       "cross-signed alternative.\n",
+		       validator, x509_name ( last ));
 	}
 
 	/* Otherwise, try to download a suitable cross-signing


### PR DESCRIPTION
Some TLS implementations will include the full cert chain (including the
root) in the initial handshake. In that situation, we would try to
validate the cert chain and then get caught up on that self-signed cert.
If that root cert was not provided, then we would have checked ipxe's
cross-signed roots to close the gap.

This change expands that cross-signed cert-downloading behavior to
include situations where we encounter a self-signed cert.

Closes #147

Signed-off-by: Josh McSavaney <me@mcsau.cc>