### PR TITLE
[intel] Add PCI ID Intel X553 0x15e4

### DIFF
--- a/src/drivers/net/intelx.c
+++ b/src/drivers/net/intelx.c
@@ -481,6 +481,7 @@ static struct pci_device_id intelx_nics[] = {
 	PCI_ROM ( 0x8086, 0x15ab, "x552", "X552", 0 ),
 	PCI_ROM ( 0x8086, 0x15c8, "x553t", "X553/X557-AT", 0 ),
 	PCI_ROM ( 0x8086, 0x15ce, "x553-sfp", "X553 (SFP+)", 0 ),
+	PCI_ROM ( 0x8086, 0x15e4, "x553", "X553", 0 ),
 	PCI_ROM ( 0x8086, 0x15e5, "x553", "X553", 0 ),
 };
 


### PR DESCRIPTION
In our lab we have a Asrock board with a Intel X553 network card with 4x1GBit/s which uses the intelx driver but does not work with iPXE out of the box.
A colleague figured out that the PCI device ID was missing (thx Stefan).
I wanted to submit this here for other people who may want to use the same board with iPXE.