### PR TITLE
[build] Respect $CC

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ SYMBOL_PREFIX	:=
 #
 # Locations of tools
 #
-HOST_CC		:= gcc
+HOST_CC		:= $(CC)
 RM		:= rm -f
 TOUCH		:= touch
 MKDIR		:= mkdir
@@ -26,7 +26,7 @@ PRINTF		:= printf
 PERL		:= perl
 PYTHON		:= python
 TRUE		:= true
-CC		:= $(CROSS_COMPILE)gcc
+CC		:= $(CROSS_COMPILE)$(CC)
 CPP		:= $(CC) -E
 AS		:= $(CROSS_COMPILE)as
 LD		:= $(CROSS_COMPILE)ld


### PR DESCRIPTION
On BSD systems 'gcc' is not the default compiler.
But $CC is honored.  This also makes it build with ccache.