### PR TITLE
[interface] Initialize temporary interface in intf_shutdown()

### DIFF
--- a/src/core/interface.c
+++ b/src/core/interface.c
@@ -276,7 +276,7 @@ void intf_close ( struct interface *intf, int rc ) {
  * unplugs the interface.
  */
 void intf_shutdown ( struct interface *intf, int rc ) {
-	struct interface tmp;
+	struct interface tmp = INTF_INIT ( null_intf_desc );
 
 	DBGC ( INTF_COL ( intf ), "INTF " INTF_FMT " shutting down (%s)\n",
 	       INTF_DBG ( intf ), strerror ( rc ) );


### PR DESCRIPTION
Initialize the temporary interface to a null interface.

This prevents GPFs due to dereferencing garbage in intf_close() and intf_unplug() when interface.c is built with debug messages enabled.