### PR TITLE
[rng] Add more entropy

### DIFF
--- a/src/core/random.c
+++ b/src/core/random.c
@@ -21,14 +21,16 @@ static int32_t rnd_seed = 0;
  *  - system time ticks
  *  - cpu profiling timestamp
  *  - address of stack variable
- *  - fair dice roll (ensures nonzero seed)
+ *
+ * The RNG implementation requires that the seed is non-zero;
+ * this function guarantees that with `| 4`
  */
 void srandom ( unsigned int seed ) {
 	if ( ! ( rnd_seed = seed ) ) {
 		rnd_seed = ( currticks()
 			^ profile_timestamp()
 			^ ( size_t ) &seed
-		) | 4;
+		) | 4; /* Chosen by fair dice roll */
 	}
 	DBG ( "seed=%08x ", rnd_seed );
 }
@@ -41,7 +43,9 @@ void srandom ( unsigned int seed ) {
 long int random ( void ) {
 	int32_t q;
 
-	if ( ! rnd_seed ) /* Initialize linear congruential generator */
+	if ( ! rnd_seed )
+		/* Initialize linear congruential generator,
+		   providing 0 to autoselect a seed */
 		srandom ( 0 );
 
 	/* simplified version of the LCG given in Bruce Schneier's


### PR DESCRIPTION
When running as efirom, the RNG is always seeded with the same value (0xc0, sometimes +/- 1).

Add some entropy to fix this:
* address of stack variable
* profile_timestamp()

This alleviates some separate issues:
* RNG seeded with `4` when running ipxe.efi inside VMwarePlayer or QEMU due to `currticks() called before initialisation`
* Servers getting confused by reused TCP sequence numbers and DHCP request IDs across reboots

The size of `random.o` has increased from 4260 to 5080 bytes

Tested on an i350-t4v2 in a Dell Optiplex 3090 (bios 2.2.0) using commit dd3547543811dd2e996b910bdadb609414904352, and QEMU/VMwarePlayer on f58b5109f46088bdbb5345a9d94b636c54345bdf