### PR TITLE
elf2efi: ignore LoongArch PC-relative relocations and relaxations

### DIFF
--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -140,6 +140,12 @@
 #ifndef R_LARCH_64
 #define R_LARCH_64 2
 #endif
+#ifndef R_LARCH_B16
+#define R_LARCH_B16 64
+#endif
+#ifndef R_LARCH_B21
+#define R_LARCH_B21 65
+#endif
 #ifndef R_LARCH_B26
 #define R_LARCH_B26 66
 #endif
@@ -154,6 +160,12 @@
 #endif
 #ifndef R_LARCH_GOT_PC_LO12
 #define R_LARCH_GOT_PC_LO12 76
+#endif
+#ifndef R_LARCH_RELAX
+#define R_LARCH_RELAX 100
+#endif
+#ifndef R_LARCH_PCREL20_S2
+#define R_LARCH_PCREL20_S2 103
 #endif
 #ifndef R_X86_64_GOTPCRELX
 #define R_X86_64_GOTPCRELX 41
@@ -849,14 +861,22 @@ static void process_reloc ( struct elf_file *elf, const Elf_Shdr *shdr,
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_LDST32_ABS_LO12_NC ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_LDST64_ABS_LO12_NC ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_LDST128_ABS_LO12_NC ) :
+		case ELF_MREL ( EM_LOONGARCH, R_LARCH_B16):
+		case ELF_MREL ( EM_LOONGARCH, R_LARCH_B21):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_B26):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_PCALA_HI20 ):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_PCALA_LO12 ):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_GOT_PC_HI20 ):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_GOT_PC_LO12 ):
+		case ELF_MREL ( EM_LOONGARCH, R_LARCH_PCREL20_S2 ):
 			/* Skip PC-relative relocations; all relative
 			 * offsets remain unaltered when the object is
 			 * loaded.
+			 */
+			break;
+		case ELF_MREL ( EM_LOONGARCH, R_LARCH_RELAX ):
+			/* Relocation can be relaxed (optimized out).
+			 * Ignore it for now.
 			 */
 			break;
 		case ELF_MREL ( EM_X86_64, R_X86_64_32 ) :


### PR DESCRIPTION
With this patch I can (cross-) compile ipxe for LoongArch UEFI with GCC 13.2 and binutils 2.41+ (and netboot LoongArch machines).

Several new relocations types have been added in LoongArch ABI version 2.10. In particular
- R_LARCH_B16 (18-bit PC-relative jump)
- R_LARCH_B21 (23-bit PC-relative jump)
- R_LARCH_PCREL20_S2 (22-bit PC-relative offset)

Also relocation relaxations have been introduced. Recent GCC (13.2) and binutils 2.41+ use these types of relocations, which confuses elf2efi tool. As a result ipxe EFI images for LoongArch fail to build with the following error:
```
make ARCH=loong64 CROSS_COMPILE=loongarch64-linux-gnu- bin-loong64-efi/ipxe.efi
[skipped lots of boring lines]
Unrecognised relocation type 103
```

To avoid the problem
- Ignore R_LARCH_B{16,21} and R_LARCH_PCREL20_S2 (just like other PC-relative relocations)
- Ignore relaxations (R_LARCH_RELAX) for now. Relocation relaxations are basically optimizations, omitting them results in correct binary (although it might be suboptimal).

Fixes: #1159