### PR TITLE
intelxvf: Add additional PCI device ID to table

### DIFF
--- a/src/drivers/net/intelxvf.c
+++ b/src/drivers/net/intelxvf.c
@@ -530,6 +530,7 @@ static struct pci_device_id intelxvf_nics[] = {
 	PCI_ROM ( 0x8086, 0x1515, "x540-vf", "X540 VF", 0 ),
 	PCI_ROM ( 0x8086, 0x1565, "x550-vf", "X550 VF", 0 ),
 	PCI_ROM ( 0x8086, 0x15a8, "x552-vf", "X552 VF", 0 ),
+	PCI_ROM ( 0x8086, 0x15c5, "x557-vf", "X557-AT2 VF", 0 ),
 };
 
 /** PCI driver */


### PR DESCRIPTION
Adding this missing identifier allows the X557-AT2 chipset
seen on (at least) Super Micro A2SDI-H-TF motherboards to
function with iPXE.

Signed-off-by: Tyler J. Stachecki <stachecki.tyler@gmail.com>