### PR TITLE
[efi] Improve ELF to PE conversion

### DIFF
--- a/src/scripts/efi.lds
+++ b/src/scripts/efi.lds
@@ -106,5 +106,6 @@ SECTIONS {
 	*(.einfo.*)
 	*(.discard)
 	*(.discard.*)
+	*(.pci_devlist.*)
     }
 }

--- a/src/scripts/efi.lds
+++ b/src/scripts/efi.lds
@@ -8,22 +8,22 @@
 SECTIONS {
 
     /* The file starts at a virtual address of zero, and sections are
-     * contiguous.  Each section is aligned to at least _max_align,
-     * which defaults to 32.  Load addresses are equal to virtual
+     * contiguous.  Each section is aligned to at least _page_align,
+     * which defaults to 4096.  Load addresses are equal to virtual
      * addresses.
      */
 
-    _max_align = 32;
+    _page_align = 4096;
 
-    /* Allow plenty of space for file headers */
-    . = 0x1000;
+    /* Allow one page of space for file headers, common PE/COFF layout */
+    . = _page_align;
 
     /*
      * The text section
      *
      */
 
-    . = ALIGN ( _max_align );
+    . = ALIGN ( _page_align );
     .text : {
 	_text = .;
 	*(.text)
@@ -36,7 +36,7 @@ SECTIONS {
      *
      */
 
-    . = ALIGN ( _max_align );
+    . = ALIGN ( _page_align );
     .rodata : {
 	_rodata = .;
 	*(.rodata)
@@ -49,7 +49,7 @@ SECTIONS {
      *
      */
 
-    . = ALIGN ( _max_align );
+    . = ALIGN ( _page_align );
     .data : {
 	_data = .;
 	*(.data)
@@ -65,7 +65,7 @@ SECTIONS {
      *
      */
 
-    . = ALIGN ( _max_align );
+    . = ALIGN ( _page_align );
     .bss : {
 	_bss = .;
 	*(.bss)

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -758,6 +758,7 @@ create_reloc_section ( struct pe_header *pe_header,
 	reloc->hdr.VirtualAddress = pe_header->nt.OptionalHeader.SizeOfImage;
 	reloc->hdr.SizeOfRawData = section_filesz;
 	reloc->hdr.Characteristics = ( EFI_IMAGE_SCN_CNT_INITIALIZED_DATA |
+				       EFI_IMAGE_SCN_MEM_DISCARDABLE |
 				       EFI_IMAGE_SCN_MEM_NOT_PAGED |
 				       EFI_IMAGE_SCN_MEM_READ );
 
@@ -822,6 +823,7 @@ create_debug_section ( struct pe_header *pe_header, const char *filename ) {
 	debug->hdr.VirtualAddress = pe_header->nt.OptionalHeader.SizeOfImage;
 	debug->hdr.SizeOfRawData = section_filesz;
 	debug->hdr.Characteristics = ( EFI_IMAGE_SCN_CNT_INITIALIZED_DATA |
+				       EFI_IMAGE_SCN_MEM_DISCARDABLE |
 				       EFI_IMAGE_SCN_MEM_NOT_PAGED |
 				       EFI_IMAGE_SCN_MEM_READ );
 	debug->fixup = fixup_debug_section;


### PR DESCRIPTION
As currently ELF sections rather than segments are converted to PE sections, PE section alignment is hard-coded, and some fields describing virtual properties are assigned values based on file alignment, EFI PE drivers generated by elf2efi are generally not well-aligned. This can cause issues when enforcing strict PE parsing rules (as I am currently proposing for EDK II / OVMF), or when enforcing section permissions.

This PR fixes all discovered issues regarding PE image alignment. Furthermore, the constructed debug and relocation sections are marked as discardable for security reasons. All changes made are in conformance with the PE specification.

The changes have been validated using a stricter EDK II image loader, with OVMF booting and successfully loading the appropriate EFI ROM. Images created by the old utility are rejected as expected. Please note that I have not been able to test the full functionality of the ROM image, only that it loads successfully.