### PR TITLE
[shell] Make "ifstat" show the link-layer protocol for each netdev.

### DIFF
--- a/src/usr/ifmgmt.c
+++ b/src/usr/ifmgmt.c
@@ -108,10 +108,11 @@ static void ifstat_errors ( struct net_device_stats *stats,
  * @v netdev		Network device
  */
 void ifstat ( struct net_device *netdev ) {
-	printf ( "%s: %s using %s on %s (%s)\n"
+	printf ( "%s: %s using %s on %s (%s) [%s]\n"
 		 "  [Link:%s%s, TX:%d TXE:%d RX:%d RXE:%d]\n",
 		 netdev->name, netdev_addr ( netdev ),
 		 netdev->dev->driver_name, netdev->dev->name,
+		 netdev->ll_protocol->name,
 		 ( netdev_is_open ( netdev ) ? "open" : "closed" ),
 		 ( netdev_link_ok ( netdev ) ? "up" : "down" ),
 		 ( netdev_link_blocked ( netdev ) ? " (blocked)" : "" ),


### PR DESCRIPTION
This is useful on devices that perform auto-detection for ports. Example output:

    iPXE> ifstat
    net0: 00:11:22:33:44:55 using mt4099 on 0000:00:03.0 (Ethernet) [open]
      [Link:down, TX:0 TXE:0 RX:0 RXE:0]
      [Link status: Unknown (http://ipxe.org/1a086101)]
    net1: 00:11:22:33:44:56 using mt4099 on 0000:00:03.0 (IPoIB) [open]
      [Link:down, TX:0 TXE:0 RX:0 RXE:0]
      [Link status: Initialising (http://ipxe.org/1a136101)]

Signed-off-by: Christian Iversen <ci@iversenit.dk>