### PR TITLE
[uri] Allow for relative URIs that include colons within the path

### DIFF
--- a/src/core/uri.c
+++ b/src/core/uri.c
@@ -334,8 +334,15 @@ struct uri * parse_uri ( const char *uri_string ) {
 		uri->efragment = tmp;
 	}
 
-	/* Identify absolute/relative URI */
-	if ( ( tmp = strchr ( raw, ':' ) ) ) {
+	/* Identify absolute URIs */
+	epath = raw;
+	for ( tmp = raw ; ; tmp++ ) {
+		/* Possible scheme character (for our URI schemes) */
+		if ( isalpha ( *tmp ) || ( *tmp == '-' ) || ( *tmp == '_' ) )
+			continue;
+		/* Invalid scheme character or NUL: is a relative URI */
+		if ( *tmp != ':' )
+			break;
 		/* Absolute URI: identify hierarchical/opaque */
 		uri->scheme = raw;
 		*(tmp++) = '\0';
@@ -347,9 +354,7 @@ struct uri * parse_uri ( const char *uri_string ) {
 			uri->opaque = tmp;
 			epath = NULL;
 		}
-	} else {
-		/* Relative URI */
-		epath = raw;
+		break;
 	}
 
 	/* If we don't have a path (i.e. we have an absolute URI with

--- a/src/tests/uri_test.c
+++ b/src/tests/uri_test.c
@@ -657,6 +657,15 @@ static struct uri_test uri_file_volume = {
 	},
 };
 
+/** Relative URI with colons in path */
+static struct uri_test uri_colons = {
+	"/boot/52:54:00:12:34:56/boot.ipxe",
+	{
+		.path = "/boot/52:54:00:12:34:56/boot.ipxe",
+		.epath = "/boot/52:54:00:12:34:56/boot.ipxe",
+	},
+};
+
 /** URI with port number */
 static struct uri_port_test uri_explicit_port = {
 	"http://192.168.0.1:8080/boot.php",
@@ -957,6 +966,7 @@ static void uri_test_exec ( void ) {
 	uri_parse_format_dup_ok ( &uri_file_relative );
 	uri_parse_format_dup_ok ( &uri_file_absolute );
 	uri_parse_format_dup_ok ( &uri_file_volume );
+	uri_parse_format_dup_ok ( &uri_colons );
 
 	/** URI port number tests */
 	uri_port_ok ( &uri_explicit_port );


### PR DESCRIPTION
RFC3986 allows for colons to appear within the path component of a
relative URI, but iPXE will currently parse such URIs incorrectly by
interpreting the text before the colon as the URI scheme.

Fix by checking for valid characters when identifying the URI scheme.
Deliberately deviate from the RFC3986 definition of valid characters
by accepting "_" (which was incorrectly used in the iPXE-specific
"ib_srp" URI scheme and so must be accepted for compatibility with
existing deployments), and by omitting the code to check for
characters that are not used in any URI scheme supported by iPXE.

Fixes: #554
Reported-by: Ignat Korchagin <ignat@cloudflare.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>