### PR TITLE
Fix EAPoL-Start behaviour to allow slow authentication exchanges to succeed

### DIFF
--- a/src/include/ipxe/eapol.h
+++ b/src/include/ipxe/eapol.h
@@ -42,10 +42,15 @@ struct eapol_supplicant {
 	struct eap_supplicant eap;
 	/** EAPoL-Start retransmission timer */
 	struct retry_timer timer;
+	/** EAPoL-Start transmission count */
+	unsigned int count;
 };
 
 /** Delay between EAPoL-Start packets */
 #define EAPOL_START_INTERVAL ( 2 * TICKS_PER_SEC )
+
+/** Maximum number of EAPoL-Start packets to transmit */
+#define EAPOL_START_COUNT 3
 
 /** An EAPoL handler */
 struct eapol_handler {


### PR DESCRIPTION
EAP exchanges may take a long time to reach a final status, especially when relying upon MAC Authentication Bypass (MAB).  Our current behaviour of sending EAPoL-Start every few seconds until a final status is obtained can prevent these exchanges from ever completing.

Fix by suppressing EAPoL-Start once EAP is in progress, and by limiting the total number of EAPoL-Start packets sent per authentication attempt.

Fixes: #1048 