### PR TITLE
[lacp] Detect and ignore erroneously looped back LACP packets

### DIFF
--- a/src/net/eth_slow.c
+++ b/src/net/eth_slow.c
@@ -286,6 +286,9 @@ static int eth_slow_rx ( struct io_buffer *iobuf,
 		return -EINVAL;
 	}
 
+	/* Strip any trailing padding */
+	iob_unput ( iobuf, ( sizeof ( *eth_slow ) - iob_len ( iobuf ) ) );
+
 	/* Handle according to subtype */
 	switch ( eth_slow->header.subtype ) {
 	case ETH_SLOW_SUBTYPE_LACP:


### PR DESCRIPTION
Some network topologies seem to cause LACP packets transmitted by iPXE
to be looped back as received packets.  Since iPXE's trivial LACP
responder will send one response per received packet, this results in
an immediate LACP packet storm.

Detect looped back LACP packets (based on the received LACP actor MAC
address), and refuse to respond to such packets.

Fixes: #157 

Reported-by: Tore Anderson <tore@fud.no>
Signed-off-by: Michael Brown <mcb30@ipxe.org>