### PR TITLE
[build] Use a deterministic serial number in sdsk

### DIFF
--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -269,6 +269,7 @@ if [ -n "${FATIMG}" ] ; then
 	FATSIZE=$(( FATCYLS * 504 ))
 	FATARGS="-s 63 -h 16 -t ${FATCYLS}"
     fi
+    FATARGS="${FATARGS} -N 0x$(sha1sum "${FATDIR}"/* | cut -c 1-40 | sha1sum | cut -c 1-8)"
     truncate -s "${FATSIZE}K" "${FATIMG}"
     mformat -v iPXE -i "${FATIMG}" ${FATARGS} ::
     mcopy -i "${FATIMG}" -s "${FATDIR}"/* ::


### PR DESCRIPTION
The new deterministic serial number is based on the content hash.

Without this patch, `ipxe.sdsk` varied in the random 4-byte serial number stored by `mformat` at offset 0x27.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).