### PR TITLE
[dhcp] Unregister ProxyDHCP and PXEBS settings on a successful DHCPACK

### DIFF
--- a/src/net/udp/dhcp.c
+++ b/src/net/udp/dhcp.c
@@ -601,6 +601,12 @@ static void dhcp_request_rx ( struct dhcp_session *dhcp,
 		return;
 	}
 
+	/* Unregister any existing ProxyDHCP or PXEBS settings */
+	if ( ( settings = find_settings ( PROXYDHCP_SETTINGS_NAME ) ) != NULL )
+		unregister_settings ( settings );
+	if ( ( settings = find_settings ( PXEBS_SETTINGS_NAME ) ) != NULL )
+		unregister_settings ( settings );
+
 	/* Perform ProxyDHCP if applicable */
 	if ( dhcp->proxy_offer /* Have ProxyDHCP offer */ &&
 	     ( ! dhcp->no_pxedhcp ) /* ProxyDHCP not disabled */ ) {


### PR DESCRIPTION
When a DHCP transaction does not result in the registration of a new "proxydhcp" or "pxebs" settings block, any existing settings blocks are currently left unaltered.

This can cause surprising behaviour.  For example: when chainloading iPXE, the "proxydhcp" and "pxebs" settings blocks may be prepopulated using cached values from the previous PXE bootloader.  If iPXE performs a subsequent DHCP request, then the DHCP or ProxyDHCP servers may choose to respond differently to iPXE.  The response may choose to omit the ProxyDHCP or PXEBS stages, in which case no new "proxydhcp" or "pxebs" settings blocks may be registered.  This will result in iPXE using a combination of both old and new DHCP responses.

Fix by assuming that a successful DHCPACK effectively acquires ownership of the "proxydhcp" and "pxebs" settings blocks, and that any existing settings blocks should therefore be unregistered.

Fixes: #913 

Reported-by: Henry Tung <htung@palantir.com>