### PR TITLE
Add xorrisofs to the mkisofs equivalent list

### DIFF
--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -149,7 +149,7 @@ ISOARGS=
 #
 if [ -n "${ISOIMG}" ] ; then
     MKISOFS=
-    for CMD in genisoimage mkisofs ; do
+    for CMD in genisoimage mkisofs xorrisofs ; do
 	if ${CMD} --version >/dev/null 2>/dev/null ; then
 	    MKISOFS="${CMD}"
 	    break


### PR DESCRIPTION
Add xorrisofs support, a Gnu mkisofs equivalent that is available in most Distros Repositories.