### PR TITLE
[eisa] Check for system board presence before probing for slots

### DIFF
--- a/src/drivers/bus/eisa.c
+++ b/src/drivers/bus/eisa.c
@@ -98,7 +98,15 @@ static void eisa_remove ( struct eisa_device *eisa ) {
 static int eisabus_probe ( struct root_device *rootdev ) {
 	struct eisa_device *eisa = NULL;
 	unsigned int slot;
+	uint8_t system;
 	int rc;
+
+	/* Check for EISA system board */
+	system = inb ( EISA_VENDOR_ID );
+	if ( system & 0x80 ) {
+		DBG ( "No EISA system board (read %02x)\n", system );
+		return -ENODEV;
+	}
 
 	for ( slot = EISA_MIN_SLOT ; slot <= EISA_MAX_SLOT ; slot++ ) {
 		/* Allocate struct eisa_device */


### PR DESCRIPTION
EISA expansion slot I/O port addresses overlap space that may be assigned to PCI devices, which can lead to register reads and writes with unwanted side effects during EISA probing.

Reduce the chances of performing EISA probing on PCI devices by probing EISA slot vendor and product ID registers only if the EISA system board vendor ID register indicates that the motherboard supports EISA.

Fixes: #877 

Debugged-by: Václav Ovsík <vaclav.ovsik@gmail.com>
Tested-by: Václav Ovsík <vaclav.ovsik@gmail.com>
Signed-off-by: Michael Brown <mcb30@ipxe.org>