### PR TITLE
Better experience for shallow repository

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -208,7 +208,7 @@ install :
 #
 # Version number calculations
 #
-VERSIONS := $(if $(wildcard ../.git),$(shell git describe --tags --always --long --abbrev=1 --match "v*"))
+VERSIONS := $(if $(wildcard ../.git),$(shell git describe --tags --always --long --abbrev=32 --match "v*"))
 
 ifneq ($(filter v%, $(VERSIONS)),)
 VERSION_TUPLE	:= $(subst ., ,$(subst -, ,$(patsubst v%,%,$(VERSIONS))))
@@ -231,7 +231,7 @@ endif
 MM_VERSION	= $(VERSION_MAJOR).$(VERSION_MINOR)
 VERSION		= $(MM_VERSION).$(VERSION_PATCH)$(EXTRAVERSION)
 ifneq ($(GITVERSION),)
-VERSION		+= ($(GITVERSION))
+VERSION		+= ($(shell echo $(GITVERSION) | cut -c1-8))
 endif
 version :
 	@$(ECHO) "$(VERSION)"

--- a/src/Makefile
+++ b/src/Makefile
@@ -208,8 +208,9 @@ install :
 #
 # Version number calculations
 #
-ifneq ($(wildcard ../.git),)
-VERSIONS := $(shell git describe --tags --always --long --abbrev=1 --match "v*")
+VERSIONS := $(if $(wildcard ../.git),$(shell git describe --tags --always --long --abbrev=1 --match "v*"))
+
+ifneq ($(filter v%, $(VERSIONS)),)
 VERSION_TUPLE	:= $(subst ., ,$(subst -, ,$(patsubst v%,%,$(VERSIONS))))
 VERSION_MAJOR	:= $(word 1,$(VERSION_TUPLE))
 VERSION_MINOR	:= $(word 2,$(VERSION_TUPLE))
@@ -225,6 +226,7 @@ VERSION_MAJOR	= 1
 VERSION_MINOR	= 0
 VERSION_PATCH	= 0
 EXTRAVERSION	= +
+GITVERSION	= $(VERSIONS)
 endif
 MM_VERSION	= $(VERSION_MAJOR).$(VERSION_MINOR)
 VERSION		= $(MM_VERSION).$(VERSION_PATCH)$(EXTRAVERSION)


### PR DESCRIPTION
The current assumption is that, if the .git directory exists, at least one tag must exist. Otherwise, builds fail and the reason of the failure is not clear.

From users' perspective, having the full git history is not necessary. In fact, shallow clone (git clone --depth=<N>) is often used by umbrella projects since having the HEAD is enough for compilation.

This pull request fixes the broken build, and makes version string deterministic.
