### PR TITLE
[efi] Enable DOWNLOAD_PROTO_HTTPS by default

### DIFF
--- a/src/config/defaults/efi.h
+++ b/src/config/defaults/efi.h
@@ -25,7 +25,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define ACPI_EFI
 #define FDT_EFI
 
+/* Enable IPv6 and HTTPS */
 #define	NET_PROTO_IPV6		/* IPv6 protocol */
+#define	DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
 
 #define DOWNLOAD_PROTO_FILE	/* Local filesystem access */
 

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -55,7 +55,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
 #define	DOWNLOAD_PROTO_TFTP	/* Trivial File Transfer Protocol */
 #define	DOWNLOAD_PROTO_HTTP	/* Hypertext Transfer Protocol */
-#undef	DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
+//#define DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
 #undef	DOWNLOAD_PROTO_FTP	/* File Transfer Protocol */
 #undef	DOWNLOAD_PROTO_SLAM	/* Scalable Local Area Multicast */
 #undef	DOWNLOAD_PROTO_NFS	/* Network File System Protocol */


### PR DESCRIPTION
HTTPS is the current standard and should be used when possible.
Very much in common with 0c25daad38b2b345fbe6c4838ea2d9c82cc08228

Signed-off-by: Christian Nilsson <nikize@gmail.com>