### PR TITLE
[ipv6] Support/Use DHCPv6 assigned address if there is no Prefix option in RA

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -1791,6 +1791,9 @@ const struct setting_type setting_type_ipv6 __setting_type = {
 /** IPv6 settings scope */
 const struct settings_scope dhcpv6_scope;
 
+/** NDP settings scope */
+const struct settings_scope ndp_settings_scope;
+
 /**
  * Integer setting type indices
  *

--- a/src/include/ipxe/dhcpv6.h
+++ b/src/include/ipxe/dhcpv6.h
@@ -19,6 +19,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 /** DHCPv6 client port */
 #define DHCPV6_CLIENT_PORT 546
 
+/** DHCPv6 assigned IPv6 address prefix length */
+#define DHCPV6_LEASE_PREFIX_LEN 128
+
 /**
  * A DHCPv6 option
  *

--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -291,6 +291,9 @@ extern const struct settings_scope ipv6_settings_scope;
 /** DHCPv6 setting scope */
 extern const struct settings_scope dhcpv6_scope;
 
+/** NDP setting scope */
+extern const struct settings_scope ndp_settings_scope;
+
 /**
  * A generic settings block
  *

--- a/src/net/udp/dhcpv6.c
+++ b/src/net/udp/dhcpv6.c
@@ -283,7 +283,26 @@ static int dhcpv6_applies ( struct settings *settings __unused,
 			    const struct setting *setting ) {
 
 	return ( ( setting->scope == &dhcpv6_scope ) ||
-		 ( setting_cmp ( setting, &ip6_setting ) == 0 ) );
+		 ( setting_cmp ( setting, &ip6_setting ) == 0 ) ||
+		 ( setting_cmp ( setting, &len6_setting ) == 0 ) );
+}
+
+/**
+ * Fetch prefix len of DHCPv6 leased address
+ *
+ * @v dhcpset		DHCPv6 settings
+ * @v data		Buffer to fill with setting data
+ * @v len		Length of buffer
+ * @ret len		Length of setting data, or negative error
+ */
+static int dhcpv6_fetch_len6_len (void *data, size_t len ) {
+	uint8_t len6 = DHCPV6_LEASE_PREFIX_LEN;
+
+	if ( len > sizeof ( len6 ) )
+		len = sizeof ( len6 );
+	memcpy ( data, &len6, len );
+
+	return sizeof ( len6 );
 }
 
 /**
@@ -330,6 +349,10 @@ static int dhcpv6_fetch ( struct settings *settings,
 	/* Handle leased address */
 	if ( setting_cmp ( setting, &ip6_setting ) == 0 )
 		return dhcpv6_fetch_lease ( dhcpv6set, data, len );
+
+	/* Handle leased address prefix len */
+	if ( setting_cmp ( setting, &len6_setting ) == 0 )
+		return dhcpv6_fetch_len6_len ( data, len );
 
 	/* Find option */
 	option = dhcpv6_option ( &dhcpv6set->options, setting->tag );


### PR DESCRIPTION
It is a valid case that RAs dont have any Prefix options but still set the router/gateway when they are received. In such a case, the ipv6 address received via DHCPv6 needs to use the RA sender address as gateway.

This is outlined in the linked RFC 4861 section 6.3.4
https://www.rfc-editor.org/rfc/rfc4861#section-6.3.4

The current implementation doesnt take into the consideration the received RA sender address as a gateway, as required by 
RFC 4861, when there is no Prefix option attached to the RA message.

This PR is an attempt to correct this behavior.
This is related to the issue here as well: #1141 and to #449