### PR TITLE
Support for creating ipxe.iso on non-x86

### DIFF
--- a/src/Makefile.efi
+++ b/src/Makefile.efi
@@ -52,8 +52,8 @@ $(BIN)/efidrv.cab : $(BIN)/alldrv.efis # $(ALL_drv.efi) is not yet defined
 
 $(BIN)/%.iso : $(BIN)/%.efi util/genfsimg
 	$(QM)$(ECHO) "  [GENFSIMG] $@"
-	$(Q)util/genfsimg -o $@ $<
+	$(Q)util/genfsimg -a $(ARCH) -o $@ $<
 
 $(BIN)/%.usb : $(BIN)/%.efi util/genfsimg
 	$(QM)$(ECHO) "  [GENFSIMG] $@"
-	$(Q)util/genfsimg -o $@ $<
+	$(Q)util/genfsimg -a $(ARCH) -o $@ $<

--- a/src/arch/x86/Makefile.pcbios
+++ b/src/arch/x86/Makefile.pcbios
@@ -58,13 +58,13 @@ LIST_NAME_isarom := ROMS
 NON_AUTO_MEDIA	+= iso
 $(BIN)/%.iso : $(BIN)/%.lkrn util/genfsimg
 	$(QM)$(ECHO) "  [GENFSIMG] $@"
-	$(Q)util/genfsimg -o $@ $<
+	$(Q)util/genfsimg -a x86 -o $@ $<
 
 # FAT filesystem images (via syslinux)
 NON_AUTO_MEDIA	+= sdsk
 $(BIN)/%.sdsk : $(BIN)/%.lkrn util/genfsimg
 	$(QM)$(ECHO) "  [GENFSIMG] $@"
-	$(Q)util/genfsimg -o $@ $<
+	$(Q)util/genfsimg -a x86 -o $@ $<
 
 # rule to write disk images to /dev/fd0
 NON_AUTO_MEDIA	+= fd0

--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -122,11 +122,15 @@ copy_syslinux_file() {
 OUTFILE=
 PAD=0
 SCRIPT=
-while getopts "hlo:p:s:" OPTION ; do
+ARCH=
+while getopts "hla:o:p:s:" OPTION ; do
     case "${OPTION}" in
 	h)
 	    help
 	    exit 0
+	    ;;
+	a)
+	    ARCH="${OPTARG}"
 	    ;;
 	o)
 	    OUTFILE="${OPTARG}"
@@ -234,10 +238,14 @@ done
 #
 if [ -n "${ISOIMG}" ] ; then
     ISOARGS="-J -R -l"
-    copy_syslinux_file "isolinux.bin" "${ISODIR}"
-    copy_syslinux_file "ldlinux.c32" "${ISODIR}" 2>/dev/null || true
-    ISOARGS="${ISOARGS} -no-emul-boot -eltorito-boot isolinux.bin"
-    ISOARGS="${ISOARGS} -boot-load-size 4 -boot-info-table"
+    case ${ARCH} in
+      i386|x86|x86_64)
+	copy_syslinux_file "isolinux.bin" "${ISODIR}"
+	copy_syslinux_file "ldlinux.c32" "${ISODIR}" 2>/dev/null || true
+	ISOARGS="${ISOARGS} -no-emul-boot -eltorito-boot isolinux.bin"
+	ISOARGS="${ISOARGS} -boot-load-size 4 -boot-info-table"
+	;;
+    esac
     if [ -n "${EFI}" ] ; then
 	ISOARGS="${ISOARGS} -eltorito-alt-boot -no-emul-boot -e esp.img"
     else
@@ -273,7 +281,11 @@ if [ -n "${FATIMG}" ] ; then
     mformat -v iPXE -i "${FATIMG}" ${FATARGS} ::
     mcopy -i "${FATIMG}" -s "${FATDIR}"/* ::
     if [ "${BIOSDIR}" = "${FATDIR}" ] ; then
-	syslinux "${FATIMG}"
+      case ${ARCH} in
+	i386|x86|x86_64)
+	  syslinux "${FATIMG}"
+	  ;;
+      esac
     fi
 fi
 


### PR DESCRIPTION
syslinux only supports the x86 platform, other platforms do not. 
On non-x86 platforms, only UEFI is supported, and steps related to syslinux need to be skipped.

Test passed on loong64 with `make bin-loong64-efi/ipxe.iso`.