### PR TITLE
[ipv4] Support RFC3021-style /31 links

### DIFF
--- a/src/net/ipv4.c
+++ b/src/net/ipv4.c
@@ -373,7 +373,7 @@ static int ipv4_tx ( struct io_buffer *iobuf,
 		ntohs ( iphdr->chksum ) );
 
 	/* Calculate link-layer destination address, if possible */
-	if ( ( ( next_hop.s_addr ^ INADDR_BROADCAST ) & ~netmask.s_addr ) == 0){
+	if ( inaddr_is_broadcast ( &next_hop, &netmask ) ) {
 		/* Broadcast address */
 		ipv4_stats.out_bcast_pkts++;
 		ll_dest = netdev->ll_broadcast;


### PR DESCRIPTION
For /31 IPv4 links, there is no directed broadcast address, it should be treated as a regular unicast address instead.