### PR TITLE
VLAN support for cached DHCPACK

### DIFF
--- a/src/arch/x86/interface/pcbios/bios_cachedhcp.c
+++ b/src/arch/x86/interface/pcbios/bios_cachedhcp.c
@@ -59,7 +59,7 @@ static void cachedhcp_init ( void ) {
 	}
 
 	/* Record cached DHCPACK */
-	if ( ( rc = cachedhcp_record ( &cached_dhcpack,
+	if ( ( rc = cachedhcp_record ( &cached_dhcpack, 0,
 				       phys_to_user ( cached_dhcpack_phys ),
 				       sizeof ( BOOTPLAYER_t ) ) ) != 0 ) {
 		DBGC ( colour, "CACHEDHCP could not record DHCPACK: %s\n",

--- a/src/include/ipxe/cachedhcp.h
+++ b/src/include/ipxe/cachedhcp.h
@@ -18,7 +18,8 @@ extern struct cached_dhcp_packet cached_dhcpack;
 extern struct cached_dhcp_packet cached_proxydhcp;
 extern struct cached_dhcp_packet cached_pxebs;
 
-extern int cachedhcp_record ( struct cached_dhcp_packet *cache, userptr_t data,
+extern int cachedhcp_record ( struct cached_dhcp_packet *cache,
+			      unsigned int vlan, userptr_t data,
 			      size_t max_len );
 
 #endif /* _IPXE_CACHEDHCP_H */

--- a/src/include/ipxe/efi/efi_cachedhcp.h
+++ b/src/include/ipxe/efi/efi_cachedhcp.h
@@ -11,6 +11,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
 #include <ipxe/efi/efi.h>
 
-extern int efi_cachedhcp_record ( EFI_HANDLE device );
+extern int efi_cachedhcp_record ( EFI_HANDLE device,
+				  EFI_DEVICE_PATH_PROTOCOL *path );
 
 #endif /* _IPXE_EFI_CACHEDHCP_H */

--- a/src/include/ipxe/efi/efi_path.h
+++ b/src/include/ipxe/efi/efi_path.h
@@ -26,6 +26,7 @@ efi_path_next ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern EFI_DEVICE_PATH_PROTOCOL *
 efi_path_end ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern size_t efi_path_len ( EFI_DEVICE_PATH_PROTOCOL *path );
+extern unsigned int efi_path_vlan ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern EFI_DEVICE_PATH_PROTOCOL * efi_paths ( EFI_DEVICE_PATH_PROTOCOL *first,
 					      ... );
 extern EFI_DEVICE_PATH_PROTOCOL * efi_netdev_path ( struct net_device *netdev );

--- a/src/include/ipxe/efi/efi_path.h
+++ b/src/include/ipxe/efi/efi_path.h
@@ -22,6 +22,8 @@ struct ib_srp_device;
 struct usb_function;
 
 extern EFI_DEVICE_PATH_PROTOCOL *
+efi_path_next ( EFI_DEVICE_PATH_PROTOCOL *path );
+extern EFI_DEVICE_PATH_PROTOCOL *
 efi_path_end ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern size_t efi_path_len ( EFI_DEVICE_PATH_PROTOCOL *path );
 extern EFI_DEVICE_PATH_PROTOCOL * efi_paths ( EFI_DEVICE_PATH_PROTOCOL *first,

--- a/src/interface/efi/efi_local.c
+++ b/src/interface/efi/efi_local.c
@@ -419,14 +419,15 @@ static int efi_local_open_resolved ( struct efi_local *local,
  * Open specified path
  *
  * @v local		Local file
- * @v path		Path to file
+ * @v filename		Path to file relative to our own image
  * @ret rc		Return status code
  */
-static int efi_local_open_path ( struct efi_local *local, const char *path ) {
-	FILEPATH_DEVICE_PATH *fp = container_of ( efi_loaded_image->FilePath,
-						  FILEPATH_DEVICE_PATH, Header);
-	size_t fp_len = efi_path_len ( &fp->Header );
-	char base[ fp_len / 2 /* Cannot exceed this length */ ];
+static int efi_local_open_path ( struct efi_local *local,
+				 const char *filename ) {
+	EFI_DEVICE_PATH_PROTOCOL *path = efi_loaded_image->FilePath;
+	EFI_DEVICE_PATH_PROTOCOL *next;
+	FILEPATH_DEVICE_PATH *fp;
+	char base[ efi_path_len ( path ) / 2 /* Cannot exceed this length */ ];
 	size_t remaining = sizeof ( base );
 	size_t len;
 	char *resolved;
@@ -436,13 +437,12 @@ static int efi_local_open_path ( struct efi_local *local, const char *path ) {
 	/* Construct base path to our own image, if possible */
 	memset ( base, 0, sizeof ( base ) );
 	tmp = base;
-	while ( fp && ( fp->Header.Type != END_DEVICE_PATH_TYPE ) ) {
+	for ( ; ( next = efi_path_next ( path ) ) ; path = next ) {
+		fp = container_of ( path, FILEPATH_DEVICE_PATH, Header );
 		len = snprintf ( tmp, remaining, "%ls", fp->PathName );
 		assert ( len < remaining );
 		tmp += len;
 		remaining -= len;
-		fp = ( ( ( void * ) fp ) + ( ( fp->Header.Length[1] << 8 ) |
-					     fp->Header.Length[0] ) );
 	}
 	DBGC2 ( local, "LOCAL %p base path \"%s\"\n",
 		local, base );
@@ -454,7 +454,7 @@ static int efi_local_open_path ( struct efi_local *local, const char *path ) {
 	}
 
 	/* Resolve path */
-	resolved = resolve_path ( base, path );
+	resolved = resolve_path ( base, filename );
 	if ( ! resolved ) {
 		rc = -ENOMEM;
 		goto err_resolve;

--- a/src/interface/efi/efi_local.c
+++ b/src/interface/efi/efi_local.c
@@ -425,7 +425,7 @@ static int efi_local_open_resolved ( struct efi_local *local,
 static int efi_local_open_path ( struct efi_local *local, const char *path ) {
 	FILEPATH_DEVICE_PATH *fp = container_of ( efi_loaded_image->FilePath,
 						  FILEPATH_DEVICE_PATH, Header);
-	size_t fp_len = ( fp ? efi_path_len ( &fp->Header ) : 0 );
+	size_t fp_len = efi_path_len ( &fp->Header );
 	char base[ fp_len / 2 /* Cannot exceed this length */ ];
 	size_t remaining = sizeof ( base );
 	size_t len;

--- a/src/interface/efi/efi_path.c
+++ b/src/interface/efi/efi_path.c
@@ -41,18 +41,42 @@
  */
 
 /**
+ * Find next element in device path
+ *
+ * @v path		Device path, or NULL
+ * @v next		Next element in device path, or NULL if at end
+ */
+EFI_DEVICE_PATH_PROTOCOL * efi_path_next ( EFI_DEVICE_PATH_PROTOCOL *path ) {
+
+	/* Check for non-existent device path */
+	if ( ! path )
+		return NULL;
+
+	/* Check for end of device path */
+	if ( path->Type == END_DEVICE_PATH_TYPE )
+		return NULL;
+
+	/* Move to next component of the device path */
+	path = ( ( ( void * ) path ) +
+		 /* There's this amazing new-fangled thing known as
+		  * a UINT16, but who wants to use one of those? */
+		 ( ( path->Length[1] << 8 ) | path->Length[0] ) );
+
+	return path;
+}
+
+/**
  * Find end of device path
  *
  * @v path		Device path, or NULL
  * @ret path_end	End of device path, or NULL
  */
 EFI_DEVICE_PATH_PROTOCOL * efi_path_end ( EFI_DEVICE_PATH_PROTOCOL *path ) {
+	EFI_DEVICE_PATH_PROTOCOL *next;
 
-	while ( path && ( path->Type != END_DEVICE_PATH_TYPE ) ) {
-		path = ( ( ( void * ) path ) +
-			 /* There's this amazing new-fangled thing known as
-			  * a UINT16, but who wants to use one of those? */
-			 ( ( path->Length[1] << 8 ) | path->Length[0] ) );
+	/* Find end of device path */
+	while ( ( next = efi_path_next ( path ) ) != NULL ) {
+		path = next;
 	}
 
 	return path;

--- a/src/interface/efi/efi_path.c
+++ b/src/interface/efi/efi_path.c
@@ -95,6 +95,29 @@ size_t efi_path_len ( EFI_DEVICE_PATH_PROTOCOL *path ) {
 }
 
 /**
+ * Get VLAN tag from device path
+ *
+ * @v path		Device path
+ * @ret tag		VLAN tag, or 0 if not a VLAN
+ */
+unsigned int efi_path_vlan ( EFI_DEVICE_PATH_PROTOCOL *path ) {
+	EFI_DEVICE_PATH_PROTOCOL *next;
+	VLAN_DEVICE_PATH *vlan;
+
+	/* Search for VLAN device path */
+	for ( ; ( next = efi_path_next ( path ) ) ; path = next ) {
+		if ( ( path->Type == MESSAGING_DEVICE_PATH ) &&
+		     ( path->SubType == MSG_VLAN_DP ) ) {
+			vlan = container_of ( path, VLAN_DEVICE_PATH, Header );
+			return vlan->VlanId;
+		}
+	}
+
+	/* No VLAN device path found */
+	return 0;
+}
+
+/**
  * Concatenate EFI device paths
  *
  * @v ...		List of device paths (NULL terminated)

--- a/src/interface/efi/efi_path.c
+++ b/src/interface/efi/efi_path.c
@@ -43,12 +43,12 @@
 /**
  * Find end of device path
  *
- * @v path		Path to device
- * @ret path_end	End of device path
+ * @v path		Device path, or NULL
+ * @ret path_end	End of device path, or NULL
  */
 EFI_DEVICE_PATH_PROTOCOL * efi_path_end ( EFI_DEVICE_PATH_PROTOCOL *path ) {
 
-	while ( path->Type != END_DEVICE_PATH_TYPE ) {
+	while ( path && ( path->Type != END_DEVICE_PATH_TYPE ) ) {
 		path = ( ( ( void * ) path ) +
 			 /* There's this amazing new-fangled thing known as
 			  * a UINT16, but who wants to use one of those? */
@@ -61,7 +61,7 @@ EFI_DEVICE_PATH_PROTOCOL * efi_path_end ( EFI_DEVICE_PATH_PROTOCOL *path ) {
 /**
  * Find length of device path (excluding terminator)
  *
- * @v path		Path to device
+ * @v path		Device path, or NULL
  * @ret path_len	Length of device path
  */
 size_t efi_path_len ( EFI_DEVICE_PATH_PROTOCOL *path ) {

--- a/src/interface/efi/efiprefix.c
+++ b/src/interface/efi/efiprefix.c
@@ -78,12 +78,13 @@ EFI_STATUS EFIAPI _efi_start ( EFI_HANDLE image_handle,
  */
 static void efi_init_application ( void ) {
 	EFI_HANDLE device = efi_loaded_image->DeviceHandle;
+	EFI_DEVICE_PATH_PROTOCOL *path = efi_loaded_image_path;
 
 	/* Identify autoboot device, if any */
 	efi_set_autoboot_ll_addr ( device );
 
 	/* Store cached DHCP packet, if any */
-	efi_cachedhcp_record ( device );
+	efi_cachedhcp_record ( device, path );
 
 	/* Load autoexec script, if any */
 	efi_autoexec_load ( device );


### PR DESCRIPTION
When chainloading iPXE from a VLAN device, the MAC address within the cached DHCPACK will match the MAC address of the trunk device created by iPXE, and the cached DHCPACK will then end up being erroneously applied to the trunk device.  This tends to break outbound IPv4 routing, since both the trunk and VLAN devices will have the same assigned IPv4 address.

Fix by recording the VLAN tag along with the cached DHCPACK, and treating the VLAN tag as part of the filter used to match the cached DHCPACK against candidate network devices.

Also retain any unclaimed DHCPACK after startup to allow it to be matched against (and applied to) any device that gets created at runtime.