### PR TITLE
Fix .gitignore files so bin and local dirs are not lost

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,4 @@
 .toolcheck
 .echocheck
 TAGS*
-bin*
+bin-*

--- a/src/bin/.gitignore
+++ b/src/bin/.gitignore
@@ -1,1 +1,2 @@
 *
+!.gitignore

--- a/src/config/local/.gitignore
+++ b/src/config/local/.gitignore
@@ -1,1 +1,2 @@
 *
+!.gitignore


### PR DESCRIPTION
I ran into a problem after I cloned ipxe, then committed that tree to another repo, iPXE would not build in the new repo. I found it was because the bin and config/local directories were not committed in the new repo due to .gitignore rules. This PR updates the .gitignore rules so the required directories are not excluded when committing the tree.