### PR TITLE
WIP: ipxe ConnectX-3 driver feature backport from Mellanox Upstream soup [do not merge as-is]

### DIFF
--- a/src/drivers/infiniband/MT25218_PRM.h
+++ b/src/drivers/infiniband/MT25218_PRM.h
@@ -73,7 +73,7 @@ struct arbelprm_ud_address_vector_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	rgid_31_0[0x00020];    /* Remote GID[31:0] if G bit is set. Must be set to 0x2 if G bit is cleared. */
 /* -------------- */
-}; 
+};
 
 /* Send doorbell */
 
@@ -88,7 +88,7 @@ struct arbelprm_send_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00002];
     pseudo_bit_t	qpn[0x00018];          /* QP number this doorbell is rung on */
 /* -------------- */
-}; 
+};
 
 /* ACCESS_LAM_inject_errors_input_modifier */
 
@@ -102,7 +102,7 @@ struct arbelprm_access_lam_inject_errors_input_modifier_st {	/* Little Endian */
     pseudo_bit_t	index0[0x00007];
     pseudo_bit_t	q0[0x00001];
 /* -------------- */
-}; 
+};
 
 /* ACCESS_LAM_inject_errors_input_parameter */
 
@@ -114,7 +114,7 @@ struct arbelprm_access_lam_inject_errors_input_parameter_st {	/* Little Endian *
     pseudo_bit_t	ra[0x00010];           /* Row Address */
     pseudo_bit_t	ca[0x00010];           /* Column Address */
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -127,7 +127,7 @@ struct arbelprm_recv_wqe_segment_next_st {	/* Little Endian */
                                                   */
     pseudo_bit_t	reserved1[0x0001a];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment data inline */
 
@@ -141,7 +141,7 @@ struct arbelprm_wqe_segment_data_inline_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment data ptr */
 
@@ -155,7 +155,7 @@ struct arbelprm_wqe_segment_data_ptr_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	local_address_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment rd */
 
@@ -167,7 +167,7 @@ struct arbelprm_local_invalidate_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x000a0];
 /* -------------- */
-}; 
+};
 
 /* Fast_Registration_Segment */
 
@@ -197,7 +197,7 @@ struct arbelprm_fast_registration_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reg_len_l[0x00020];    /* Region Length[31:0] */
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment atomic */
 
@@ -210,7 +210,7 @@ struct arbelprm_wqe_segment_atomic_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	compare_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment remote address */
 
@@ -223,7 +223,7 @@ struct arbelprm_wqe_segment_remote_address_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* end wqe segment bind */
 
@@ -253,7 +253,7 @@ struct arbelprm_wqe_segment_bind_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	length_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment ud */
 
@@ -267,7 +267,7 @@ struct arbelprm_wqe_segment_ud_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment rd */
 
@@ -279,7 +279,7 @@ struct arbelprm_wqe_segment_rd_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment ctrl */
 
@@ -296,7 +296,7 @@ struct arbelprm_wqe_segment_ctrl_send_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	immediate[0x00020];    /* If the OpCode encodes an operation with Immediate (RDMA-write/SEND), This field will hold the Immediate data to be sent. If the OpCode encodes send and invalidate operations, this field holds the Invalidation key to be inserted into the packet; otherwise, this field is reserved. */
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment next */
 
@@ -338,7 +338,7 @@ struct arbelprm_wqe_segment_next_st {	/* Little Endian */
     pseudo_bit_t	always1[0x00001];
     pseudo_bit_t	reserved1[0x00018];
 /* -------------- */
-}; 
+};
 
 /* Address Path */
 
@@ -384,7 +384,7 @@ struct arbelprm_address_path_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	rgid_31_0[0x00020];    /* Remote GID[31:0] */
 /* -------------- */
-}; 
+};
 
 /* HCA Command Register (HCR) */
 
@@ -414,7 +414,7 @@ struct arbelprm_hca_command_register_st {	/* Little Endian */
     pseudo_bit_t	status[0x00008];       /* Command execution status report. Valid only if command interface in under SW ownership (Go bit is cleared)
                                                  0 - command completed without error. If different than zero, command execution completed with error. Syndrom encoding is depended on command executed and is defined for each command */
 /* -------------- */
-}; 
+};
 
 /* CQ Doorbell */
 
@@ -435,7 +435,7 @@ struct arbelprm_cq_cmd_doorbell_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	cq_param[0x00020];     /* parameter to be used by CQ command */
 /* -------------- */
-}; 
+};
 
 /* RD-send doorbell */
 
@@ -449,7 +449,7 @@ struct arbelprm_rd_send_doorbell_st {	/* Little Endian */
 /* -------------- */
     struct arbelprm_send_doorbell_st	send_doorbell;/* Send Parameters */
 /* -------------- */
-}; 
+};
 
 /* Multicast Group Member QP */
 
@@ -458,7 +458,7 @@ struct arbelprm_mgmqp_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00007];
     pseudo_bit_t	qi[0x00001];           /* Qi: QPN_i is valid */
 /* -------------- */
-}; 
+};
 
 /* vsd */
 
@@ -575,7 +575,7 @@ struct arbelprm_vsd_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	vsd_dw55[0x00020];
 /* -------------- */
-}; 
+};
 
 /* ACCESS_LAM_inject_errors */
 
@@ -586,7 +586,7 @@ struct arbelprm_access_lam_inject_errors_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Logical DIMM Information */
 
@@ -626,7 +626,7 @@ struct arbelprm_dimminfo_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00040];
 /* -------------- */
-}; 
+};
 
 /* UAR Parameters */
 
@@ -661,7 +661,7 @@ struct arbelprm_uar_params_st {	/* Little Endian */
                                                  Number of entries in table is 2^log_max_uars. 
                                                  Table must be aligned to its size. */
 /* -------------- */
-}; 
+};
 
 /* Translation and Protection Tables Parameters */
 
@@ -695,7 +695,7 @@ struct arbelprm_tptparams_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Multicast Support Parameters */
 
@@ -729,7 +729,7 @@ struct arbelprm_multicastparam_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved5[0x00020];
 /* -------------- */
-}; 
+};
 
 /* QPC/EEC/CQC/EQC/RDB Parameters */
 
@@ -821,7 +821,7 @@ struct arbelprm_qpcbaseaddr_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved10[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Header_Log_Register */
 
@@ -830,7 +830,7 @@ struct arbelprm_header_log_register_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Performance Monitors */
 
@@ -862,7 +862,7 @@ struct arbelprm_performance_monitors_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	event_counter2[0x00020];/* Read/write event counter, counting events specified by EvCntl and EvCnt2 fields repsectively. When the event counter reaches is maximum value of 0xFFFFFF, the next event will cause it to roll over to zero, set F1 or F2 bit respectively and generate interrupt by I1 I2 bit respectively. */
 /* -------------- */
-}; 
+};
 
 /* Receive segment format */
 
@@ -876,7 +876,7 @@ struct arbelprm_wqe_segment_ctrl_recv_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00020];
 /* -------------- */
-}; 
+};
 
 /* MLX WQE segment format */
 
@@ -895,7 +895,7 @@ struct arbelprm_wqe_segment_ctrl_mlx_st {	/* Little Endian */
     pseudo_bit_t	vcrc[0x00010];         /* Packet's VCRC (if not 0 - otherwise computed by HW) */
     pseudo_bit_t	rlid[0x00010];         /* Destination LID (must match given headers) */
 /* -------------- */
-}; 
+};
 
 /* Send WQE segment format */
 
@@ -926,7 +926,7 @@ struct arbelprm_send_wqe_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00200];
 /* -------------- */
-}; 
+};
 
 /* QP and EE Context Entry */
 
@@ -1118,7 +1118,7 @@ struct arbelprm_queue_pair_ee_context_entry_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved33[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Clear Interrupt [63:0] */
 
@@ -1132,7 +1132,7 @@ struct arbelprm_clr_int_st {	/* Little Endian */
                                                  Write transactions to this register will clear (de-assert) the virtual interrupt output pins of InfiniHost-III-EX. The value to be written in this register is obtained by executing QUERY_ADAPTER command on command interface after system boot. 
                                                  This register is write-only. Reading from this register will cause undefined result */
 /* -------------- */
-}; 
+};
 
 /* EQ_Arm_DB_Region */
 
@@ -1143,7 +1143,7 @@ struct arbelprm_eq_arm_db_region_st {	/* Little Endian */
     pseudo_bit_t	eq_x_arm_l[0x00020];   /* EQ[31:0]  X state.
                                                  This register is used to Arm EQs when setting the appropriate bits. */
 /* -------------- */
-}; 
+};
 
 /* EQ Set CI DBs Table */
 
@@ -1404,7 +1404,7 @@ struct arbelprm_eq_set_ci_table_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved63[0x00020];
 /* -------------- */
-}; 
+};
 
 /* InfiniHost-III-EX Configuration Registers */
 
@@ -1415,7 +1415,7 @@ struct arbelprm_configuration_registers_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x3fcb20];
 /* -------------- */
-}; 
+};
 
 /* QP_DB_Record */
 
@@ -1429,7 +1429,7 @@ struct arbelprm_qp_db_record_st {	/* Little Endian */
                                                  0x5 for SRQ */
     pseudo_bit_t	qp_number[0x00018];    /* QP number */
 /* -------------- */
-}; 
+};
 
 /* CQ_ARM_DB_Record */
 
@@ -1445,7 +1445,7 @@ struct arbelprm_cq_arm_db_record_st {	/* Little Endian */
     pseudo_bit_t	res[0x00003];          /* Must be 0x2 */
     pseudo_bit_t	cq_number[0x00018];    /* CQ number */
 /* -------------- */
-}; 
+};
 
 /* CQ_CI_DB_Record */
 
@@ -1456,7 +1456,7 @@ struct arbelprm_cq_ci_db_record_st {	/* Little Endian */
     pseudo_bit_t	res[0x00003];          /* Must be 0x1 */
     pseudo_bit_t	cq_number[0x00018];    /* CQ number */
 /* -------------- */
-}; 
+};
 
 /* Virtual_Physical_Mapping */
 
@@ -1472,7 +1472,7 @@ struct arbelprm_virtual_physical_mapping_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00006];
     pseudo_bit_t	pa_l[0x00014];         /* Physical Address[31:12] */
 /* -------------- */
-}; 
+};
 
 /* MOD_STAT_CFG */
 
@@ -1485,7 +1485,7 @@ struct arbelprm_mod_stat_cfg_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x007e0];
 /* -------------- */
-}; 
+};
 
 /* SRQ Context */
 
@@ -1528,7 +1528,7 @@ struct arbelprm_srq_context_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00060];
 /* -------------- */
-}; 
+};
 
 /* PBL */
 
@@ -1549,7 +1549,7 @@ struct arbelprm_pbl_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	mtt_3_l[0x00020];      /* Fourth MTT[31:0] */
 /* -------------- */
-}; 
+};
 
 /* Performance Counters */
 
@@ -1580,7 +1580,7 @@ struct arbelprm_performance_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00620];
 /* -------------- */
-}; 
+};
 
 /* Transport and CI Error Counters */
 
@@ -1724,7 +1724,7 @@ struct arbelprm_transport_and_ci_error_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved12[0x002a0];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - HCR Completion Event */
 
@@ -1743,7 +1743,7 @@ struct arbelprm_hcr_completion_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Completion with Error CQE */
 
@@ -1791,7 +1791,7 @@ struct arbelprm_completion_with_error_st {	/* Little Endian */
                                                  0xFE - For completion with error on Receive Queues
                                                  0xFF - For completion with error on Send Queues */
 /* -------------- */
-}; 
+};
 
 /* Resize CQ Input Mailbox */
 
@@ -1814,7 +1814,7 @@ struct arbelprm_resize_cq_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00100];
 /* -------------- */
-}; 
+};
 
 /* MAD_IFC Input Modifier */
 
@@ -1826,7 +1826,7 @@ struct arbelprm_mad_ifc_input_modifier_st {	/* Little Endian */
     pseudo_bit_t	rlid[0x00010];         /* Remote (source) LID  from the received MAD.
                                                  This field is required for trap generation upon MKey/BKey validation. */
 /* -------------- */
-}; 
+};
 
 /* MAD_IFC Input Mailbox */
 
@@ -1863,7 +1863,7 @@ struct arbelprm_mad_ifc_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved5[0x004c0];
 /* -------------- */
-}; 
+};
 
 /* Query Debug Message */
 
@@ -1924,7 +1924,7 @@ struct arbelprm_query_debug_msg_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00400];
 /* -------------- */
-}; 
+};
 
 /* User Access Region */
 
@@ -1939,7 +1939,7 @@ struct arbelprm_uar_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x03ec0];
 /* -------------- */
-}; 
+};
 
 /* Receive doorbell */
 
@@ -1953,7 +1953,7 @@ struct arbelprm_receive_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved3[0x00002];
     pseudo_bit_t	qpn[0x00018];          /* QP number or SRQ number this doorbell is rung on */
 /* -------------- */
-}; 
+};
 
 /* SET_IB Parameters */
 
@@ -1974,7 +1974,7 @@ struct arbelprm_set_ib_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00180];
 /* -------------- */
-}; 
+};
 
 /* Multicast Group Member */
 
@@ -2014,7 +2014,7 @@ struct arbelprm_mgm_entry_st {	/* Little Endian */
 /* -------------- */
     struct arbelprm_mgmqp_st	mgmqp_7;   /* Multicast Group Member QP */
 /* -------------- */
-}; 
+};
 
 /* INIT_IB Parameters */
 
@@ -2068,7 +2068,7 @@ struct arbelprm_init_ib_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved5[0x006c0];
 /* -------------- */
-}; 
+};
 
 /* Query Device Limitations */
 
@@ -2285,7 +2285,7 @@ struct arbelprm_query_dev_lim_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved41[0x002c0];
 /* -------------- */
-}; 
+};
 
 /* QUERY_ADAPTER Parameters Block */
 
@@ -2299,7 +2299,7 @@ struct arbelprm_query_adapter_st {	/* Little Endian */
 /* -------------- */
     struct arbelprm_vsd_st	vsd;
 /* -------------- */
-}; 
+};
 
 /* QUERY_FW Parameters Block */
 
@@ -2375,7 +2375,7 @@ struct arbelprm_query_fw_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved6[0x004c0];
 /* -------------- */
-}; 
+};
 
 /* ACCESS_LAM */
 
@@ -2384,7 +2384,7 @@ struct arbelprm_access_lam_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00080];
 /* -------------- */
-}; 
+};
 
 /* ENABLE_LAM Parameters Block */
 
@@ -2418,7 +2418,7 @@ struct arbelprm_enable_lam_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00400];
 /* -------------- */
-}; 
+};
 
 /* Memory Access Parameters for UD Address Vector Table */
 
@@ -2430,7 +2430,7 @@ struct arbelprm_udavtable_memory_parameters_st {	/* Little Endian */
     pseudo_bit_t	xlation_en[0x00001];   /* When cleared, address is physical address and no translation will be done. When set, address is virtual. */
     pseudo_bit_t	reserved1[0x00002];
 /* -------------- */
-}; 
+};
 
 /* INIT_HCA & QUERY_HCA Parameters Block */
 
@@ -2495,7 +2495,7 @@ struct arbelprm_init_hca_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved11[0x00600];
 /* -------------- */
-}; 
+};
 
 /* Event Queue Context Table Entry */
 
@@ -2555,7 +2555,7 @@ struct arbelprm_eqc_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved9[0x00080];
 /* -------------- */
-}; 
+};
 
 /* Memory Translation Table (MTT) Entry */
 
@@ -2566,7 +2566,7 @@ struct arbelprm_mtt_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x0000b];
     pseudo_bit_t	ptag_l[0x00014];       /* Low-order bits of Physical tag. The size of the field depends on the page size of the region. Maximum PTAG size is 52 bits. */
 /* -------------- */
-}; 
+};
 
 /* Memory Protection Table (MPT) Entry */
 
@@ -2641,7 +2641,7 @@ struct arbelprm_mpt_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved8[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Completion Queue Context Table Entry */
 
@@ -2719,7 +2719,7 @@ struct arbelprm_completion_queue_context_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved8[0x00020];
 /* -------------- */
-}; 
+};
 
 /* GPIO_event_data */
 
@@ -2732,7 +2732,7 @@ struct arbelprm_gpio_event_data_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - QP/EE Events */
 
@@ -2749,7 +2749,7 @@ struct arbelprm_qp_ee_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00060];
 /* -------------- */
-}; 
+};
 
 /* InfiniHost-III-EX Type0 Configuration Header */
 
@@ -2947,7 +2947,7 @@ struct arbelprm_mt25208_type0_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved13[0x006a0];
 /* -------------- */
-}; 
+};
 
 /* Event Data Field - Performance Monitor */
 
@@ -2965,7 +2965,7 @@ struct arbelprm_performance_monitor_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Page Faults */
 
@@ -2989,7 +2989,7 @@ struct arbelprm_page_fault_event_data_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	prefetch_len[0x00020]; /* Indicates how many subsequent pages in the same memory region/window will be accessed by the following transaction after this page fault is resolved. measured in bytes. SW can use this information in order to page-in the subsequent pages if they are not present. */
 /* -------------- */
-}; 
+};
 
 /* WQE segments format */
 
@@ -3006,7 +3006,7 @@ struct arbelprm_wqe_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00080];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Port State Change */
 
@@ -3019,7 +3019,7 @@ struct arbelprm_port_state_change_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Completion Queue Error */
 
@@ -3036,7 +3036,7 @@ struct arbelprm_completion_queue_error_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Completion Event */
 
@@ -3046,7 +3046,7 @@ struct arbelprm_completion_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x000a0];
 /* -------------- */
-}; 
+};
 
 /* Event Queue Entry */
 
@@ -3065,7 +3065,7 @@ struct arbelprm_event_queue_entry_st {	/* Little Endian */
                                                  1 HW */
     pseudo_bit_t	reserved3[0x00018];
 /* -------------- */
-}; 
+};
 
 /* QP/EE State Transitions Command Parameters */
 
@@ -3078,7 +3078,7 @@ struct arbelprm_qp_ee_state_transitions_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x009c0];
 /* -------------- */
-}; 
+};
 
 /* Completion Queue Entry Format */
 
@@ -3131,7 +3131,7 @@ struct arbelprm_completion_queue_entry_st {	/* Little Endian */
                                                  0xFE - For completion with error on Receive Queues
                                                  0xFF - For completion with error on Send Queues */
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -3152,7 +3152,7 @@ struct arbelprm_ecc_detect_event_data_st {	/* Little Endian */
     pseudo_bit_t	err_ra[0x00010];
     pseudo_bit_t	err_ca[0x00010];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - ECC Detection Event */
 
@@ -3177,7 +3177,7 @@ struct arbelprm_scrubbing_event_st {	/* Little Endian */
     pseudo_bit_t	err_ra[0x00010];       /* Error row address */
     pseudo_bit_t	err_ca[0x00010];       /* Error column address */
 /* -------------- */
-}; 
+};
 
 /* Miscellaneous Counters */
 
@@ -3186,28 +3186,28 @@ struct arbelprm_misc_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x007e0];
 /* -------------- */
-}; 
+};
 
 /* LAM_EN Output Parameter */
 
 struct arbelprm_lam_en_out_param_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Extended_Completion_Queue_Entry */
 
 struct arbelprm_extended_completion_queue_entry_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /*  */
 
 struct arbelprm_eq_cmd_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* 0 */
 
@@ -3456,5 +3456,5 @@ struct arbelprm_arbel_prm_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved59[0xffcfc0];
 /* -------------- */
-}; 
+};
 #endif /* H_prefix_arbelprm_bits_fixnames_MT25218_PRM_csp_H */

--- a/src/drivers/infiniband/MT25408_PRM.h
+++ b/src/drivers/infiniband/MT25408_PRM.h
@@ -47,7 +47,7 @@ struct hermonprm_ud_address_vector_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00008];
 /* -------------- */
     pseudo_bit_t	hop_limit[0x00008];    /* IPv6 hop limit */
-    pseudo_bit_t	max_stat_rate[0x00004];/* Maximum static rate control. 
+    pseudo_bit_t	max_stat_rate[0x00004];/* Maximum static rate control.
                                                  0 - 4X injection rate
                                                  1 - 1X injection rate
                                                  other - reserved
@@ -72,7 +72,7 @@ struct hermonprm_ud_address_vector_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	rgid_31_0[0x00020];    /* Remote GID[31:0] if G bit is set. Must be set to 0x2 if G bit is cleared. */
 /* -------------- */
-}; 
+};
 
 /* Send doorbell */
 
@@ -87,7 +87,7 @@ struct hermonprm_send_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00002];
     pseudo_bit_t	qpn[0x00018];          /* QP number this doorbell is rung on */
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment data inline */
 
@@ -101,7 +101,7 @@ struct hermonprm_wqe_segment_data_inline_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment data ptr */
 
@@ -115,7 +115,7 @@ struct hermonprm_wqe_segment_data_ptr_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	local_address_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment rd */
 
@@ -127,7 +127,7 @@ struct hermonprm_local_invalidate_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x000a0];
 /* -------------- */
-}; 
+};
 
 /* Fast_Registration_Segment   ####michal - doesn't match PRM (fields were added, see below) new table size in bytes -  0x30 */
 
@@ -157,7 +157,7 @@ struct hermonprm_fast_registration_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reg_len_l[0x00020];    /* Region Length[31:0] */
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment atomic */
 
@@ -170,7 +170,7 @@ struct hermonprm_wqe_segment_atomic_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	compare_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment remote address */
 
@@ -183,7 +183,7 @@ struct hermonprm_wqe_segment_remote_address_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* end wqe segment bind */
 
@@ -213,7 +213,7 @@ struct hermonprm_wqe_segment_bind_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	length_l[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment ud */
 
@@ -227,7 +227,7 @@ struct hermonprm_wqe_segment_ud_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment rd */
 
@@ -239,7 +239,7 @@ struct hermonprm_wqe_segment_rd_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Send wqe segment ctrl */
 
@@ -263,7 +263,7 @@ struct hermonprm_wqe_segment_ctrl_send_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	immediate[0x00020];    /* If the OpCode encodes an operation with Immediate (RDMA-write/SEND), This field will hold the Immediate data to be sent. If the OpCode encodes send and invalidate operations, this field holds the Invalidation key to be inserted into the packet; otherwise, this field is reserved. */
 /* -------------- */
-}; 
+};
 
 /* Address Path	# ###michal - match to PRM */
 
@@ -280,19 +280,19 @@ struct hermonprm_address_path_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00008];
 /* -------------- */
     pseudo_bit_t	hop_limit[0x00008];    /* IPv6 hop limit */
-    pseudo_bit_t	max_stat_rate[0x00004];/* Maximum static rate control. 
-                                                 0 - 100% injection rate 
+    pseudo_bit_t	max_stat_rate[0x00004];/* Maximum static rate control.
+                                                 0 - 100% injection rate
                                                  1 - 25% injection rate
                                                  2 - 12.5% injection rate
                                                  3 - 50% injection rate
-                                                 7: 2.5 Gb/s. 
-                                                 8: 10 Gb/s. 
-                                                 9: 30 Gb/s. 
-                                                 10: 5 Gb/s. 
+                                                 7: 2.5 Gb/s.
+                                                 8: 10 Gb/s.
+                                                 9: 30 Gb/s.
+                                                 10: 5 Gb/s.
                                                  11: 20 Gb/s.
-                                                 12: 40 Gb/s. 
-                                                 13: 60 Gb/s. 
-                                                 14: 80 Gb/s. 
+                                                 12: 40 Gb/s.
+                                                 13: 60 Gb/s.
+                                                 14: 80 Gb/s.
                                                  15: 120 Gb/s. */
     pseudo_bit_t	reserved2[0x00004];
     pseudo_bit_t	mgid_index[0x00007];   /* Index to port GID table */
@@ -328,7 +328,7 @@ struct hermonprm_address_path_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	dmac_31_0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* HCA Command Register (HCR)    #### michal - match PRM */
 
@@ -359,7 +359,7 @@ struct hermonprm_hca_command_register_st {	/* Little Endian */
     pseudo_bit_t	status[0x00008];       /* Command execution status report. Valid only if command interface in under SW ownership (Go bit is cleared)
                                                  0 - command completed without error. If different than zero, command execution completed with error. Syndrom encoding is depended on command executed and is defined for each command */
 /* -------------- */
-}; 
+};
 
 /* CQ Doorbell */
 
@@ -373,14 +373,14 @@ struct hermonprm_cq_cmd_doorbell_st {	/* Little Endian */
                                                  Other - Reserved */
     pseudo_bit_t	reserved0[0x00001];
     pseudo_bit_t	cmd_sn[0x00002];       /* Command Sequence Number - This field should be incremented upon receiving completion notification of the respective CQ.
-                                                 This transition is done by ringing Request notification for next Solicited, Request notification for next Solicited or Unsolicited 
+                                                 This transition is done by ringing Request notification for next Solicited, Request notification for next Solicited or Unsolicited
                                                  completion or Request notification for multiple completions doorbells after receiving completion notification.
                                                  This field is initialized to Zero */
     pseudo_bit_t	reserved1[0x00002];
 /* -------------- */
     pseudo_bit_t	cq_param[0x00020];     /* parameter to be used by CQ command */
 /* -------------- */
-}; 
+};
 
 /* RD-send doorbell */
 
@@ -394,7 +394,7 @@ struct hermonprm_rd_send_doorbell_st {	/* Little Endian */
 /* -------------- */
     struct hermonprm_send_doorbell_st	send_doorbell;/* Send Parameters */
 /* -------------- */
-}; 
+};
 
 /* Multicast Group Member QP   #### michal - match PRM */
 
@@ -404,7 +404,7 @@ struct hermonprm_mgmqp_st {	/* Little Endian */
     pseudo_bit_t	blck_lb[0x00001];      /* Block self-loopback messages arriving to this qp */
     pseudo_bit_t	qi[0x00001];           /* Qi: QPN_i is valid */
 /* -------------- */
-}; 
+};
 
 /* vsd */
 
@@ -521,7 +521,7 @@ struct hermonprm_vsd_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	vsd_dw55[0x00020];
 /* -------------- */
-}; 
+};
 
 /* UAR Parameters */
 
@@ -535,7 +535,7 @@ struct hermonprm_uar_params_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x000a0];
 /* -------------- */
-}; 
+};
 
 /* Translation and Protection Tables Parameters */
 
@@ -552,7 +552,7 @@ struct hermonprm_tptparams_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	log_dmpt_sz[0x00006];  /* Log (base 2) of the number of region/windows entries in the dMPT table. */
     pseudo_bit_t	reserved0[0x00002];
-    pseudo_bit_t	pfto[0x00005];         /* Page Fault RNR Timeout - 
+    pseudo_bit_t	pfto[0x00005];         /* Page Fault RNR Timeout -
                                                  The field returned in RNR Naks generated when a page fault is detected.
                                                  It has no effect when on-demand-paging is not used. */
     pseudo_bit_t	reserved1[0x00013];
@@ -575,7 +575,7 @@ struct hermonprm_tptparams_st {	/* Little Endian */
                                                  Entry size is 64 bytes.
                                                  Table must be aligned to its size. */
 /* -------------- */
-}; 
+};
 
 /* Multicast Support Parameters   #### michal - match PRM */
 
@@ -584,14 +584,14 @@ struct hermonprm_multicastparam_st {	/* Little Endian */
                                                  The base address must be aligned to the entry size.
                                                  Address may be set to 0xFFFFFFFF if multicast is not supported. */
 /* -------------- */
-    pseudo_bit_t	mc_base_addr_l[0x00020];/* Base Address of the Multicast Table [31:0]. 
+    pseudo_bit_t	mc_base_addr_l[0x00020];/* Base Address of the Multicast Table [31:0].
                                                  The base address must be aligned to the entry size.
                                                  Address may be set to 0xFFFFFFFF if multicast is not supported. */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00040];
 /* -------------- */
     pseudo_bit_t	log_mc_table_entry_sz[0x00005];/* Log2 of the Size of multicast group member (MGM) entry.
-                                                 Must be greater than 5 (to allow CTRL and GID sections). 
+                                                 Must be greater than 5 (to allow CTRL and GID sections).
                                                  That implies the number of QPs per MC table entry. */
     pseudo_bit_t	reserved1[0x0000b];
     pseudo_bit_t	reserved2[0x00010];
@@ -611,7 +611,7 @@ struct hermonprm_multicastparam_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved6[0x00020];
 /* -------------- */
-}; 
+};
 
 /* QPC/EEC/CQC/EQC/RDB Parameters   #### michal - doesn't match PRM (field name are differs. see below) */
 
@@ -679,12 +679,12 @@ struct hermonprm_qpcbaseaddr_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	log_num_rd[0x00003];   /* Log (base 2) of the maximum number of RdmaRdC entries per QP. This denotes the maximum number of outstanding reads/atomics as a responder. */
     pseudo_bit_t	reserved7[0x00002];
-    pseudo_bit_t	rdmardc_base_addr_l[0x0001b];/* rdmardc_base_addr_l: Base address of table that holds remote read and remote atomic requests [31:0]. 
+    pseudo_bit_t	rdmardc_base_addr_l[0x0001b];/* rdmardc_base_addr_l: Base address of table that holds remote read and remote atomic requests [31:0].
                                                  Table must be aligned to RDB entry size (32 bytes). */
 /* -------------- */
     pseudo_bit_t	reserved8[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Header_Log_Register */
 
@@ -693,7 +693,7 @@ struct hermonprm_header_log_register_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Performance Monitors */
 
@@ -725,7 +725,7 @@ struct hermonprm_performance_monitors_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	event_counter2[0x00020];/* Read/write event counter, counting events specified by EvCntl and EvCnt2 fields repsectively. When the event counter reaches is maximum value of 0xFFFFFF, the next event will cause it to roll over to zero, set F1 or F2 bit respectively and generate interrupt by I1 I2 bit respectively. */
 /* -------------- */
-}; 
+};
 
 /* MLX WQE segment format */
 
@@ -751,7 +751,7 @@ struct hermonprm_wqe_segment_ctrl_mlx_st {	/* Little Endian */
     pseudo_bit_t	reserved5[0x00010];
     pseudo_bit_t	rlid[0x00010];         /* Destination LID (must match given headers) */
 /* -------------- */
-}; 
+};
 
 /* Send WQE segment format */
 
@@ -780,7 +780,7 @@ struct hermonprm_send_wqe_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00200];
 /* -------------- */
-}; 
+};
 
 /* QP and EE Context Entry */
 
@@ -833,7 +833,7 @@ struct hermonprm_queue_pair_ee_context_entry_st {	/* Little Endian */
                                                  0x3 - 1024
                                                  0x4 - 2048
                                                  other - reserved
-                                                 
+
                                                  Should be configured to 0x4 for UD and MLX QPs. */
 /* -------------- */
     pseudo_bit_t	usr_page[0x00018];     /* UAR number to ring doorbells for this QP (aliased to doorbell and Blue Flame pages) */
@@ -883,7 +883,7 @@ struct hermonprm_queue_pair_ee_context_entry_st {	/* Little Endian */
     pseudo_bit_t	reserved24[0x00008];
 /* -------------- */
     pseudo_bit_t	reserved25[0x00004];
-    pseudo_bit_t	ric[0x00001];          /* Invalid Credits. 
+    pseudo_bit_t	ric[0x00001];          /* Invalid Credits.
                                                  1 - place "Invalid Credits" to ACKs sent from this queue.
                                                  0 - ACKs report the actual number of end to end credits on the connection.
                                                  Not valid (reserved) in EE context.
@@ -895,12 +895,12 @@ struct hermonprm_queue_pair_ee_context_entry_st {	/* Little Endian */
     pseudo_bit_t	rwe[0x00001];          /* If set - RDMA - write enabled on receive queue. Not valid (reserved) in EE context. */
     pseudo_bit_t	rre[0x00001];          /* If set - RDMA - read enabled on receive queue. Not valid (reserved) in EE context. */
     pseudo_bit_t	reserved28[0x00005];
-    pseudo_bit_t	rra_max[0x00003];      /* Maximum number of outstanding RDMA-read/Atomic operations allowed on receive queue is 2^RRA_Max. 
+    pseudo_bit_t	rra_max[0x00003];      /* Maximum number of outstanding RDMA-read/Atomic operations allowed on receive queue is 2^RRA_Max.
                                                  Must be 0 for EE context. */
     pseudo_bit_t	physical_function[0x00008];
 /* -------------- */
     pseudo_bit_t	next_rcv_psn[0x00018]; /* Next (expected) PSN on receive */
-    pseudo_bit_t	min_rnr_nak[0x00005];  /* Minimum RNR NAK timer value (TTTTT field encoding according to the IB spec Vol1 9.7.5.2.8). 
+    pseudo_bit_t	min_rnr_nak[0x00005];  /* Minimum RNR NAK timer value (TTTTT field encoding according to the IB spec Vol1 9.7.5.2.8).
                                                  Not valid (reserved) in EE context. */
     pseudo_bit_t	reserved30[0x00003];
 /* -------------- */
@@ -919,7 +919,7 @@ struct hermonprm_queue_pair_ee_context_entry_st {	/* Little Endian */
                                                  On send datagrams, if Q_Key[31] specified in the WQE is set, then this Q_Key will be transmitted in the outgoing message.
                                                  Not valid (reserved) in EE context. */
 /* -------------- */
-    pseudo_bit_t	srqn[0x00018];         /* SRQN - Shared Receive Queue Number - specifies the SRQ number from which the QP dequeues receive descriptors. 
+    pseudo_bit_t	srqn[0x00018];         /* SRQN - Shared Receive Queue Number - specifies the SRQ number from which the QP dequeues receive descriptors.
                                                  SRQN is valid only if SRQ bit is set. Not valid (reserved) in EE context. */
     pseudo_bit_t	srq[0x00001];          /* SRQ - Shared Receive Queue. If this bit is set, then the QP is associated with a SRQ. Not valid (reserved) in EE context. */
     pseudo_bit_t	reserved34[0x00007];
@@ -983,7 +983,7 @@ struct hermonprm_queue_pair_ee_context_entry_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved48[0x000c0];
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -993,21 +993,21 @@ struct hermonprm_mcg_qp_dw_st {	/* Little Endian */
     pseudo_bit_t	blck_lb[0x00001];
     pseudo_bit_t	reserved1[0x00001];
 /* -------------- */
-}; 
+};
 
 /* Clear Interrupt [63:0]              #### michal - match to PRM */
 
 struct hermonprm_clr_int_st {	/* Little Endian */
     pseudo_bit_t	clr_int_h[0x00020];    /* Clear Interrupt [63:32]
-                                                 Write transactions to this register will clear (de-assert) the virtual interrupt output pins of InfiniHost-III-EX. The value to be written in this register is obtained by executing QUERY_ADAPTER command on command interface after system boot. 
+                                                 Write transactions to this register will clear (de-assert) the virtual interrupt output pins of InfiniHost-III-EX. The value to be written in this register is obtained by executing QUERY_ADAPTER command on command interface after system boot.
                                                  This register is write-only. Reading from this register will cause undefined result
                                                   */
 /* -------------- */
     pseudo_bit_t	clr_int_l[0x00020];    /* Clear Interrupt [31:0]
-                                                 Write transactions to this register will clear (de-assert) the virtual interrupt output pins of InfiniHost-III-EX. The value to be written in this register is obtained by executing QUERY_ADAPTER command on command interface after system boot. 
+                                                 Write transactions to this register will clear (de-assert) the virtual interrupt output pins of InfiniHost-III-EX. The value to be written in this register is obtained by executing QUERY_ADAPTER command on command interface after system boot.
                                                  This register is write-only. Reading from this register will cause undefined result */
 /* -------------- */
-}; 
+};
 
 /* EQ Set CI DBs Table */
 
@@ -1268,7 +1268,7 @@ struct hermonprm_eq_set_ci_table_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved63[0x00020];
 /* -------------- */
-}; 
+};
 
 /* InfiniHost-III-EX Configuration Registers     #### michal - match to PRM */
 
@@ -1279,7 +1279,7 @@ struct hermonprm_configuration_registers_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x3fcb20];
 /* -------------- */
-}; 
+};
 
 /* QP_DB_Record         ### michal = gdror fixed */
 
@@ -1287,7 +1287,7 @@ struct hermonprm_qp_db_record_st {	/* Little Endian */
     pseudo_bit_t	receive_wqe_counter[0x00010];/* Modulo-64K counter of WQEs posted to the QP since its creation. Should be initialized to zero. */
     pseudo_bit_t	reserved0[0x00010];
 /* -------------- */
-}; 
+};
 
 /* CQ_ARM_DB_Record */
 
@@ -1303,7 +1303,7 @@ struct hermonprm_cq_arm_db_record_st {	/* Little Endian */
     pseudo_bit_t	res[0x00003];          /* Must be 0x2 */
     pseudo_bit_t	cq_number[0x00018];    /* CQ number */
 /* -------------- */
-}; 
+};
 
 /* CQ_CI_DB_Record */
 
@@ -1314,7 +1314,7 @@ struct hermonprm_cq_ci_db_record_st {	/* Little Endian */
     pseudo_bit_t	res[0x00003];          /* Must be 0x1 */
     pseudo_bit_t	cq_number[0x00018];    /* CQ number */
 /* -------------- */
-}; 
+};
 
 /* Virtual_Physical_Mapping */
 
@@ -1330,7 +1330,7 @@ struct hermonprm_virtual_physical_mapping_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00006];
     pseudo_bit_t	pa_l[0x00014];         /* Physical Address[31:12] */
 /* -------------- */
-}; 
+};
 
 /* MOD_STAT_CFG            #### michal - gdror fix */
 
@@ -1518,7 +1518,7 @@ struct hermonprm_srq_context_st {	/* Little Endian */
     pseudo_bit_t	reserved10[0x00002];
     pseudo_bit_t	db_record_addr_l[0x0001e];/* SRQ DB Record physical address [31:2] */
 /* -------------- */
-}; 
+};
 
 /* PBL */
 
@@ -1539,7 +1539,7 @@ struct hermonprm_pbl_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	mtt_3_l[0x00020];      /* Fourth MTT[31:0] */
 /* -------------- */
-}; 
+};
 
 /* Performance Counters   #### michal - gdror fixed */
 
@@ -1554,7 +1554,7 @@ struct hermonprm_performance_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00620];
 /* -------------- */
-}; 
+};
 
 /* Transport and CI Error Counters */
 
@@ -1575,10 +1575,10 @@ struct hermonprm_transport_and_ci_error_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	sq_num_lpe[0x00020];   /* Requester - number of local protection errors */
 /* -------------- */
-    pseudo_bit_t	rq_num_wrfe[0x00020];  /* Responder - number of CQEs with error. 
+    pseudo_bit_t	rq_num_wrfe[0x00020];  /* Responder - number of CQEs with error.
                                                  Incremented each time a CQE with error is generated */
 /* -------------- */
-    pseudo_bit_t	sq_num_wrfe[0x00020];  /* Requester - number of CQEs with error. 
+    pseudo_bit_t	sq_num_wrfe[0x00020];  /* Requester - number of CQEs with error.
                                                  Incremented each time a CQE with error is generated */
 /* -------------- */
     pseudo_bit_t	reserved0[0x00020];
@@ -1698,7 +1698,7 @@ struct hermonprm_transport_and_ci_error_counters_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved12[0x002a0];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - HCR Completion Event   #### michal - match PRM */
 
@@ -1717,7 +1717,7 @@ struct hermonprm_hcr_completion_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Completion with Error CQE             #### michal - gdror fixed */
 
@@ -1732,7 +1732,7 @@ struct hermonprm_completion_with_error_st {	/* Little Endian */
                                                          0x02 - Local QP Operation Error
                                                          0x03 - Local EE Context Operation Error
                                                          0x04 - Local Protection Error
-                                                         0x05 - Work Request Flushed Error 
+                                                         0x05 - Work Request Flushed Error
                                                          0x06 - Memory Window Bind Error
                                                          0x10 - Bad Response Error
                                                          0x11 - Local Access Error
@@ -1752,7 +1752,7 @@ struct hermonprm_completion_with_error_st {	/* Little Endian */
     pseudo_bit_t	wqe_counter[0x00010];
 /* -------------- */
     pseudo_bit_t	opcode[0x00005];       /* The opcode of WQE completion is reported for.
-                                                 
+
                                                  The following values are reported in case of completion with error:
                                                  0xFE - For completion with error on Receive Queues
                                                  0xFF - For completion with error on Send Queues */
@@ -1761,7 +1761,7 @@ struct hermonprm_completion_with_error_st {	/* Little Endian */
     pseudo_bit_t	owner[0x00001];        /* HW Flips this bit for every CQ warp around. Initialized to Zero. */
     pseudo_bit_t	reserved3[0x00018];
 /* -------------- */
-}; 
+};
 
 /* Resize CQ Input Mailbox */
 
@@ -1790,7 +1790,7 @@ struct hermonprm_resize_cq_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved10[0x00100];
 /* -------------- */
-}; 
+};
 
 /* MAD_IFC Input Modifier */
 
@@ -1802,14 +1802,14 @@ struct hermonprm_mad_ifc_input_modifier_st {	/* Little Endian */
     pseudo_bit_t	rlid[0x00010];         /* Remote (source) LID  from the received MAD.
                                                  This field is required for trap generation upon MKey/BKey validation. */
 /* -------------- */
-}; 
+};
 
 /* MAD_IFC Input Mailbox     ###michal -gdror fixed */
 
 struct hermonprm_mad_ifc_st {	/* Little Endian */
     pseudo_bit_t	request_mad_packet[64][0x00020];/* Request MAD Packet (256bytes) */
 /* -------------- */
-    pseudo_bit_t	my_qpn[0x00018];       /* Destination QP number from the received MAD. 
+    pseudo_bit_t	my_qpn[0x00018];       /* Destination QP number from the received MAD.
                                                  This field is reserved if Mad_extended_info indication in the input modifier is clear. */
     pseudo_bit_t	reserved0[0x00008];
 /* -------------- */
@@ -1822,25 +1822,25 @@ struct hermonprm_mad_ifc_st {	/* Little Endian */
     pseudo_bit_t	reserved3[0x00010];
     pseudo_bit_t	ml_path[0x00007];      /* My (destination) LID path bits  from the received MAD.
                                                  This field is reserved if Mad_extended_info indication in the input modifier is clear. */
-    pseudo_bit_t	g[0x00001];            /* If set, the GRH field in valid. 
+    pseudo_bit_t	g[0x00001];            /* If set, the GRH field in valid.
                                                  This field is reserved if Mad_extended_info indication in the input modifier is clear. */
     pseudo_bit_t	reserved4[0x00004];
     pseudo_bit_t	sl[0x00004];           /* Service Level of the received MAD.
                                                  This field is reserved if Mad_extended_info indication in the input modifier is clear. */
 /* -------------- */
-    pseudo_bit_t	pkey_indx[0x00010];    /* Index in PKey table that matches PKey of the received MAD. 
+    pseudo_bit_t	pkey_indx[0x00010];    /* Index in PKey table that matches PKey of the received MAD.
                                                  This field is reserved if Mad_extended_info indication in the input modifier is clear. */
     pseudo_bit_t	reserved5[0x00010];
 /* -------------- */
     pseudo_bit_t	reserved6[0x00160];
 /* -------------- */
-    pseudo_bit_t	grh[10][0x00020];      /* The GRH field of the MAD packet that was scattered to the first 40 bytes pointed to by the scatter list. 
-                                                 Valid if Mad_extended_info bit (in the input modifier) and g bit are set. 
+    pseudo_bit_t	grh[10][0x00020];      /* The GRH field of the MAD packet that was scattered to the first 40 bytes pointed to by the scatter list.
+                                                 Valid if Mad_extended_info bit (in the input modifier) and g bit are set.
                                                  Otherwise this field is reserved. */
 /* -------------- */
     pseudo_bit_t	reserved7[0x004c0];
 /* -------------- */
-}; 
+};
 
 /* Query Debug Message     #### michal - gdror fixed */
 
@@ -1899,7 +1899,7 @@ struct hermonprm_query_debug_msg_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x003c0];
 /* -------------- */
-}; 
+};
 
 /* User Access Region */
 
@@ -1914,7 +1914,7 @@ struct hermonprm_uar_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x03ec0];
 /* -------------- */
-}; 
+};
 
 /* Receive doorbell */
 
@@ -1928,7 +1928,7 @@ struct hermonprm_receive_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved3[0x00002];
     pseudo_bit_t	qpn[0x00018];          /* QP number or SRQ number this doorbell is rung on */
 /* -------------- */
-}; 
+};
 
 /* SET_IB Parameters */
 
@@ -1949,7 +1949,7 @@ struct hermonprm_set_ib_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00180];
 /* -------------- */
-}; 
+};
 
 /* Multicast Group Member    #### michal - gdror fixed */
 
@@ -1989,7 +1989,7 @@ struct hermonprm_mgm_entry_st {	/* Little Endian */
 /* -------------- */
     struct hermonprm_mgmqp_st	mgmqp_7;   /* Multicast Group Member QP */
 /* -------------- */
-}; 
+};
 
 /* INIT_PORT Parameters    #### michal - match PRM */
 
@@ -2041,7 +2041,7 @@ struct hermonprm_init_port_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved5[0x006c0];
 /* -------------- */
-}; 
+};
 
 /* Query Device Capablities     #### michal - gdror fixed */
 
@@ -2267,7 +2267,7 @@ struct hermonprm_query_dev_cap_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved46[0x002c0];
 /* -------------- */
-}; 
+};
 
 /* QUERY_ADAPTER Parameters Block    #### michal - gdror fixed */
 
@@ -2281,7 +2281,7 @@ struct hermonprm_query_adapter_st {	/* Little Endian */
 /* -------------- */
     struct hermonprm_vsd_st	vsd;         /* ###michal- this field was replaced by 2 fields : vsd .1664; vsd(continued/psid .128; */
 /* -------------- */
-}; 
+};
 
 /* QUERY_FW Parameters Block      #### michal - doesn't match PRM */
 
@@ -2298,7 +2298,7 @@ struct hermonprm_query_fw_st {	/* Little Endian */
     pseudo_bit_t	log_max_outstanding_cmd[0x00008];/* Log2 of the maximum number of commands the HCR can support simultaneously */
     pseudo_bit_t	reserved1[0x00017];
     pseudo_bit_t	dt[0x00001];           /* Debug Trace Support
-                                                 0 - Debug trace is not supported 
+                                                 0 - Debug trace is not supported
                                                  1 - Debug trace is supported */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00001];
@@ -2346,7 +2346,7 @@ struct hermonprm_query_fw_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved8[0x00600];
 /* -------------- */
-}; 
+};
 
 /* Memory Access Parameters for UD Address Vector Table */
 
@@ -2358,7 +2358,7 @@ struct hermonprm_udavtable_memory_parameters_st {	/* Little Endian */
     pseudo_bit_t	xlation_en[0x00001];   /* When cleared, address is physical address and no translation will be done. When set, address is virtual. */
     pseudo_bit_t	reserved1[0x00002];
 /* -------------- */
-}; 
+};
 
 /* INIT_HCA & QUERY_HCA Parameters Block ####michal-doesn't match PRM (see differs below) new size in bytes:0x300 */
 
@@ -2407,7 +2407,7 @@ struct hermonprm_init_hca_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved10[0x00600];
 /* -------------- */
-}; 
+};
 
 /* Event Queue Context Table Entry     #### michal - gdror fixed */
 
@@ -2454,19 +2454,19 @@ struct hermonprm_eqc_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved12[0x00040];
 /* -------------- */
-    pseudo_bit_t	consumer_counter[0x00018];/* Consumer counter. The counter is incremented for each EQE polled from the EQ. 
-                                                  Must be 0x0 in EQ initialization. 
+    pseudo_bit_t	consumer_counter[0x00018];/* Consumer counter. The counter is incremented for each EQE polled from the EQ.
+                                                  Must be 0x0 in EQ initialization.
                                                   Maintained by HW (valid for the QUERY_EQ command only). */
     pseudo_bit_t	reserved13[0x00008];
 /* -------------- */
-    pseudo_bit_t	producer_counter[0x00018];/* Producer Coutner. The counter is incremented for each EQE that is written by the HW to the EQ. 
+    pseudo_bit_t	producer_counter[0x00018];/* Producer Coutner. The counter is incremented for each EQE that is written by the HW to the EQ.
                                                   EQ overrun is reported if Producer_counter + 1 equals to Consumer_counter and a EQE needs to be added.
                                                   Maintained by HW (valid for the QUERY_EQ command only) */
     pseudo_bit_t	reserved14[0x00008];
 /* -------------- */
     pseudo_bit_t	reserved15[0x00080];
 /* -------------- */
-}; 
+};
 
 /* Memory Translation Table (MTT) Entry     #### michal - match to PRM */
 
@@ -2477,7 +2477,7 @@ struct hermonprm_mtt_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00002];
     pseudo_bit_t	ptag_l[0x0001d];       /* Low-order bits of Physical tag. The size of the field depends on the page size of the region. Maximum PTAG size is 52 bits. */
 /* -------------- */
-}; 
+};
 
 /* Memory Protection Table (MPT) Entry   ### doesn't match PRM (new fields were added). new size in bytes : 0x54 */
 
@@ -2547,7 +2547,7 @@ struct hermonprm_mpt_st {	/* Little Endian */
     pseudo_bit_t	mtt_fbo[0x00015];      /* First byte offset in the zero-based region - the first byte within the first block/page start address refers to. When mtt_rep is being used, fbo points within the replicated block (i.e. block-size x 2^mtt_rep) */
     pseudo_bit_t	reserved10[0x0000b];
 /* -------------- */
-}; 
+};
 
 /* Completion Queue Context Table Entry	#### michal - match PRM */
 
@@ -2559,7 +2559,7 @@ struct hermonprm_completion_queue_context_st {	/* Little Endian */
                                                  0x6 - ARMED SOLICITED (Request Solicited Notification)
                                                  0xA - FIRED
                                                  other - reserved
-                                                 
+
                                                  Must be 0x0 in CQ initialization.
                                                  Valid for the QUERY_CQ and HW2SW_CQ commands only. */
     pseudo_bit_t	reserved1[0x00005];
@@ -2605,7 +2605,7 @@ struct hermonprm_completion_queue_context_st {	/* Little Endian */
     pseudo_bit_t	reserved11[0x00008];
 /* -------------- */
     pseudo_bit_t	solicit_producer_indx[0x00018];/* Maintained by HW.
-                                                 Valid for QUERY_CQ and HW2SW_CQ commands only. 
+                                                 Valid for QUERY_CQ and HW2SW_CQ commands only.
                                                   */
     pseudo_bit_t	reserved12[0x00008];
 /* -------------- */
@@ -2627,7 +2627,7 @@ struct hermonprm_completion_queue_context_st {	/* Little Endian */
     pseudo_bit_t	reserved17[0x00003];
     pseudo_bit_t	db_record_addr_l[0x0001d];/* CQ DB Record physical address [31:3] */
 /* -------------- */
-}; 
+};
 
 /* GPIO_event_data   #### michal - gdror fixed */
 
@@ -2640,7 +2640,7 @@ struct hermonprm_gpio_event_data_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00020];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - QP/EE Events     #### michal - doesn't match PRM */
 
@@ -2657,7 +2657,7 @@ struct hermonprm_qp_ee_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved4[0x00060];
 /* -------------- */
-}; 
+};
 
 /* InfiniHost-III-EX Type0 Configuration Header   ####michal - doesn't match PRM (new fields added, see below) */
 
@@ -2803,19 +2803,19 @@ struct hermonprm_mt25208_type0_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	uncorrectable_error_status_register[0x00020];/* 0 Training Error Status
                                                  4 Data Link Protocol Error Status
-                                                 12 Poisoned TLP Status 
-                                                 13 Flow Control Protocol Error Status 
-                                                 14 Completion Timeout Status 
-                                                 15 Completer Abort Status 
-                                                 16 Unexpected Completion Status 
-                                                 17 Receiver Overflow Status 
-                                                 18 Malformed TLP Status 
-                                                 19 ECRC Error Status 
+                                                 12 Poisoned TLP Status
+                                                 13 Flow Control Protocol Error Status
+                                                 14 Completion Timeout Status
+                                                 15 Completer Abort Status
+                                                 16 Unexpected Completion Status
+                                                 17 Receiver Overflow Status
+                                                 18 Malformed TLP Status
+                                                 19 ECRC Error Status
                                                  20 Unsupported Request Error Status */
 /* -------------- */
     pseudo_bit_t	uncorrectable_error_mask_register[0x00020];/* 0 Training Error Mask
                                                  4 Data Link Protocol Error Mask
-                                                 12 Poisoned TLP Mask 
+                                                 12 Poisoned TLP Mask
                                                  13 Flow Control Protocol Error Mask
                                                  14 Completion Timeout Mask
                                                  15 Completer Abort Mask
@@ -2855,7 +2855,7 @@ struct hermonprm_mt25208_type0_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved13[0x006a0];
 /* -------------- */
-}; 
+};
 
 /* Event Data Field - Performance Monitor */
 
@@ -2873,7 +2873,7 @@ struct hermonprm_performance_monitor_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00040];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Page Faults */
 
@@ -2897,7 +2897,7 @@ struct hermonprm_page_fault_event_data_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	prefetch_len[0x00020]; /* Indicates how many subsequent pages in the same memory region/window will be accessed by the following transaction after this page fault is resolved. measured in bytes. SW can use this information in order to page-in the subsequent pages if they are not present. */
 /* -------------- */
-}; 
+};
 
 /* WQE segments format */
 
@@ -2914,7 +2914,7 @@ struct hermonprm_wqe_segment_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00080];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Port State Change   #### michal - match PRM */
 
@@ -2927,7 +2927,7 @@ struct hermonprm_port_state_change_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Completion Queue Error     #### michal - match PRM */
 
@@ -2944,7 +2944,7 @@ struct hermonprm_completion_queue_error_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved3[0x00060];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - Completion Event	#### michal - match PRM */
 
@@ -2954,12 +2954,12 @@ struct hermonprm_completion_event_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x000a0];
 /* -------------- */
-}; 
+};
 
 /* Event Queue Entry         #### michal - match to PRM */
 
 struct hermonprm_event_queue_entry_st {	/* Little Endian */
-    pseudo_bit_t	event_sub_type[0x00008];/* Event Sub Type. 
+    pseudo_bit_t	event_sub_type[0x00008];/* Event Sub Type.
                                                  Defined for events which have sub types, zero elsewhere. */
     pseudo_bit_t	reserved0[0x00008];
     pseudo_bit_t	event_type[0x00008];   /* Event Type */
@@ -2968,12 +2968,12 @@ struct hermonprm_event_queue_entry_st {	/* Little Endian */
     pseudo_bit_t	event_data[6][0x00020];/* Delivers auxilary data to handle event. */
 /* -------------- */
     pseudo_bit_t	reserved2[0x00007];
-    pseudo_bit_t	owner[0x00001];        /* Owner of the entry 
-                                                 0 SW 
+    pseudo_bit_t	owner[0x00001];        /* Owner of the entry
+                                                 0 SW
                                                  1 HW */
     pseudo_bit_t	reserved3[0x00018];
 /* -------------- */
-}; 
+};
 
 /* QP/EE State Transitions Command Parameters  ###michal - doesn't match PRM (field name changed) */
 
@@ -2986,7 +2986,7 @@ struct hermonprm_qp_ee_state_transitions_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved1[0x00800];
 /* -------------- */
-}; 
+};
 
 /* Completion Queue Entry Format        #### michal - fixed by gdror */
 
@@ -3010,7 +3010,7 @@ struct hermonprm_completion_queue_entry_st {	/* Little Endian */
                                                  For IPoIB (UD) and RawEth CQEs this field contains the RSS hash function value.
                                                  Otherwise, this field is reserved. */
 /* -------------- */
-    pseudo_bit_t	srq_rqpn[0x00018];     /* For Responder UD QPs, Remote (source) QP number. 
+    pseudo_bit_t	srq_rqpn[0x00018];     /* For Responder UD QPs, Remote (source) QP number.
                                                  For Responder SRC QPs, SRQ number.
                                                  Otherwise, this field is reserved. */
     pseudo_bit_t	ml_path_mac_index[0x00007];/* For responder UD over IB CQE: These are the lower LMC bits of the DLID in an incoming UD packet, higher bits of this field, that are not part of the LMC bits are zeroed by HW. Invalid if incoming message DLID is the permissive LID or incoming message is multicast.
@@ -3028,17 +3028,17 @@ struct hermonprm_completion_queue_entry_st {	/* Little Endian */
                                                   For responder UD over Ethernet and RawEth - it is VLAN-header[15:12]
                                                   Otherwise, this field is reserved. */
 /* -------------- */
-    pseudo_bit_t	smac31_0_rawether_ipoib_status[0x00020];/* For responder UD over Ethernet - source MAC[31:0] of the packet. 
-                                                  For responder RawEth and UD over IB - RawEth-IPoIB status {3 reserved, ipok,udp,tcp,ipv4opt,ipv6,ipv4vf,ipv4,rht(6),ipv6extmask(6),reserved(2),l2am,reserved(2),bfcs,reserved(2),enc} 
+    pseudo_bit_t	smac31_0_rawether_ipoib_status[0x00020];/* For responder UD over Ethernet - source MAC[31:0] of the packet.
+                                                  For responder RawEth and UD over IB - RawEth-IPoIB status {3 reserved, ipok,udp,tcp,ipv4opt,ipv6,ipv4vf,ipv4,rht(6),ipv6extmask(6),reserved(2),l2am,reserved(2),bfcs,reserved(2),enc}
                                                   Otherwise, this field is reserved. */
 /* -------------- */
-    pseudo_bit_t	byte_cnt[0x00020];     /* Byte count of data transferred. Applicable for RDMA-read, Atomic and all receive operations. completions. 
+    pseudo_bit_t	byte_cnt[0x00020];     /* Byte count of data transferred. Applicable for RDMA-read, Atomic and all receive operations. completions.
                                                  For Receive Queue that is subject for headers. separation, byte_cnt[31:24] specify number of bytes scattered to the first scatter entry (headers. length). Byte_cnt[23:0] specify total byte count received (including headers). */
 /* -------------- */
     pseudo_bit_t	checksum[0x00010];     /* Valid for RawEth and IPoIB only. */
     pseudo_bit_t	wqe_counter[0x00010];
 /* -------------- */
-    pseudo_bit_t	opcode[0x00005];       /* Send completions - same encoding as WQE. 
+    pseudo_bit_t	opcode[0x00005];       /* Send completions - same encoding as WQE.
                                                   Error coding is 0x1F
                                                   Receive:
                                                   0x0 - RDMA-Write with Immediate
@@ -3052,14 +3052,14 @@ struct hermonprm_completion_queue_entry_st {	/* Little Endian */
     pseudo_bit_t	reserved1[0x00010];
     pseudo_bit_t	reserved2[0x00008];
 /* -------------- */
-}; 
+};
 
 /*  */
 
 struct hermonprm_mcg_qps_st {	/* Little Endian */
     struct hermonprm_mcg_qp_dw_st	dw[128];
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -3084,7 +3084,7 @@ struct hermonprm_mcg_hdr_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	gid0[0x00020];
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -3096,7 +3096,7 @@ struct hermonprm_sched_queue_context_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00006];
     pseudo_bit_t	weight[0x00010];       /* Weight of this SchQ */
 /* -------------- */
-}; 
+};
 
 /*  */
 
@@ -3117,7 +3117,7 @@ struct hermonprm_ecc_detect_event_data_st {	/* Little Endian */
     pseudo_bit_t	err_ra[0x00010];
     pseudo_bit_t	err_ca[0x00010];
 /* -------------- */
-}; 
+};
 
 /* Event_data Field - ECC Detection Event */
 
@@ -3142,14 +3142,14 @@ struct hermonprm_scrubbing_event_st {	/* Little Endian */
     pseudo_bit_t	err_ra[0x00010];       /* Error row address */
     pseudo_bit_t	err_ca[0x00010];       /* Error column address */
 /* -------------- */
-}; 
+};
 
 /*  */
 
 struct hermonprm_eq_cmd_doorbell_st {	/* Little Endian */
     pseudo_bit_t	reserved0[0x00020];
 /* -------------- */
-}; 
+};
 
 /* 0 */
 
@@ -3400,5 +3400,5 @@ struct hermonprm_hermon_prm_st {	/* Little Endian */
 /* -------------- */
     pseudo_bit_t	reserved64[0xffcfc0];
 /* -------------- */
-}; 
+};
 #endif /* H_prefix_hermonprm_bits_fixnames_MT25408_PRM_csp_H */

--- a/src/drivers/infiniband/hermon.c
+++ b/src/drivers/infiniband/hermon.c
@@ -214,8 +214,8 @@ static int hermon_cmd ( struct hermon *hermon, unsigned long command,
 		     opcode_modifier, op_mod,
 		     go, 1,
 		     t, hermon->toggle );
-	DBGC ( hermon, "Hermon %p issuing command %04x\n",
-	       hermon, opcode );
+	DBGC2 ( hermon, "Hermon %p issuing command %04x\n",
+		hermon, opcode );
 	DBGC2_HDA ( hermon, virt_to_phys ( hermon->config + HERMON_HCR_BASE ),
 		    &hcr, sizeof ( hcr ) );
 	if ( in_len && ( command & HERMON_HCR_IN_MBOX ) ) {

--- a/src/drivers/infiniband/hermon.c
+++ b/src/drivers/infiniband/hermon.c
@@ -3994,15 +3994,22 @@ static void hermon_bofm_remove ( struct pci_device *pci ) {
 }
 
 static struct pci_device_id hermon_nics[] = {
+	/* Mellanox ConnectX VPI (ethernet + infiniband) */
 	PCI_ROM ( 0x15b3, 0x6340, "mt25408", "MT25408 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x634a, "mt25418", "MT25418 HCA driver", 0 ),
+
+	/* Mellanox ConnectX EN (ethernet only) */
+	PCI_ROM ( 0x15b3, 0x6368, "mt25448", "MT25448 HCA driver", 0 ),
+	PCI_ROM ( 0x15b3, 0x6372, "mt25458", "MT25458 HCA driver", 0 ),
+
+	/* Mellanox ConnectX-2 VPI (ethernet + infiniband) */
 	PCI_ROM ( 0x15b3, 0x6732, "mt26418", "MT26418 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x673c, "mt26428", "MT26428 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x6746, "mt26438", "MT26438 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x6778, "mt26488", "MT26488 HCA driver", 0 ),
-	PCI_ROM ( 0x15b3, 0x6368, "mt25448", "MT25448 HCA driver", 0 ),
+
+	/* Mellanox ConnectX-2 EN (ethernet only) */
 	PCI_ROM ( 0x15b3, 0x6750, "mt26448", "MT26448 HCA driver", 0 ),
-	PCI_ROM ( 0x15b3, 0x6372, "mt25458", "MT25458 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x675a, "mt26458", "MT26458 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x6764, "mt26468", "MT26468 HCA driver", 0 ),
 	PCI_ROM ( 0x15b3, 0x676e, "mt26478", "MT26478 HCA driver", 0 ),

--- a/src/drivers/infiniband/hermon.h
+++ b/src/drivers/infiniband/hermon.h
@@ -999,7 +999,7 @@ struct hermon {
 
 #define HERMON_HCR_BASE			0x80680
 #define HERMON_HCR_REG(x)		( HERMON_HCR_BASE + 4 * (x) )
-#define HERMON_HCR_MAX_WAIT_MS		2000
+#define HERMON_HCR_MAX_WAIT_MS		10000
 #define HERMON_MBOX_ALIGN		(1 << 12)
 /* MELLANOX-FIXME: HERMON_MBOX_SIZE is 1<<12 in flexboot upstream */
 #define HERMON_MBOX_SIZE		(1 << 10)

--- a/src/drivers/infiniband/hermon.h
+++ b/src/drivers/infiniband/hermon.h
@@ -926,8 +926,9 @@ struct hermon {
 #define HERMON_HCR_BASE			0x80680
 #define HERMON_HCR_REG(x)		( HERMON_HCR_BASE + 4 * (x) )
 #define HERMON_HCR_MAX_WAIT_MS		2000
-#define HERMON_MBOX_ALIGN		4096
-#define HERMON_MBOX_SIZE		1024
+#define HERMON_MBOX_ALIGN		(1 << 12)
+/* MELLANOX-FIXME: HERMON_MBOX_SIZE is 1<<12 in flexboot upstream */
+#define HERMON_MBOX_SIZE		(1 << 10)
 
 /* HCA command is split into
  *

--- a/src/drivers/infiniband/hermon.h
+++ b/src/drivers/infiniband/hermon.h
@@ -34,8 +34,30 @@ FILE_LICENCE ( GPL2_OR_LATER );
 
 /* Device reset */
 #define HERMON_RESET_OFFSET		0x0f0010
-#define HERMON_RESET_MAGIC		0x01000000UL
-#define HERMON_RESET_WAIT_TIME_MS	1000
+
+/*
+  The Mellanox documentation specifies that the value
+
+     "0x00000001 (Big Endian)"
+
+  is the way to reset a Hermon device.  However, this does not seem to
+  work. Curiously, the same value in little endian seems to work perfectly. This
+  has been tested many times on a ConnectX-3 card. Each time, the little-endian
+  version works, and the big-endian version fails most of the time. This is
+  likely because the reset failed, and the card may or may not be in a good
+  state at this point.
+
+  It's also worth noting that the FlexBoot fork uses two different reset values,
+  with ambiguous naming and semantics, neither of which match HERMON_RESET_MAGIC
+  in either little- or big-endian. One of the FlexBoot values (HERMON_RESET_END)
+  has the top and bottom bit set, which suggests there is confusion surrounding
+  the reset procedures, even inside Mellanox.
+
+  Best guess at this point, is that there is an error in the documentation, and
+  the value is supposed to be little-endian.
+*/
+#define HERMON_RESET_MAGIC		0x00000001UL
+#define HERMON_RESET_WAIT_TIME_MS	500
 
 /* Work queue entry and completion queue entry opcodes */
 #define HERMON_OPCODE_NOP		0x00
@@ -1001,8 +1023,7 @@ struct hermon {
 #define HERMON_HCR_REG(x)		( HERMON_HCR_BASE + 4 * (x) )
 #define HERMON_HCR_MAX_WAIT_MS		10000
 #define HERMON_MBOX_ALIGN		(1 << 12)
-/* MELLANOX-FIXME: HERMON_MBOX_SIZE is 1<<12 in flexboot upstream */
-#define HERMON_MBOX_SIZE		(1 << 10)
+#define HERMON_MBOX_SIZE		(1 << 12)
 
 /* HCA command is split into
  *

--- a/src/drivers/infiniband/nodnic_prm.h
+++ b/src/drivers/infiniband/nodnic_prm.h
@@ -38,10 +38,10 @@ struct nodnic_wqe_segment_data_ptr_st {	/* Little Endian */
 
 struct MLX_DECLARE_STRUCT ( nodnic_wqe_segment_data_ptr );
 
-#define HERMON_MAX_SCATTER 1
+#define NODNIC_MAX_SCATTER 1
 
 struct nodnic_recv_wqe {
-	struct nodnic_wqe_segment_data_ptr data[HERMON_MAX_SCATTER];
+	struct nodnic_wqe_segment_data_ptr data[NODNIC_MAX_SCATTER];
 } __attribute__ (( packed ));
 
 #endif /* SRC_DRIVERS_INFINIBAND_MLX_NODNIC_INCLUDE_PRM_NODNIC_PRM_H_ */

--- a/src/include/ipxe/infiniband.h
+++ b/src/include/ipxe/infiniband.h
@@ -445,6 +445,8 @@ struct ib_device {
 	uint8_t sm_sl;
 	/** Partition key */
 	uint16_t pkey;
+	/** Partition key table index */
+	uint16_t pkey_index;
 
 	/** RDMA key
 	 *


### PR DESCRIPTION
Hello good ipxe folks

I've backported the ConnectX-3 support from Flexboot sources, and managed to make it work with upstream ipxe.

It has taken a *lot* of tedious cleanup, refactoring, and organizing to find and extract the relevant changes from flexboot.

However, the current state is still far too invasive, but it *does* work, so consider it a PoC.

Eventually, I would very much like to get this merged into mainline, but I fully realize there is a way to go yet.

After talking to mcb30 on irc, it was suggested to open this for a WIP pre-review.