### PR TITLE
[efi] Ensure build-id is deterministic

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1167,7 +1167,7 @@ $(BLIB) : $(BLIB_OBJS) $(BLIB_LIST) $(MAKEDEPS)
 	$(Q)$(RM) $(BLIB)
 	$(QM)$(ECHO) "  [AR] $@"
 	$(Q)$(AR) rD $@ $(sort $(BLIB_OBJS))
-	$(Q)$(OBJCOPY) --prefix-symbols=$(SYMBOL_PREFIX) $@
+	$(Q)$(OBJCOPY) -D --prefix-symbols=$(SYMBOL_PREFIX) $@
 	$(Q)$(RANLIB) -D $@
 blib : $(BLIB)
 


### PR DESCRIPTION
Without this patch,
`BUILD_ID_CMD` used a checksum of `blib.a` that varied from mtimes

See https://reproducible-builds.org/ for why this matters.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).