### PR TITLE
[infiniband] Require drivers to report the number of device ports

### DIFF
--- a/src/drivers/infiniband/arbel.c
+++ b/src/drivers/infiniband/arbel.c
@@ -3061,6 +3061,7 @@ static int arbel_probe ( struct pci_device *pci ) {
 		ibdev->op = &arbel_ib_operations;
 		ibdev->dev = &pci->dev;
 		ibdev->port = ( ARBEL_PORT_BASE + i );
+		ibdev->ports = ARBEL_NUM_PORTS;
 		ib_set_drvdata ( ibdev, arbel );
 	}
 

--- a/src/drivers/infiniband/flexboot_nodnic.c
+++ b/src/drivers/infiniband/flexboot_nodnic.c
@@ -1165,6 +1165,7 @@ flexboot_nodnic_allocate_infiniband_devices( struct flexboot_nodnic *flexboot_no
 		ibdev->op = &flexboot_nodnic_ib_operations;
 		ibdev->dev = &pci->dev;
 		ibdev->port = ( FLEXBOOT_NODNIC_PORT_BASE + i);
+		ibdev->ports = device_priv->device_cap.num_ports;
 		ib_set_drvdata(ibdev, flexboot_nodnic_priv);
 	}
 	return status;

--- a/src/drivers/infiniband/golan.c
+++ b/src/drivers/infiniband/golan.c
@@ -2386,6 +2386,7 @@ static int golan_probe_normal ( struct pci_device *pci ) {
 		ibdev->op = &golan_ib_operations;
 		ibdev->dev = &pci->dev;
 		ibdev->port = (GOLAN_PORT_BASE + i);
+		ibdev->ports = golan->caps.num_ports;
 		ib_set_drvdata( ibdev, golan );
 	}
 

--- a/src/drivers/infiniband/hermon.c
+++ b/src/drivers/infiniband/hermon.c
@@ -3829,6 +3829,7 @@ static int hermon_probe ( struct pci_device *pci ) {
 		ibdev->op = &hermon_ib_operations;
 		ibdev->dev = &pci->dev;
 		ibdev->port = ( HERMON_PORT_BASE + i );
+		ibdev->ports = hermon->cap.num_ports;
 		ib_set_drvdata ( ibdev, hermon );
 	}
 

--- a/src/drivers/infiniband/linda.c
+++ b/src/drivers/infiniband/linda.c
@@ -2330,6 +2330,7 @@ static int linda_probe ( struct pci_device *pci ) {
 	ibdev->op = &linda_ib_operations;
 	ibdev->dev = &pci->dev;
 	ibdev->port = 1;
+	ibdev->ports = 1;
 
 	/* Fix up PCI device */
 	adjust_pci_device ( pci );

--- a/src/drivers/infiniband/qib7322.c
+++ b/src/drivers/infiniband/qib7322.c
@@ -2348,6 +2348,7 @@ static int qib7322_probe ( struct pci_device *pci ) {
 		ibdev->dev = &pci->dev;
 		ibdev->op = &qib7322_ib_operations;
 		ibdev->port = ( QIB7322_PORT_BASE + i );
+		ibdev->ports = QIB7322_MAX_PORTS;
 		ibdev->link_width_enabled = ibdev->link_width_supported =
 			IB_LINK_WIDTH_4X; /* 1x does not work */
 		ibdev->link_speed_enabled = ibdev->link_speed_supported =

--- a/src/include/ipxe/infiniband.h
+++ b/src/include/ipxe/infiniband.h
@@ -416,6 +416,8 @@ struct ib_device {
 	struct ib_device_operations *op;
 	/** Port number */
 	unsigned int port;
+	/** Total ports on device */
+	unsigned int ports;
 	/** Port open request counter */
 	unsigned int open_count;
 
@@ -538,7 +540,6 @@ extern int ib_mcast_attach ( struct ib_device *ibdev, struct ib_queue_pair *qp,
 			     union ib_gid *gid );
 extern void ib_mcast_detach ( struct ib_device *ibdev,
 			      struct ib_queue_pair *qp, union ib_gid *gid );
-extern int ib_count_ports ( struct ib_device *ibdev );
 extern int ib_set_port_info ( struct ib_device *ibdev, union ib_mad *mad );
 extern int ib_set_pkey_table ( struct ib_device *ibdev, union ib_mad *mad );
 extern struct ib_device * alloc_ibdev ( size_t priv_size );

--- a/src/net/infiniband.c
+++ b/src/net/infiniband.c
@@ -814,26 +814,6 @@ void ib_mcast_detach ( struct ib_device *ibdev, struct ib_queue_pair *qp,
  */
 
 /**
- * Count Infiniband HCA ports
- *
- * @v ibdev		Infiniband device
- * @ret num_ports	Number of ports
- */
-int ib_count_ports ( struct ib_device *ibdev ) {
-	struct ib_device *tmp;
-	int num_ports = 0;
-
-	/* Search for IB devices with the same physical device to
-	 * identify port count.
-	 */
-	for_each_ibdev ( tmp ) {
-		if ( tmp->dev == ibdev->dev )
-			num_ports++;
-	}
-	return num_ports;
-}
-
-/**
  * Set port information
  *
  * @v ibdev		Infiniband device

--- a/src/net/infiniband/ib_sma.c
+++ b/src/net/infiniband/ib_sma.c
@@ -63,7 +63,7 @@ static void ib_sma_node_info ( struct ib_device *ibdev,
 	node_info->base_version = IB_MGMT_BASE_VERSION;
 	node_info->class_version = IB_SMP_CLASS_VERSION;
 	node_info->node_type = IB_NODE_TYPE_HCA;
-	node_info->num_ports = ib_count_ports ( ibdev );
+	node_info->num_ports = ibdev->ports;
 	memcpy ( &node_info->sys_guid, &ibdev->node_guid,
 		 sizeof ( node_info->sys_guid ) );
 	memcpy ( &node_info->node_guid, &ibdev->node_guid,


### PR DESCRIPTION
Allow drivers to override total number of reported infiband ports. This is
required to report the correct number of total ports, on devices with dynamic
port types.

For example, dual-port Mellanox cards configured for (eth, ib) would be rejected
by the subnet manager, because they report using "port 2, out of 1".

Signed-off-by: Christian Iversen <ci@iversenit.dk>