### PR TITLE
[autoboot] Set cwuri as an uri for embedded image if cwuri is non-NULL

### DIFF
--- a/src/usr/autoboot.c
+++ b/src/usr/autoboot.c
@@ -593,6 +593,8 @@ int ipxe ( struct net_device *netdev ) {
 	/* Boot system */
 	if ( ( image = first_image() ) != NULL ) {
 		/* We have an embedded image; execute it */
+		if ( cwuri )
+			image_set_uri ( image, cwuri );
 		return image_exec ( image );
 	} else if ( shell_banner() ) {
 		/* User wants shell; just give them a shell */


### PR DESCRIPTION
Since commit [1] the following script/set of commands stopped working:

```
iPXE> ifconf -c dhcp net0
Configuring [dhcp] (net0 52:54:00:12:34:56)............... ok
iPXE> imgfetch ${filename}
Could not start download: Operation not supported (http://ipxe.org/3c092083)
```

However, when we specify the full path, it works:

```
iPXE> imgfetch tftp://${next-server}/${filename}
tftp://10.0.2.2//new.efi... ok
```

This is reproduceable on iPXE with an embedded script. The problem is in
interworkings between cwuri, DHCP parameters from the UEFI and embedded scripts.

Code added in [1] runs very early on iPXE initialisation. If we get a cached
lease from UEFI, we will use it and the code in tftp.c will properly set cwuri
to tftp://${next-server}/.

Later at init, code in autoboot.c will detect an embedded iPXE script and will
try to execute it. Since the embedded script currently has ->uri set to NULL,
image_exec() will reset cwuri to NULL, previously set by cached TFTP lease.

But now, even if we manually re-run "dhcp" on the interface, the cwuri will not
be restored, because iPXE will not detect any changes to ${next-server}.

This was not a problem before [1], because previously ${next-server} was not yet
set, when the embedded script was executed and later invocation of "dhcp"
triggered iPXE to set cwuri correctly.

Fix this by setting cwuri as an uri for embedded script, if cwuri is not NULL at
the time of execution.

[1]: cd3de55 ("[efi] Record cached DHCPACK from loaded image's device handle, if present")