### PR TITLE
[efi] Do not rely on ProcessorBind.h when building host binaries

### DIFF
--- a/src/include/ipxe/efi/ProcessorBind.h
+++ b/src/include/ipxe/efi/ProcessorBind.h
@@ -10,20 +10,54 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *  - mcb30
  */
 
-#if __i386__
+#ifdef EFI_HOSTONLY
+
+/*
+ * We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
+ * binary for execution on the build host itself, since the host's CPU
+ * architecture may not even be supported by EDK2.
+ */
+
+/* Define the basic integer types in terms of the host's <stdint.h> */
+#include <stdint.h>
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef uint8_t UINT8;
+typedef long INTN;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef unsigned long UINTN;
+typedef int8_t CHAR8;
+typedef int16_t CHAR16;
+typedef uint8_t BOOLEAN;
+
+/* Define EFIAPI as whatever API the host uses by default */
+#define EFIAPI
+
+/* Define an architecture-neutral MDE_CPU macro to prevent build errors */
+#define MDE_CPU_EBC
+
+#else /* EFI_HOSTONLY */
+
+#ifdef __i386__
 #include <ipxe/efi/Ia32/ProcessorBind.h>
 #endif
 
-#if __x86_64__
+#ifdef __x86_64__
 #include <ipxe/efi/X64/ProcessorBind.h>
 #endif
 
-#if __arm__
+#ifdef __arm__
 #include <ipxe/efi/Arm/ProcessorBind.h>
 #endif
 
-#if __aarch64__
+#ifdef __aarch64__
 #include <ipxe/efi/AArch64/ProcessorBind.h>
 #endif
+
+#endif /* EFI_HOSTONLY */
 
 #endif /* _IPXE_EFI_PROCESSOR_BIND_H */

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -33,6 +33,8 @@
 #include <fcntl.h>
 #include <elf.h>
 #include <libgen.h>
+
+#define EFI_HOSTONLY
 #include <ipxe/efi/Uefi.h>
 #include <ipxe/efi/IndustryStandard/PeImage.h>
 


### PR DESCRIPTION
We cannot rely on the EDK2 ProcessorBind.h headers when compiling a binary for execution on the build host itself (e.g. elf2efi), since the host's CPU architecture may not even be supported by EDK2.

Fix by skipping ProcessorBind.h when building a host binary, and defining the bare minimum required to allow other EDK2 headers to compile cleanly.

Fixes: #856 

Reported-by: Michal Suchánek <msuchanek@suse.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>