### PR TITLE
[efi] Do not attempt to drive PCI bridge devices

### DIFF
--- a/src/drivers/bus/pci.c
+++ b/src/drivers/bus/pci.c
@@ -205,6 +205,7 @@ int pci_read_config ( struct pci_device *pci ) {
 	pci_read_config_dword ( pci, PCI_REVISION, &tmp );
 	pci->class = ( tmp >> 8 );
 	pci_read_config_byte ( pci, PCI_INTERRUPT_LINE, &pci->irq );
+	pci_read_config_byte ( pci, PCI_HEADER_TYPE, &pci->hdrtype );
 	pci_read_bases ( pci );
 
 	/* Initialise generic device component */

--- a/src/include/ipxe/pci.h
+++ b/src/include/ipxe/pci.h
@@ -227,6 +227,8 @@ struct pci_device {
 	uint32_t class;
 	/** Interrupt number */
 	uint8_t irq;
+	/** Header type */
+	uint8_t hdrtype;
 	/** Segment, bus, device, and function (bus:dev.fn) number */
 	uint32_t busdevfn;
 	/** Driver for this device */


### PR DESCRIPTION
The "bridge" driver introduced in 3aa6b79 ("[pci] Add minimal PCI bridge driver") is required only for BIOS builds using the ENA driver, where experimentation shows that we cannot rely on the BIOS to fully assign MMIO addresses.

Since the driver is a valid PCI driver, it will end up binding to all PCI bridge devices even on a UEFI platform, where the firmware is likely to have completed MMIO address assignment correctly.  This has no impact on most systems since there is generally no UEFI driver for PCI bridges: the enumeration of the whole PCI bus is handled by the PciBusDxe driver bound to the root bridge.

Experimentation shows that at least one laptop will freeze at the point that iPXE attempts to bind to the bridge device.  No deeper investigation has been carried out to find the root cause.

Fix by causing efipci_supported() to return an error unless the configuration space header type indicates a non-bridge device.

Fixes: #876 

Reported-by: Marcel Petersen <mp@sbe.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>