### PR TITLE
[realtek] Explicitly disable VLAN offload

### DIFF
--- a/src/drivers/net/realtek.c
+++ b/src/drivers/net/realtek.c
@@ -1067,11 +1067,15 @@ static void realtek_detect ( struct realtek_nic *rtl ) {
 	 * Note that enabling DAC seems to cause bizarre behaviour
 	 * (lockups, garbage data on the wire) on some systems, even
 	 * if only 32-bit addresses are used.
+	 *
+	 * Disable VLAN offload, since some cards seem to have it
+	 * enabled by default.
 	 */
 	cpcr = readw ( rtl->regs + RTL_CPCR );
 	cpcr |= ( RTL_CPCR_MULRW | RTL_CPCR_CPRX | RTL_CPCR_CPTX );
 	if ( sizeof ( physaddr_t ) > sizeof ( uint32_t ) )
 		cpcr |= RTL_CPCR_DAC;
+	cpcr &= ~RTL_CPCR_VLAN;
 	writew ( cpcr, rtl->regs + RTL_CPCR );
 	check_cpcr = readw ( rtl->regs + RTL_CPCR );
 

--- a/src/drivers/net/realtek.h
+++ b/src/drivers/net/realtek.h
@@ -228,8 +228,9 @@ enum realtek_legacy_status {
 
 /** C+ Command Register (word) */
 #define RTL_CPCR 0xe0
-#define RTL_CPCR_DAC		0x0010	/**< PCI Dual Address Cycle Enable */
-#define RTL_CPCR_MULRW		0x0008	/**< PCI Multiple Read/Write Enable */
+#define RTL_CPCR_VLAN		0x0040	/**< VLAN tag stripping enable */
+#define RTL_CPCR_DAC		0x0010	/**< PCI Dual Address Cycle enable */
+#define RTL_CPCR_MULRW		0x0008	/**< PCI Multiple Read/Write enable */
 #define RTL_CPCR_CPRX		0x0002	/**< C+ receive enable */
 #define RTL_CPCR_CPTX		0x0001	/**< C+ transmit enable */
 


### PR DESCRIPTION
Some cards seem to have the receive VLAN tag stripping feature enabled by default, which causes received VLAN packets to be misinterpreted as being received by the trunk device.

Fix by disabling VLAN tag stripping in the C+ Command Register.

Debugged-by: ?????? <yiyihu@gmail.com>
Tested-by: ?????? <yiyihu@gmail.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>