### PR TITLE
Add workaround for I210 reset hardware bugs

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -290,6 +290,18 @@ static int intel_reset ( struct intel_nic *intel ) {
 		       pba, readl ( intel->regs + INTEL_PBA ) );
 	}
 
+	/* The Intel I210's packet buffer size registers reset only on
+	 * power up.  If an operating system changes these but then
+	 * the computer recieves a reset signal without losing power,
+	 * the registers will stay the same (but be incompatible with
+	 * other register defaults), thus making the device unable to
+	 * pass traffic.
+	 */
+	if ( intel->flags & INTEL_PBSIZE_RST ) {
+		writel ( INTEL_RXPBS_I210, intel->regs + INTEL_RXPBS );
+		writel ( INTEL_TXPBS_I210, intel->regs + INTEL_TXPBS );
+	}
+
 	/* Always reset MAC.  Required to reset the TX and RX rings. */
 	writel ( ( ctrl | INTEL_CTRL_RST ), intel->regs + INTEL_CTRL );
 	mdelay ( INTEL_RESET_DELAY_MS );
@@ -1139,7 +1151,7 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x1525, "82567v-4", "82567V-4", 0 ),
 	PCI_ROM ( 0x8086, 0x1526, "82576-5", "82576", 0 ),
 	PCI_ROM ( 0x8086, 0x1527, "82580-f2", "82580 Fiber", 0 ),
-	PCI_ROM ( 0x8086, 0x1533, "i210", "I210", 0 ),
+	PCI_ROM ( 0x8086, 0x1533, "i210", "I210", INTEL_PBSIZE_RST ),
 	PCI_ROM ( 0x8086, 0x1539, "i211", "I211", 0 ),
 	PCI_ROM ( 0x8086, 0x153a, "i217lm", "I217-LM", INTEL_NO_PHY_RST ),
 	PCI_ROM ( 0x8086, 0x153b, "i217v", "I217-V", 0 ),
@@ -1147,7 +1159,7 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x155a, "i218lm", "I218-LM", INTEL_NO_PHY_RST ),
 	PCI_ROM ( 0x8086, 0x156f, "i219lm", "I219-LM", INTEL_I219 ),
 	PCI_ROM ( 0x8086, 0x1570, "i219v", "I219-V", INTEL_I219 ),
-	PCI_ROM ( 0x8086, 0x157b, "i210-2", "I210", 0 ),
+	PCI_ROM ( 0x8086, 0x157b, "i210-2", "I210", INTEL_PBSIZE_RST ),
 	PCI_ROM ( 0x8086, 0x15a0, "i218lm-2", "I218-LM", INTEL_NO_PHY_RST ),
 	PCI_ROM ( 0x8086, 0x15a1, "i218v-2", "I218-V", 0 ),
 	PCI_ROM ( 0x8086, 0x15a2, "i218lm-3", "I218-LM", INTEL_NO_PHY_RST ),

--- a/src/drivers/net/intel.h
+++ b/src/drivers/net/intel.h
@@ -138,6 +138,10 @@ struct intel_descriptor {
 /** Packet Buffer Size */
 #define INTEL_PBS 0x01008UL
 
+/** Receive packet buffer size */
+#define INTEL_RXPBS 0x02404UL
+#define INTEL_RXPBS_I210	0x000000a2UL	/**< I210 power-up default */
+
 /** Receive Descriptor register block */
 #define INTEL_RD 0x02800UL
 
@@ -153,6 +157,10 @@ struct intel_descriptor {
 
 /** Receive buffer length */
 #define INTEL_RX_MAX_LEN 2048
+
+/** Transmit packet buffer size */
+#define INTEL_TXPBS 0x03404UL
+#define INTEL_TXPBS_I210	0x04000014UL	/**< I210 power-up default */
 
 /** Transmit Descriptor register block */
 #define INTEL_TD 0x03800UL
@@ -319,6 +327,8 @@ enum intel_flags {
 	INTEL_NO_ASDE = 0x0008,
 	/** Reset may cause a complete device hang */
 	INTEL_RST_HANG = 0x0010,
+	/** PBSIZE registers must be explicitly reset */
+	INTEL_PBSIZE_RST = 0x0020,
 };
 
 /** The i219 has a seriously broken reset mechanism */


### PR DESCRIPTION
Hello, this fixes a weird hardware bug with I210s that I encountered. Basically not all the registers return to their default values on reset, so depending on how an OS is using the device it may become unable to pass traffic. I encountered this by using the QAV features on the I210 and then failing to get a DHCP address on the next boot after a reset signal was asserted.

More than happy to add explanation, testing logs, change up code, etc.

Using the current master branch, using the bin-x86_64-efi/ipxe.efi target:
```
FS0:\> master_ipxe.efi
iPXE initialising devices...ok
iPXE 1.21.1+ (g96bb6) -- Open Source Network Boot Firmware -- https://ipxe.org
Features: DNS HTTP iSCSI TFTP VLAN SRP AoE EFI Menu
iPXE> dhcp net1
Configuring (net1 00:17:3c:02:d6:7e).................. No configuration methods succeeded (https://ipxe.org/040ee186)
iPXE> ifstat net1
net1: 00:17:3c:02:d6:7e using i210-2 on 0000:0f:00.0 (Ethernet) [closed]
[Link:up, TX:0 TXE:9 RX:107 RXE:20]
[TXE: 9 x "Operation canceled (https://ipxe.org/0b086095)"]
[RXE: 4 x "The socket is not connected (https://ipxe.org/380f6093)"]
[RXE: 16 x "Error 0x440e6083 (https://ipxe.org/440e6083)"]
iPXE> 
```

With this fix, same target:
```
FS0:\> my_ipxe.efi
iPXE initialising devices...ok
iPXE 1.21.1+ (g4366e) -- Open Source Network Boot Firmware -- https://ipxe.org
Features: DNS HTTP iSCSI TFTP VLAN SRP AoE EFI Menu
iPXE> dhcp net1
Configuring (net1 00:17:3c:02:d6:7e)...... ok
iPXE> ifstat net1
net1: 00:17:3c:02:d6:7e using i210-2 on 0000:0f:00.0 (Ethernet) [open]
[Link:up, TX:9 TXE:0 RX:57 RXE:26]
[RXE: 5 x "Error 0x440e6083 (https://ipxe.org/440e6083)"]
[RXE: 21 x "The socket is not connected (https://ipxe.org/380f6093)"]
```