### PR TITLE
[rndis] Fix size of reserved fields

### DIFF
--- a/src/include/ipxe/rndis.h
+++ b/src/include/ipxe/rndis.h
@@ -84,7 +84,7 @@ struct rndis_initialise_completion {
 	/** Packet alignment factor */
 	uint32_t align;
 	/** Reserved */
-	uint32_t reserved;
+	uint32_t reserved[2];
 } __attribute__ (( packed ));
 
 /** RNDIS halt message */
@@ -237,7 +237,7 @@ struct rndis_packet_message {
 	/** Per-packet information record */
 	struct rndis_packet_field ppi;
 	/** Reserved */
-	uint32_t reserved;
+	uint32_t reserved[2];
 } __attribute__ (( packed ));
 
 /** RNDIS packet record */


### PR DESCRIPTION
Most RNDIS data structures include a trailing 4-byte reserved field.
For the REMOTE_NDIS_PACKET_MSG and REMOTE_NDIS_INITIALIZE_CMPLT
structures, this is an 8-byte field instead.

iPXE currently uses incorrect structure definitions with a 4-byte
reserved field in all data structures, resulting in data payloads that
overlap the last 4 bytes of the 8-byte reserved field.

RNDIS uses explicit offsets to locate any data payloads beyond the
message header, and so liberal RNDIS parsers (such as those used in
Hyper-V and in the Linux USB Ethernet gadget driver) are still able to
parse the malformed structures.

A stricter RNDIS parser (such as that found in some older Android
builds that seem to use an out-of-tree USB Ethernet gadget driver) may
reject the malformed structures since the data payload offset is less
than the header length, causing iPXE to be unable to transmit packets.

Fix by correcting the length of the reserved fields.

Debugged-by: Martin Nield <pmn1492@gmail.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>

Fixes: #377 