### PR TITLE
[ipv6] Support/Use DHCPv6 assigned address if there is no Prefix option

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -1791,6 +1791,9 @@ const struct setting_type setting_type_ipv6 __setting_type = {
 /** IPv6 settings scope */
 const struct settings_scope dhcpv6_scope;
 
+/** NDP settings scope */
+const struct settings_scope ndp_settings_scope;
+
 /**
  * Integer setting type indices
  *

--- a/src/include/ipxe/dhcpv6.h
+++ b/src/include/ipxe/dhcpv6.h
@@ -19,6 +19,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 /** DHCPv6 client port */
 #define DHCPV6_CLIENT_PORT 546
 
+/** DHCPv6 assigned IPv6 address prefix length */
+#define DHCPV6_LEASE_PREFIX_LEN 128
+
 /**
  * A DHCPv6 option
  *

--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -291,6 +291,9 @@ extern const struct settings_scope ipv6_settings_scope;
 /** DHCPv6 setting scope */
 extern const struct settings_scope dhcpv6_scope;
 
+/** NDP setting scope */
+extern const struct settings_scope ndp_settings_scope;
+
 /**
  * A generic settings block
  *

--- a/src/net/ndp.c
+++ b/src/net/ndp.c
@@ -618,9 +618,6 @@ struct ndp_settings {
 	union ndp_option options[0];
 };
 
-/** NDP settings scope */
-static const struct settings_scope ndp_settings_scope;
-
 /**
  * Construct NDP tag
  *
@@ -674,7 +671,31 @@ static const struct settings_scope ndp_settings_scope;
 static int ndp_applies ( struct settings *settings __unused,
 			 const struct setting *setting ) {
 
-	return ( setting->scope == &ndp_settings_scope );
+	return ( ( setting->scope == &ndp_settings_scope ) ||
+			 ( setting_cmp ( setting, &gateway6_setting ) == 0 ));
+}
+
+/**
+ * Fetch gateway of NDP
+ *
+ * @v dhcpset	NDP settings
+ * @v data		Buffer to fill with setting data
+ * @v len		Length of buffer
+ * @ret len		Length of setting data, or negative error
+ */
+static int ndp_fetch_gateway6 (struct ndp_settings *ndpset, void *data, size_t len ) {
+	struct in6_addr *gateway = &ndpset->router;
+
+	/* Do nothing unless a gateway address exists */
+	if ( IN6_IS_ADDR_UNSPECIFIED ( gateway ) )
+		return -ENOENT;
+
+	/* Copy gateway address */
+	if ( len > sizeof ( *gateway ) )
+		len = sizeof ( *gateway );
+	memcpy ( data, gateway, len );
+
+	return sizeof ( *gateway );
 }
 
 /**
@@ -702,6 +723,10 @@ static int ndp_fetch ( struct settings *settings,
 	size_t offset;
 	size_t option_len;
 	void *option_data;
+
+	/* Handle gateway address */
+	if ( setting_cmp ( setting, &gateway6_setting ) == 0 )
+		return ndp_fetch_gateway6 ( ndpset, data, len );
 
 	/* Parse setting tag */
 	tag_type = NDP_TAG_TYPE ( setting->tag );

--- a/src/net/udp/dhcpv6.c
+++ b/src/net/udp/dhcpv6.c
@@ -283,7 +283,26 @@ static int dhcpv6_applies ( struct settings *settings __unused,
 			    const struct setting *setting ) {
 
 	return ( ( setting->scope == &dhcpv6_scope ) ||
-		 ( setting_cmp ( setting, &ip6_setting ) == 0 ) );
+		 ( setting_cmp ( setting, &ip6_setting ) == 0 ) ||
+		 ( setting_cmp ( setting, &len6_setting ) == 0 ) );
+}
+
+/**
+ * Fetch prefix len of DHCPv6 leased address
+ *
+ * @v dhcpset		DHCPv6 settings
+ * @v data		Buffer to fill with setting data
+ * @v len		Length of buffer
+ * @ret len		Length of setting data, or negative error
+ */
+static int dhcpv6_fetch_len6_len (void *data, size_t len ) {
+	uint8_t len6 = DHCPV6_LEASE_PREFIX_LEN;
+
+	if ( len > sizeof ( len6 ) )
+		len = sizeof ( len6 );
+	memcpy ( data, &len6, len );
+
+	return sizeof ( len6 );
 }
 
 /**
@@ -330,6 +349,10 @@ static int dhcpv6_fetch ( struct settings *settings,
 	/* Handle leased address */
 	if ( setting_cmp ( setting, &ip6_setting ) == 0 )
 		return dhcpv6_fetch_lease ( dhcpv6set, data, len );
+
+	/* Handle leased address prefix len */
+	if ( setting_cmp ( setting, &len6_setting ) == 0 )
+		return dhcpv6_fetch_len6_len ( data, len );
 
 	/* Find option */
 	option = dhcpv6_option ( &dhcpv6set->options, setting->tag );


### PR DESCRIPTION
It is a valid case that RAs dont have any Prefix options but still set the router/gateway when they are received. In such a case, the ipv6 address received via DHCPv6 needs to use the RA sender address as gateway.