### PR TITLE
[virtio] Update driver to use DMA API

### DIFF
--- a/src/drivers/bus/virtio-pci.c
+++ b/src/drivers/bus/virtio-pci.c
@@ -17,37 +17,47 @@
 #include "ipxe/io.h"
 #include "ipxe/iomap.h"
 #include "ipxe/pci.h"
+#include "ipxe/dma.h"
 #include "ipxe/reboot.h"
 #include "ipxe/virtio-pci.h"
 #include "ipxe/virtio-ring.h"
 
-static int vp_alloc_vq(struct vring_virtqueue *vq, u16 num)
+static int vp_alloc_vq(struct vring_virtqueue *vq, u16 num, size_t header_size)
 {
-    size_t queue_size = PAGE_MASK + vring_size(num);
+    size_t ring_size = PAGE_MASK + vring_size(num);
     size_t vdata_size = num * sizeof(void *);
+    size_t queue_size = ring_size + vdata_size + header_size;
 
-    vq->queue = zalloc(queue_size + vdata_size);
+    vq->queue = dma_alloc(vq->dma, &vq->map, queue_size, queue_size);
     if (!vq->queue) {
         return -ENOMEM;
     }
 
+    memset ( vq->queue, 0, queue_size );
+    vq->queue_size = queue_size;
+
     /* vdata immediately follows the ring */
-    vq->vdata = (void **)(vq->queue + queue_size);
+    vq->vdata = (void **)(vq->queue + ring_size);
+
+    /* empty header immediately follows vdata */
+    vq->empty_header = (struct virtio_net_hdr_modern *)(vq->queue + ring_size + vdata_size);
 
     return 0;
 }
 
 void vp_free_vq(struct vring_virtqueue *vq)
 {
-    if (vq->queue) {
-        free(vq->queue);
+    if (vq->queue && vq->queue_size) {
+        dma_free(&vq->map, vq->queue, vq->queue_size);
         vq->queue = NULL;
         vq->vdata = NULL;
+        vq->queue_size = 0;
     }
 }
 
 int vp_find_vq(unsigned int ioaddr, int queue_index,
-               struct vring_virtqueue *vq)
+               struct vring_virtqueue *vq, struct dma_device *dma_dev,
+               size_t header_size)
 {
    struct vring * vr = &vq->vring;
    u16 num;
@@ -73,9 +83,10 @@ int vp_find_vq(unsigned int ioaddr, int queue_index,
    }
 
    vq->queue_index = queue_index;
+   vq->dma = dma_dev;
 
    /* initialize the queue */
-   rc = vp_alloc_vq(vq, num);
+   rc = vp_alloc_vq(vq, num, header_size);
    if (rc) {
            DBG("VIRTIO-PCI ERROR: failed to allocate queue memory\n");
            return rc;
@@ -87,8 +98,7 @@ int vp_find_vq(unsigned int ioaddr, int queue_index,
     * NOTE: vr->desc is initialized by vring_init()
     */
 
-   outl((unsigned long)virt_to_phys(vr->desc) >> PAGE_SHIFT,
-        ioaddr + VIRTIO_PCI_QUEUE_PFN);
+   outl(dma(&vq->map, vr->desc) >> PAGE_SHIFT, ioaddr + VIRTIO_PCI_QUEUE_PFN);
 
    return num;
 }
@@ -348,7 +358,8 @@ void vpm_notify(struct virtio_pci_modern_device *vdev,
 }
 
 int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
-                 unsigned nvqs, struct vring_virtqueue *vqs)
+                 unsigned nvqs, struct vring_virtqueue *vqs,
+                 struct dma_device *dma_dev, size_t header_size)
 {
     unsigned i;
     struct vring_virtqueue *vq;
@@ -392,11 +403,12 @@ int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
 
         vq = &vqs[i];
         vq->queue_index = i;
+        vq->dma = dma_dev;
 
         /* get offset of notification word for this vq */
         off = vpm_ioread16(vdev, &vdev->common, COMMON_OFFSET(queue_notify_off));
 
-        err = vp_alloc_vq(vq, size);
+        err = vp_alloc_vq(vq, size, header_size);
         if (err) {
             DBG("VIRTIO-PCI %p: failed to allocate queue memory\n", vdev);
             return err;
@@ -406,13 +418,16 @@ int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
         /* activate the queue */
         vpm_iowrite16(vdev, &vdev->common, size, COMMON_OFFSET(queue_size));
 
-        vpm_iowrite64(vdev, &vdev->common, virt_to_phys(vq->vring.desc),
+        vpm_iowrite64(vdev, &vdev->common,
+                      dma(&vq->map, vq->vring.desc),
                       COMMON_OFFSET(queue_desc_lo),
                       COMMON_OFFSET(queue_desc_hi));
-        vpm_iowrite64(vdev, &vdev->common, virt_to_phys(vq->vring.avail),
+        vpm_iowrite64(vdev, &vdev->common,
+                      dma(&vq->map, vq->vring.avail),
                       COMMON_OFFSET(queue_avail_lo),
                       COMMON_OFFSET(queue_avail_hi));
-        vpm_iowrite64(vdev, &vdev->common, virt_to_phys(vq->vring.used),
+        vpm_iowrite64(vdev, &vdev->common,
+                      dma(&vq->map, vq->vring.used),
                       COMMON_OFFSET(queue_used_lo),
                       COMMON_OFFSET(queue_used_hi));
 

--- a/src/drivers/bus/virtio-ring.c
+++ b/src/drivers/bus/virtio-ring.c
@@ -98,7 +98,7 @@ void vring_add_buf(struct vring_virtqueue *vq,
    for (i = head; out; i = vr->desc[i].next, out--) {
 
            vr->desc[i].flags = VRING_DESC_F_NEXT;
-           vr->desc[i].addr = (u64)virt_to_phys(list->addr);
+           vr->desc[i].addr = list->addr;
            vr->desc[i].len = list->length;
            prev = i;
            list++;
@@ -106,7 +106,7 @@ void vring_add_buf(struct vring_virtqueue *vq,
    for ( ; in; i = vr->desc[i].next, in--) {
 
            vr->desc[i].flags = VRING_DESC_F_NEXT|VRING_DESC_F_WRITE;
-           vr->desc[i].addr = (u64)virt_to_phys(list->addr);
+           vr->desc[i].addr = list->addr;
            vr->desc[i].len = list->length;
            prev = i;
            list++;

--- a/src/include/ipxe/virtio-pci.h
+++ b/src/include/ipxe/virtio-pci.h
@@ -1,6 +1,8 @@
 #ifndef _VIRTIO_PCI_H_
 # define _VIRTIO_PCI_H_
 
+#include <ipxe/dma.h>
+
 /* A 32-bit r/o bitmask of the features supported by the host */
 #define VIRTIO_PCI_HOST_FEATURES        0
 
@@ -198,7 +200,8 @@ struct vring_virtqueue;
 
 void vp_free_vq(struct vring_virtqueue *vq);
 int vp_find_vq(unsigned int ioaddr, int queue_index,
-               struct vring_virtqueue *vq);
+               struct vring_virtqueue *vq, struct dma_device *dma_dev,
+               size_t header_size);
 
 
 /* Virtio 1.0 I/O routines abstract away the three possible HW access
@@ -298,7 +301,8 @@ void vpm_notify(struct virtio_pci_modern_device *vdev,
                 struct vring_virtqueue *vq);
 
 int vpm_find_vqs(struct virtio_pci_modern_device *vdev,
-                 unsigned nvqs, struct vring_virtqueue *vqs);
+                 unsigned nvqs, struct vring_virtqueue *vqs,
+                 struct dma_device *dma_dev, size_t header_size);
 
 int virtio_pci_find_capability(struct pci_device *pci, uint8_t cfg_type);
 

--- a/src/include/ipxe/virtio-ring.h
+++ b/src/include/ipxe/virtio-ring.h
@@ -2,6 +2,7 @@
 # define _VIRTIO_RING_H_
 
 #include <ipxe/virtio-pci.h>
+#include <ipxe/dma.h>
 
 /* Status byte for guest to report progress, and synchronize features. */
 /* We have seen device and processed generic fields (VIRTIO_CONFIG_F_VIRTIO) */
@@ -74,17 +75,21 @@ struct vring {
 
 struct vring_virtqueue {
    unsigned char *queue;
+   size_t queue_size;
+   struct dma_mapping map;
+   struct dma_device *dma;
    struct vring vring;
    u16 free_head;
    u16 last_used_idx;
    void **vdata;
+   struct virtio_net_hdr_modern *empty_header;
    /* PCI */
    int queue_index;
    struct virtio_pci_region notification;
 };
 
 struct vring_list {
-  char *addr;
+  physaddr_t addr;
   unsigned int length;
 };
 


### PR DESCRIPTION
This PR updates the virtio-net driver to use the new DMA API as documented in the commit log for commit https://github.com/ipxe/ipxe/commit/8d337ecda.
The virtio-net driver's shared structures (i.e. iobufs, virtqueues) are updated to be allocated/mapped via the new DMA API allocation functions - e.g. alloc_rx_iob() and dma_alloc().
These updates have the benefit of allowing IPXE to function in a AMD SEV enabled environment when a virtio-net device is configured as the shared structures are properly mapped via the PciIo->Map() protocol function.

Testing was somewhat minimal consisting of booting via iPXE over a QEMU configured virtio-net-pci device on a x86_64 virtual machine with both SEV and no-SEV enabled. Also, only a "modern" (virtio 1.0) device was tested. No testing of a "legacy" (virtio 0.9.5) device was performed (but the legacy code was also updated).

 -Aaron Young
 aaron.young@oracle.com
 
Signed-off-by: Aaron Young <aaron.young@oracle.com>