### PR TITLE
Fix compilation with gcc11

### DIFF
--- a/src/drivers/net/ath/ath5k/ath5k_eeprom.c
+++ b/src/drivers/net/ath/ath5k/ath5k_eeprom.c
@@ -410,7 +410,7 @@ ath5k_eeprom_read_turbo_modes(struct ath5k_hw *ah,
 {
 	struct ath5k_eeprom_info *ee = &ah->ah_capabilities.cap_eeprom;
 	u32 o = *offset;
-	u16 val;
+	u16 val = 0;
 	int ret;
 
 	if (ee->ee_version < AR5K_EEPROM_VERSION_5_0)

--- a/src/tests/bigint_test.c
+++ b/src/tests/bigint_test.c
@@ -227,6 +227,7 @@ void bigint_mod_exp_sample ( const bigint_element_t *base0,
 	DBG_HDA ( 0, &value_temp, sizeof ( value_temp ) );		\
 	bigint_add ( &addend_temp, &value_temp );			\
 	DBG_HDA ( 0, &value_temp, sizeof ( value_temp ) );		\
+	memset( result_raw, 0, sizeof ( result_raw ) );                 \
 	bigint_done ( &value_temp, result_raw, sizeof ( result_raw ) );	\
 									\
 	ok ( memcmp ( result_raw, expected_raw,				\


### PR DESCRIPTION
without this patch, compilation with gcc11 and `-Werror` (includes `-Werror=maybe-uninitialized`) failed

in `drivers/net/ath/ath5k/ath5k_eeprom.c:437`
```
ee->ee_switch_settling_turbo[mode] = (val >> 8) & 0x7f;
```
and
```
tests/bigint_test.c:232:14: error: 'result_raw' may be used uninitialized
```