### PR TITLE
[pxe] Avoid drawing menu items on bottom row of screen

### DIFF
--- a/src/usr/pxemenu.c
+++ b/src/usr/pxemenu.c
@@ -204,7 +204,7 @@ static void pxe_menu_draw_item ( struct pxe_menu *menu,
 	buf[ sizeof ( buf ) - 1 ] = '\0';
 
 	/* Draw row */
-	row = ( LINES - menu->num_items + index );
+	row = ( LINES - menu->num_items + index - 1 );
 	color_set ( ( selected ? CPAIR_PXE : CPAIR_DEFAULT ), NULL );
 	mvprintw ( row, 0, "%s", buf );
 	move ( row, 1 );


### PR DESCRIPTION
Many consoles will scroll immediately upon drawing a character in the rightmost column of the bottom row of the display, in order to be able to advance the cursor to the next character (even if the cursor is disabled).

This causes PXE menus to display incorrectly.  Specifically, pressing the down arrow key while already on the last menu item may cause the whole screen to scroll and the line to be duplicated.

Fix by moving the PXE menu one row up from the bottom of the screen.

Fixes: #694 

Signed-off-by: Michael Brown <mcb30@ipxe.org>