### PR TITLE
efi: only the cmdline is expected in the efi LoadOptions

### DIFF
--- a/src/image/efi_image.c
+++ b/src/image/efi_image.c
@@ -113,15 +113,12 @@ static wchar_t * efi_image_cmdline ( struct image *image ) {
 	wchar_t *cmdline;
 	size_t len;
 
-	len = ( strlen ( image->name ) +
-		( image->cmdline ?
-		  ( 1 /* " " */ + strlen ( image->cmdline ) ) : 0 ) );
+	len = ( image->cmdline ?
+		  ( strlen ( image->cmdline ) ) : 0 );
 	cmdline = zalloc ( ( len + 1 /* NUL */ ) * sizeof ( wchar_t ) );
 	if ( ! cmdline )
 		return NULL;
-	efi_snprintf ( cmdline, ( len + 1 /* NUL */ ), "%s%s%s",
-		       image->name,
-		       ( image->cmdline ? " " : "" ),
+	efi_snprintf ( cmdline, ( len + 1 /* NUL */ ), "%s",
 		       ( image->cmdline ? image->cmdline : "" ) );
 	return cmdline;
 }


### PR DESCRIPTION
The image name is not expected to be placed on the LoadOptions field.
At least in the linuxx64.efi.stub, this is not expected to have any
value as the data there overrides the kernel command line set in the efi
stub.