### PR TITLE
Setting IMAGE_GZIP as default on aarch64

### DIFF
--- a/src/config/general.h
+++ b/src/config/general.h
@@ -120,6 +120,11 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 //#define	IMAGE_ZLIB		/* ZLIB image support */
 //#define	IMAGE_GZIP		/* GZIP image support */
 
+// Enable IMAGE_GZIP on aarch64 by default
+#ifdef __aarch64__
+#define	IMAGE_GZIP		/* GZIP image support */
+#endif
+
 /*
  * Command-line commands to include
  *


### PR DESCRIPTION
On Aarch64, the bootloaders should be on the behalf of [decompressing the kernel](https://github.com/torvalds/linux/blob/master/Documentation/arm64/booting.rst#3-decompress-the-kernel-image) before loading it.

This PR enables the `IMAGE_GZIP` option by default for aarch64 architecture, letting iPXE be able to load a gzip-compressed kernel.

This PR also refers coreos/fedora-coreos-tracker#1019