### PR TITLE
[efi] Enable IMAGE_GZIP by default for AArch64

### DIFF
--- a/src/config/defaults/efi.h
+++ b/src/config/defaults/efi.h
@@ -58,4 +58,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define NAP_EFIARM
 #endif
 
+#if defined ( __aarch64__ )
+#define	IMAGE_GZIP		/* GZIP image support */
+#endif
+
 #endif /* CONFIG_DEFAULTS_EFI_H */


### PR DESCRIPTION
AArch64 kernels tend to be distributed as gzip compressed images.
Enable IMAGE_GZIP by default for AArch64 to avoid the need for
uncompressed images to be provided.

Fixes: #585 

Originally-implemented-by: Alessandro Di Stefano <aleskandro@redhat.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>