### PR TITLE
Correct memcpy issue resulting in no SNI for TLS connections

### DIFF
--- a/src/net/tls.c
+++ b/src/net/tls.c
@@ -1196,7 +1196,7 @@ static int tls_client_hello ( struct tls_connection *tls,
 	hello.extensions.server_name.list[0].len
 		= htons ( sizeof ( hello.extensions.server_name.list[0].name ));
 	memcpy ( hello.extensions.server_name.list[0].name, session->name,
-		 sizeof ( hello.extensions.server_name.list[0].name ) );
+		 name_len );
 	hello.extensions.max_fragment_length_type
 		= htons ( TLS_MAX_FRAGMENT_LENGTH );
 	hello.extensions.max_fragment_length_len


### PR DESCRIPTION
Line 1199 in tls.c determines the size of the buffer to copy for the server name for TLS using `sizeof()`.  However `sizeof()` is determined at compile time, and the length of the buffer is determined at runtime, resulting in the length copied always being 0 bytes.

This pull request changes the memcpy to use the already existing `name_len` variable, which contains the length determined at runtime, resulting in the TLS server_name extension having the name in it as expected.