### PR TITLE
[build] Work around stray sections introduced by some binutils versions

### DIFF
--- a/src/arch/x86/Makefile.pcbios
+++ b/src/arch/x86/Makefile.pcbios
@@ -4,17 +4,14 @@
 #
 SRCDIRS		+= arch/x86/drivers/net
 
-# The i386 linker script
+# The linker scripts
 #
 LDSCRIPT	= arch/x86/scripts/pcbios.lds
+LDSCRIPT_PREFIX	= arch/x86/scripts/prefixonly.lds
 
 # Stop ld from complaining about our customised linker script
 #
 LDFLAGS		+= -N --no-check-sections
-
-# Prefix always starts at address zero
-#
-LDFLAGS		+= --section-start=.prefix=0
 
 # Media types.
 #
@@ -73,12 +70,12 @@ NON_AUTO_MEDIA	+= fd0
 # Special target for building Master Boot Record binary
 $(BIN)/mbr.tmp : $(BIN)/mbr.o
 	$(QM)$(ECHO) "  [LD] $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ -e mbr $<
+	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT_PREFIX) -o $@ -e mbr $<
 
 # rule to make a USB disk image
 $(BIN)/usbdisk.tmp : $(BIN)/usbdisk.o
 	$(QM)$(ECHO) "  [LD] $@"
-	$(Q)$(LD) $(LDFLAGS) -o $@ -e mbr $<
+	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT_PREFIX) -o $@ -e mbr $<
 
 NON_AUTO_MEDIA	+= usb
 %usb: $(BIN)/usbdisk.bin %hd

--- a/src/arch/x86/scripts/prefixonly.lds
+++ b/src/arch/x86/scripts/prefixonly.lds
@@ -1,0 +1,29 @@
+/* -*- ld-script -*- */
+
+/*
+ * Linker script for prefix-only binaries (e.g. USB disk MBR)
+ *
+ */
+
+SECTIONS {
+
+    .prefix 0x0 : AT ( 0x0 ) {
+	*(.prefix)
+    }
+
+    /DISCARD/ : {
+	*(.comment)
+	*(.comment.*)
+	*(.note)
+	*(.note.*)
+	*(.eh_frame)
+	*(.eh_frame.*)
+	*(.rel)
+	*(.rel.*)
+	*(.einfo)
+	*(.einfo.*)
+	*(.discard)
+	*(.discard.*)
+    }
+
+}


### PR DESCRIPTION
Some versions of GNU ld (observed with binutils 2.36 on Arch Linux)
introduce a .note.gnu.property section marked as loadable at a high
address and with non-empty contents.  This adds approximately 128MB of
garbage to the BIOS .usb disk images.

Fix by using a custom linker script for the prefix-only binaries such
as the USB disk partition table and MBR, in order to allow unwanted
sections to be explicitly discarded.

Reported-by: Christian Hesse <mail@eworm.de>
Tested-by: Christian Hesse <mail@eworm.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>