### PR TITLE
virtio-pci.c: Fix implementation of vpm_ioread32()

### DIFF
--- a/src/drivers/bus/virtio-pci.c
+++ b/src/drivers/bus/virtio-pci.c
@@ -230,10 +230,10 @@ u32 vpm_ioread32(struct virtio_pci_modern_device *vdev,
     uint32_t data;
     switch (region->flags & VIRTIO_PCI_REGION_TYPE_MASK) {
     case VIRTIO_PCI_REGION_MEMORY:
-        data = readw(region->base + offset);
+        data = readl(region->base + offset);
         break;
     case VIRTIO_PCI_REGION_PORT:
-        data = inw(region->base + offset);
+        data = inl(region->base + offset);
         break;
     case VIRTIO_PCI_REGION_PCI_CONFIG:
         prep_pci_cfg_cap(vdev, region, offset, 4);


### PR DESCRIPTION
vpm_ioread32() only reads 16-bit of data due to a copy and paste bug (using readw/inw like vpm_ioread16() instead of readl/inl). This causes the virtio-net driver of ipxe to fail with the virtio-net device emulation of VirtualBox because it is quite strict regarding register access width and alignment which must be the natural register width.