### PR TITLE
[hermon] Minimise reset time

### DIFF
--- a/src/drivers/infiniband/hermon.h
+++ b/src/drivers/infiniband/hermon.h
@@ -35,7 +35,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
 /* Device reset */
 #define HERMON_RESET_OFFSET		0x0f0010
 #define HERMON_RESET_MAGIC		0x01000001UL
-#define HERMON_RESET_WAIT_TIME_MS	1000
+#define HERMON_RESET_MAX_WAIT_MS	1000
 
 /* Work queue entry and completion queue entry opcodes */
 #define HERMON_OPCODE_NOP		0x00


### PR DESCRIPTION
Check for reset completion by waiting for the device to respond to PCI
configuration cycles, as documented in the Programmer's Reference
Manual.  On the original ConnectX HCA, this reduces the time spent on
reset from 1000ms down to 1ms.

Signed-off-by: Michael Brown <mcb30@ipxe.org>