### PR TITLE
Have the system use `env` to find echo

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -10,8 +10,8 @@
 TAB 			:= $(shell $(PRINTF) '\t')
 ECHO_E_ECHO		:= $(ECHO)
 ECHO_E_ECHO_E		:= $(ECHO) -e
-ECHO_E_BIN_ECHO 	:= /bin/echo
-ECHO_E_BIN_ECHO_E 	:= /bin/echo -e
+ECHO_E_BIN_ECHO 	:= /usr/bin/env echo
+ECHO_E_BIN_ECHO_E 	:= /usr/bin/env echo -e
 ECHO_E_ECHO_TAB		:= $(shell $(ECHO_E_ECHO) '\t' | cat)
 ECHO_E_ECHO_E_TAB	:= $(shell $(ECHO_E_ECHO_E) '\t' | cat)
 ECHO_E_BIN_ECHO_TAB 	:= $(shell $(ECHO_E_BIN_ECHO) '\t')


### PR DESCRIPTION
On my (NixOS) system it was showing errors because the `echo` binary is not where it might normally be. Using `/usr/bin/env` should be universal and ensure that the echo binary can be found.