### PR TITLE
[libc] Use wall clock time as seed for the (non-cryptographic) RNG

### DIFF
--- a/src/core/random.c
+++ b/src/core/random.c
@@ -6,8 +6,9 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
+#include <stddef.h>
 #include <stdlib.h>
-#include <ipxe/timer.h>
+#include <time.h>
 
 static int32_t rnd_seed = 0;
 
@@ -30,8 +31,9 @@ void srandom ( unsigned int seed ) {
 long int random ( void ) {
 	int32_t q;
 
-	if ( ! rnd_seed ) /* Initialize linear congruential generator */
-		srandom ( currticks() );
+	/* Initialize linear congruential generator */
+	if ( ! rnd_seed )
+		srandom ( time ( NULL ) );
 
 	/* simplified version of the LCG given in Bruce Schneier's
 	   "Applied Cryptography" */


### PR DESCRIPTION
We currently use the number of timer ticks since power-on as a seed for the non-cryptographic RNG implemented by random().  Since iPXE is often executed directly after power-on, and since the timer tick resolution is generally low, this can often result in identical seed values being used on each cold boot attempt.

As of commit 41f786c ("[settings] Add "unixtime" builtin setting to expose the current time"), the current wall-clock time is always available within the default build of iPXE.  Use this time instead, to introduce variability between cold boot attempts on the same host. (Note that variability between different hosts is obtained by using the MAC address as an additional seed value.)

This has no effect on the separate DRBG used by cryptographic code.

Fixes: #1042 

Suggested-by: Heiko <heik0@xs4all.nl>