### PR TITLE
[build] Fix genfsimg to build ISO with long filenames

### DIFF
--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -230,7 +230,7 @@ done
 # since isohybrid will refuse to work without them.
 #
 if [ -n "${ISOIMG}" ] ; then
-    ISOARGS="-J -R"
+    ISOARGS="-J -R -l"
     copy_syslinux_file "isolinux.bin" "${ISODIR}"
     copy_syslinux_file "ldlinux.c32" "${ISODIR}" 2>/dev/null || true
     ISOARGS="${ISOARGS} -no-emul-boot -eltorito-boot isolinux.bin"


### PR DESCRIPTION
Commit 79c0173 introduced the new genfsimg, which lacks the -l option when building ISO Files.
This option is required to build level 2 (long plain) ISO9660 Filenames, which are required when using 
the .lkrn extensions. Fixes #306