### PR TITLE
[iscsi] Limit maximum transfer size to MaxBurstLength

### DIFF
--- a/src/drivers/block/scsi.c
+++ b/src/drivers/block/scsi.c
@@ -609,6 +609,7 @@ static void scsicmd_read_capacity_cmd ( struct scsi_command *scsicmd,
  */
 static void scsicmd_read_capacity_done ( struct scsi_command *scsicmd,
 					 int rc ) {
+	struct scsi_device *scsidev = scsicmd->scsidev;
 	struct scsi_read_capacity_private *priv = scsicmd_priv ( scsicmd );
 	struct scsi_capacity_16 *capacity16 = &priv->capacity.capacity16;
 	struct scsi_capacity_10 *capacity10 = &priv->capacity.capacity10;
@@ -644,6 +645,9 @@ static void scsicmd_read_capacity_done ( struct scsi_command *scsicmd,
 		}
 	}
 	capacity.max_count = -1U;
+
+	/* Allow transport layer to update capacity */
+	block_capacity ( &scsidev->scsi, &capacity );
 
 	/* Return capacity to caller */
 	block_capacity ( &scsicmd->block, &capacity );

--- a/src/include/ipxe/iscsi.h
+++ b/src/include/ipxe/iscsi.h
@@ -22,6 +22,15 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 /** Default iSCSI port */
 #define ISCSI_PORT 3260
 
+/** Default iSCSI first burst length */
+#define ISCSI_FIRST_BURST_LEN 65536
+
+/** Default iSCSI maximum burst length */
+#define ISCSI_MAX_BURST_LEN 262144
+
+/** Default iSCSI maximum receive data segment length */
+#define ISCSI_MAX_RECV_DATA_SEG_LEN 8192
+
 /**
  * iSCSI segment lengths
  *
@@ -576,6 +585,9 @@ struct iscsi_session {
 	unsigned char chap_challenge[17];
 	/** CHAP response (used for both initiator and target auth) */
 	struct chap_response chap;
+
+	/** Maximum burst length */
+	size_t max_burst_len;
 
 	/** Initiator session ID (IANA format) qualifier
 	 *


### PR DESCRIPTION
We currently specify only the iSCSI default value for MaxBurstLength and ignore any negotiated value, since our internal block device API allows only for receiving directly into caller-allocated buffers and so we have no intrinsic limit on burst length.

A conscientious target may however refuse to attempt a transfer that we request for a number of blocks that would exceed the negotiated maximum burst length.

Fix by recording the negotiated maximum burst length and using it to limit the maximum number of blocks per transfer reported by the SCSI layer.