### PR TITLE
Avoid executable stack

### DIFF
--- a/src/arch/arm64/core/setjmp.S
+++ b/src/arch/arm64/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", %progbits
 	.text
 
 	/* Must match jmp_buf structure layout */

--- a/src/arch/i386/core/gdbidt.S
+++ b/src/arch/i386/core/gdbidt.S
@@ -9,6 +9,7 @@
  * Interrupt handlers
  ****************************************************************************
  */
+	.section ".note.GNU-stack", "", @progbits
 	.section ".text", "ax", @progbits
 	.code32
 

--- a/src/arch/i386/core/setjmp.S
+++ b/src/arch/i386/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code32

--- a/src/arch/i386/tests/gdbstub_test.S
+++ b/src/arch/i386/tests/gdbstub_test.S
@@ -1,3 +1,4 @@
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 	.section ".data", "aw", @progbits

--- a/src/arch/x86/core/patch_cf.S
+++ b/src/arch/x86/core/patch_cf.S
@@ -22,6 +22,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/core/stack.S
+++ b/src/arch/x86/core/stack.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 #ifdef __x86_64__

--- a/src/arch/x86/core/stack16.S
+++ b/src/arch/x86/core/stack16.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -10,6 +10,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 #define PIC1_ICR 0x20
 #define PIC2_ICR 0xa0
 	
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/interface/pcbios/e820mangler.S
+++ b/src/arch/x86/interface/pcbios/e820mangler.S
@@ -23,6 +23,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/interface/pxe/pxe_entry.S
+++ b/src/arch/x86/interface/pxe/pxe_entry.S
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/interface/syslinux/com32_wrapper.S
+++ b/src/arch/x86/interface/syslinux/com32_wrapper.S
@@ -21,6 +21,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 
 #include "librm.h"
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 
 	.code32

--- a/src/arch/x86/prefix/bootpart.S
+++ b/src/arch/x86/prefix/bootpart.S
@@ -5,6 +5,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define STACK_SEG 	0x0200
 #define STACK_SIZE	0x2000
 	
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/dskprefix.S
+++ b/src/arch/x86/prefix/dskprefix.S
@@ -24,6 +24,7 @@ FILE_LICENCE ( GPL2_ONLY )
 
 .equ	SYSSEG, 0x1000			/* system loaded at SYSSEG<<4 */
 
+	.section ".note.GNU-stack", "", @progbits
 	.org	0
 	.arch i386
 	.text

--- a/src/arch/x86/prefix/exeprefix.S
+++ b/src/arch/x86/prefix/exeprefix.S
@@ -36,6 +36,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PSP_CMDLINE_LEN 0x80
 #define PSP_CMDLINE_START 0x81
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/hdprefix.S
+++ b/src/arch/x86/prefix/hdprefix.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/libprefix.S
+++ b/src/arch/x86/prefix/libprefix.S
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /* Image compression enabled */

--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -4,6 +4,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define BZI_LOAD_HIGH_ADDR 0x100000
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/mbr.S
+++ b/src/arch/x86/prefix/mbr.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/mromprefix.S
+++ b/src/arch/x86/prefix/mromprefix.S
@@ -41,6 +41,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define _pcirom_start _mrom_start
 #include "pciromprefix.S"
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/nbiprefix.S
+++ b/src/arch/x86/prefix/nbiprefix.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/nullprefix.S
+++ b/src/arch/x86/prefix/nullprefix.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.org	0
 	.text
 	.arch i386

--- a/src/arch/x86/prefix/pxeprefix.S
+++ b/src/arch/x86/prefix/pxeprefix.S
@@ -11,6 +11,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define PXE_HACK_EB54			0x0001
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -8,6 +8,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/romprefix.S
+++ b/src/arch/x86/prefix/romprefix.S
@@ -54,6 +54,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BUSTYPE "PCIR"
 #endif
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/undiloader.S
+++ b/src/arch/x86/prefix/undiloader.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -43,6 +43,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  ****************************************************************************
  */
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i486
 	.section ".prefix.lib", "ax", @progbits

--- a/src/arch/x86/prefix/usbdisk.S
+++ b/src/arch/x86/prefix/usbdisk.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <config/console.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/transitions/liba20.S
+++ b/src/arch/x86/transitions/liba20.S
@@ -24,6 +24,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/transitions/libkir.S
+++ b/src/arch/x86/transitions/libkir.S
@@ -31,6 +31,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 /* Breakpoint for when debugging under bochs */
 #define BOCHSBP xchgw %bx, %bx
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".text16", "awx", @progbits

--- a/src/arch/x86/transitions/librm.S
+++ b/src/arch/x86/transitions/librm.S
@@ -83,6 +83,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define if64 if 0
 #endif
 
+	.section ".note.GNU-stack", "", @progbits
+
 /****************************************************************************
  * Global descriptor table
  *

--- a/src/arch/x86_64/core/gdbidt.S
+++ b/src/arch/x86_64/core/gdbidt.S
@@ -38,6 +38,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define SIGFPE 8
 #define SIGSTKFLT 16
 
+	.section ".note.GNU-stack", "", @progbits
 	.section ".text.gdbmach_interrupt", "ax", @progbits
 	.code64
 

--- a/src/arch/x86_64/core/setjmp.S
+++ b/src/arch/x86_64/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code64
 


### PR DESCRIPTION
Messages like
  ld: warning: patch_cf.o: missing .note.GNU-stack section implies executable stack
  ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
avoided by adding several
  .section ".note.GNU-stack", "", @progbits
lines.