### PR TITLE
Make iPXE builds reproducible

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1202,7 +1202,7 @@ $(BIN)/version.%.o : core/version.c $(MAKEDEPS) $(GIT_INDEX)
 $(BIN)/%.tmp : $(BIN)/version.%.o $(BLIB) $(MAKEDEPS) $(LDSCRIPT)
 	$(QM)$(ECHO) "  [LD] $@"
 	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT) $(TGT_LD_FLAGS) $< $(BLIB) -o $@ \
-		--defsym _build_id=`$(BUILD_ID_CMD)` \
+		--defsym _build_id=$(shell $(BUILD_ID_CMD)) \
 		--defsym _build_timestamp=$(BUILD_TIMESTAMP) \
 		-Map $(BIN)/$*.tmp.map
 	$(Q)$(OBJDUMP) -ht $@ | $(PERL) $(SORTOBJDUMP) >> $(BIN)/$*.tmp.map

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1167,7 +1167,17 @@ BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
 
 # Build timestamp
 #
+# Used only as a means to automatically select the newest version of iPXE if
+# multiple iPXE drivers are loaded concurrently in a UEFI system.
+#
+# It gets rounded down to the nearest minute when used for this purpose.
+ifdef SOURCE_DATE_EPOCH
+BUILD_TIMESTAMP := $(SOURCE_DATE_EPOCH)
+else ifdef GITVERSION
+BUILD_TIMESTAMP := $(git log -1 --pretty=%ct)
+else
 BUILD_TIMESTAMP := $(shell date +%s)
+endif
 
 # Build version
 #

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1160,10 +1160,15 @@ $(BLIB) : $(BLIB_OBJS) $(BLIB_LIST) $(MAKEDEPS)
 	$(Q)$(RANLIB) -D $@
 blib : $(BLIB)
 
-# Command to generate build ID.  Must be unique for each $(BIN)/%.tmp,
-# even within the same build run.
+# Build ID
 #
-BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
+# Must be unique for each $(BIN)/%.tmp, even within the same build run.
+#
+# The build ID is supposed to be collision-free across all ROMs that might ever
+# end up installed in the same system. It doesn't just disambiguate targets
+# within a single build; it also disambiguates different builds (such as
+# builds for multiple roms, which are all built from the same blib.a).
+BUILD_ID_CMD = sha1sum $^ | sort | cksum | awk '{printf "0x%08x", $$1}'
 
 # Build timestamp
 #
@@ -1173,8 +1178,8 @@ BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
 # It gets rounded down to the nearest minute when used for this purpose.
 ifdef SOURCE_DATE_EPOCH
 BUILD_TIMESTAMP := $(SOURCE_DATE_EPOCH)
-else ifdef GITVERSION
-BUILD_TIMESTAMP := $(git log -1 --pretty=%ct)
+else ifneq ($(GITVERSION),)
+BUILD_TIMESTAMP := $(shell git log -1 --pretty=%ct)
 else
 BUILD_TIMESTAMP := $(shell date +%s)
 endif


### PR DESCRIPTION
These 2 commits seem to be all that is needed to make iPXE builds reproducible. I'd love to have reproducible iPXE builds so that I could verify CI builds against local ones for https://github.com/tinkerbell/boots.