### PR TITLE
Realtek RTL-8110SC/8169 fix

### DIFF
--- a/src/drivers/net/realtek.h
+++ b/src/drivers/net/realtek.h
@@ -307,6 +307,8 @@ struct realtek_nic {
 	int have_phy_regs;
 	/** TPPoll register offset */
 	unsigned int tppoll;
+	/** PHY id */
+	uint32_t phy_id;
 
 	/** Transmit descriptor ring */
 	struct realtek_ring tx;

--- a/src/include/mii.h
+++ b/src/include/mii.h
@@ -23,6 +23,7 @@ FILE_LICENCE ( GPL2_ONLY );
 #define MII_EXPANSION	    0x06	/* Expansion register	       */
 #define MII_CTRL1000	    0x09	/* 1000BASE-T control	       */
 #define MII_STAT1000	    0x0a	/* 1000BASE-T status	       */
+#define MII_MMD_DATA	    0x0e	/* MMD Access Data reg	       */
 #define MII_ESTATUS	    0x0f	/* Extended Status */
 #define MII_DCOUNTER	    0x12	/* Disconnect counter	       */
 #define MII_FCSCOUNTER	    0x13	/* False carrier counter       */


### PR DESCRIPTION
Related to issue #390

Further digging revealed that Linux calls these functions when suspending and resuming the interface:

https://github.com/torvalds/linux/blob/d9403d307dba1a71ee6462b22300c2d3be773b1c/drivers/net/phy/realtek.c#L408-L420

```c
static int rtl8211b_suspend(struct phy_device *phydev)
{
	phy_write(phydev, MII_MMD_DATA, BIT(9));


	return genphy_suspend(phydev);
}


static int rtl8211b_resume(struct phy_device *phydev)
{
	phy_write(phydev, MII_MMD_DATA, 0);


	return genphy_resume(phydev);
}
```

This behavior (modifying `MII_MMD_DATA` register) was adopted in the iPXE's realtek driver and it enabled it to bring the interface up.