### PR TITLE
[realtek] Work around hardware bug on RTL8211B

### DIFF
--- a/src/drivers/net/realtek.c
+++ b/src/drivers/net/realtek.c
@@ -420,6 +420,16 @@ static int realtek_phy_reset ( struct realtek_nic *rtl ) {
 		 */
 	}
 
+	/* Some cards (e.g. RTL8211B) have a hardware errata that
+	 * requires the MII_MMD_DATA register to be cleared before the
+	 * link will come up.
+	 */
+	if ( ( rc = mii_write ( &rtl->mii, MII_MMD_DATA, 0 ) ) != 0 ) {
+		/* Ignore failures, since the register may not be
+		 * present on all PHYs.
+		 */
+	}
+
 	/* Restart autonegotiation */
 	if ( ( rc = mii_restart ( &rtl->mii ) ) != 0 ) {
 		DBGC ( rtl, "REALTEK %p could not restart MII: %s\n",

--- a/src/include/mii.h
+++ b/src/include/mii.h
@@ -23,6 +23,8 @@ FILE_LICENCE ( GPL2_ONLY );
 #define MII_EXPANSION	    0x06	/* Expansion register	       */
 #define MII_CTRL1000	    0x09	/* 1000BASE-T control	       */
 #define MII_STAT1000	    0x0a	/* 1000BASE-T status	       */
+#define MII_MMD_CTRL	    0x0d	/* MMD Access Control Register */
+#define MII_MMD_DATA	    0x0e	/* MMD Access Data Register    */
 #define MII_ESTATUS	    0x0f	/* Extended Status */
 #define MII_DCOUNTER	    0x12	/* Disconnect counter	       */
 #define MII_FCSCOUNTER	    0x13	/* False carrier counter       */


### PR DESCRIPTION
The RTL8211B seems to have a bug that prevents the link from coming up
unless the MII_MMD_DATA register is cleared.

The Linux kernel driver applies this workaround (in rtl8211b_resume())
only to the specific RTL8211B PHY model, along with a matching
workaround to set bit 9 of MII_MMD_DATA when suspending the PHY.
Since we have no need to ever suspend the PHY, and since writing a
zero ought to be harmless, we just clear the register unconditionally.

Debugged-by: VL-80 <vl-80@users.noreply.github.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>

Fixes: ipxe/ipxe#390 
Fixes: ipxe/ipxe#394