### PR TITLE
[bzimage] Fix parsing of "vga=..." when not at end of command line

### DIFF
--- a/src/arch/x86/image/bzimage.c
+++ b/src/arch/x86/image/bzimage.c
@@ -252,13 +252,17 @@ static void bzimage_update_header ( struct image *image,
  */
 static int bzimage_parse_cmdline ( struct image *image,
 				   struct bzimage_context *bzimg,
-				   const char *cmdline ) {
+				   char *cmdline ) {
+	char *sep;
 	char *vga;
 	char *mem;
 
 	/* Look for "vga=" */
 	if ( ( vga = strstr ( cmdline, "vga=" ) ) ) {
 		vga += 4;
+		sep = strchr ( vga, ' ' );
+		if ( sep )
+			*sep = '\0';
 		if ( strcmp ( vga, "normal" ) == 0 ) {
 			bzimg->vid_mode = BZI_VID_MODE_NORMAL;
 		} else if ( strcmp ( vga, "ext" ) == 0 ) {
@@ -267,11 +271,13 @@ static int bzimage_parse_cmdline ( struct image *image,
 			bzimg->vid_mode = BZI_VID_MODE_ASK;
 		} else {
 			bzimg->vid_mode = strtoul ( vga, &vga, 0 );
-			if ( *vga && ( *vga != ' ' ) ) {
-				DBGC ( image, "bzImage %p strange \"vga=\""
+			if ( *vga ) {
+				DBGC ( image, "bzImage %p strange \"vga=\" "
 				       "terminator '%c'\n", image, *vga );
 			}
 		}
+		if ( sep )
+			*sep = ' ';
 	}
 
 	/* Look for "mem=" */
@@ -522,7 +528,7 @@ static void bzimage_load_initrds ( struct image *image,
  */
 static int bzimage_exec ( struct image *image ) {
 	struct bzimage_context bzimg;
-	const char *cmdline = ( image->cmdline ? image->cmdline : "" );
+	char *cmdline = ( image->cmdline ? image->cmdline : "" );
 	int rc;
 
 	/* Read and parse header from image */


### PR DESCRIPTION
bzimage_parse_cmdline() uses strcmp() to identify the named "vga=..." kernel command line option values, which will give a false negative if the option is not last on the command line.

Fix by temporarily changing the relevant command line separator (if any) to a NUL terminator.

Fixes: #777 

Debugged-by: Simon Rettberg <simon.rettberg@rz.uni-freiburg.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>