### PR TITLE
[dhcp] Let DHCPNAK return to discovery state for request host only

### DIFF
--- a/src/net/udp/dhcp.c
+++ b/src/net/udp/dhcp.c
@@ -571,12 +571,6 @@ static void dhcp_request_rx ( struct dhcp_session *dhcp,
 	if ( peer->sin_port != htons ( BOOTPS_PORT ) )
 		return;
 
-	/* Handle DHCPNAK */
-	if ( msgtype == DHCPNAK ) {
-		dhcp_defer ( dhcp );
-		return;
-	}
-
 	/* Filter out unacceptable responses */
 	if ( msgtype /* BOOTP */ && ( msgtype != DHCPACK ) )
 		return;
@@ -584,6 +578,12 @@ static void dhcp_request_rx ( struct dhcp_session *dhcp,
 		return;
 	if ( ip.s_addr != dhcp->offer.s_addr )
 		return;
+
+	/* Handle DHCPNAK */
+	if ( msgtype == DHCPNAK ) {
+		dhcp_defer ( dhcp );
+		return;
+	}
 
 	/* Record assigned address */
 	dhcp->local.sin_addr = ip;

--- a/src/net/udp/dhcp.c
+++ b/src/net/udp/dhcp.c
@@ -571,6 +571,16 @@ static void dhcp_request_rx ( struct dhcp_session *dhcp,
 	if ( peer->sin_port != htons ( BOOTPS_PORT ) )
 		return;
 
+	/* Handle DHCPNAK */
+	if ( msgtype == DHCPNAK &&
+             server_id.s_addr == dhcp->server.s_addr &&
+             ip.s_addr == dhcp->offer.s_addr ) {
+                /* Only consider NAK's from the server we sent the
+                   request to, and with the same offer */ 
+		dhcp_defer ( dhcp );
+		return;
+	}
+
 	/* Filter out unacceptable responses */
 	if ( msgtype /* BOOTP */ && ( msgtype != DHCPACK ) )
 		return;
@@ -578,12 +588,6 @@ static void dhcp_request_rx ( struct dhcp_session *dhcp,
 		return;
 	if ( ip.s_addr != dhcp->offer.s_addr )
 		return;
-
-	/* Handle DHCPNAK */
-	if ( msgtype == DHCPNAK ) {
-		dhcp_defer ( dhcp );
-		return;
-	}
 
 	/* Record assigned address */
 	dhcp->local.sin_addr = ip;


### PR DESCRIPTION
Only consider DHCPNAK from the host we sent request to, this prohibits other hosts in a multi-dhcpd environment to spuriously return the state machine to discovery state.