### PR TITLE
[interface] Fix debug message values for temporary interfaces

### DIFF
--- a/src/core/interface.c
+++ b/src/core/interface.c
@@ -285,6 +285,7 @@ void intf_shutdown ( struct interface *intf, int rc ) {
 	intf_nullify ( intf );
 
 	/* Transfer destination to temporary interface */
+	intf_temp_init ( &tmp, intf );
 	tmp.dest = intf->dest;
 	intf->dest = &null_intf;
 

--- a/src/core/xfer.c
+++ b/src/core/xfer.c
@@ -60,7 +60,7 @@ static struct xfer_metadata dummy_metadata;
  * @ret rc		Return status code
  */
 int xfer_vredirect ( struct interface *intf, int type, va_list args ) {
-	struct interface tmp = INTF_INIT ( null_intf_desc );
+	struct interface tmp;
 	struct interface *dest;
 	xfer_vredirect_TYPE ( void * ) *op =
 		intf_get_dest_op_no_passthru ( intf, xfer_vredirect, &dest );
@@ -85,6 +85,7 @@ int xfer_vredirect ( struct interface *intf, int type, va_list args ) {
 		 * If redirection fails, then send intf_close() to the
 		 * parent interface.
 		 */
+		intf_temp_init ( &tmp, intf );
 		intf_plug ( &tmp, dest );
 		rc = xfer_vreopen ( dest, type, args );
 		if ( rc == 0 ) {


### PR DESCRIPTION
The interface debug message values constructed by INTF_DBG() et al rely on the interface being embedded within a containing object.  This assumption is not valid for the temporary outbound-only interfaces constructed on the stack by intf_shutdown() and xfer_vredirect().

Formalise the notion of a temporary outbound-only interface as having a NULL interface descriptor, and overload the "original interface descriptor" field to contain a pointer to the original interface that the temporary interface is shadowing.

Fixes: #982 

Originally-fixed-by: Vincent Fazio <vfazio@gmail.com>