### PR TITLE
[image] Do not clear current working URI when executing embedded image

### DIFF
--- a/src/core/image.c
+++ b/src/core/image.c
@@ -338,9 +338,12 @@ int image_exec ( struct image *image ) {
 	/* Sanity check */
 	assert ( image->flags & IMAGE_REGISTERED );
 
-	/* Switch current working directory to be that of the image itself */
+	/* Switch current working directory to be that of the image
+	 * itself, if applicable
+	 */
 	old_cwuri = uri_get ( cwuri );
-	churi ( image->uri );
+	if ( image->uri )
+		churi ( image->uri );
 
 	/* Preserve record of any currently-running image */
 	saved_current_image = current_image;


### PR DESCRIPTION
Embedded images do not have an associated URI.  This currently causes
the current working URI (cwuri) to be cleared when starting an
embedded image.

If the current working URI has been set via a ${next-server} setting
from a cached DHCP packet then this will result in unexpected
behaviour.  An attempt by the embedded script to use a relative URI to
download files from the TFTP server will fail with the error

  Could not start download: Operation not supported (ipxe.org/3c092083)

Rerunning the "dhcp" command will not fix this error, since the TFTP
settings applicator will not see any change to the ${next-server}
setting and so will not reset the current working URI.

Fix by setting the current working URI to the image's URI only if the
image actually has an associated URI.

Debugged-by: Ignat Korchagin <ignat@cloudflare.com>
Originally-fixed-by: Ignat Korchagin <ignat@cloudflare.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>