### PR TITLE
[build] Respect value of $(CC) variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ SYMBOL_PREFIX	:=
 #
 # Locations of tools
 #
-HOST_CC		:= gcc
+HOST_CC		:= $(CC)
 RM		:= rm -f
 TOUCH		:= touch
 MKDIR		:= mkdir
@@ -26,7 +26,7 @@ PRINTF		:= printf
 PERL		:= perl
 PYTHON		:= python
 TRUE		:= true
-CC		:= $(CROSS_COMPILE)gcc
+CC		:= $(CROSS_COMPILE)$(CC)
 CPP		:= $(CC) -E
 AS		:= $(CROSS_COMPILE)as
 LD		:= $(CROSS_COMPILE)ld


### PR DESCRIPTION
On FreeBSD the gcc package installs a versioned binary such as "gcc12".  There is no plain "gcc" binary.

Simplify building on such systems by respecting the $(CC) variable.

Signed-off-by: Michael Brown <mcb30@ipxe.org>