### PR TITLE
New iPXE setting for efi HTTPS boot uri source.

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -2443,6 +2443,13 @@ const struct setting root_path_setting __setting ( SETTING_SANBOOT, root-path)={
 	.type = &setting_type_string,
 };
 
+/** Root path setting */
+const struct setting uri_path_setting __setting ( SETTING_BOOT, uri-path)={
+	.name = "uri-path",
+	.description = "HTTPS uri source from uEFI",
+	.type = &setting_type_string,
+};
+
 /** SAN filename setting */
 const struct setting san_filename_setting __setting ( SETTING_SANBOOT,
 						      san-filename ) = {

--- a/src/include/ipxe/efi/efi_uripath.h
+++ b/src/include/ipxe/efi/efi_uripath.h
@@ -1,0 +1,17 @@
+#ifndef _IPXE_EFI_URIPATH_H
+#define _IPXE_EFI_URIPATH_H
+
+/** @file
+ *
+ * EFI uri-path
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <ipxe/efi/efi.h>
+
+extern int efi_set_uri_path ( EFI_HANDLE device,
+		EFI_DEVICE_PATH_PROTOCOL *path );
+
+#endif /* _IPXE_EFI_URIPATH_H */

--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -453,6 +453,8 @@ filename_setting __setting ( SETTING_BOOT, filename );
 extern const struct setting
 root_path_setting __setting ( SETTING_SANBOOT, root-path );
 extern const struct setting
+uri_path_setting __setting ( SETTING_BOOT, uri-path );
+extern const struct setting
 san_filename_setting __setting ( SETTING_SANBOOT, san-filename );
 extern const struct setting
 username_setting __setting ( SETTING_AUTH, username );

--- a/src/interface/efi/efi_settings.c
+++ b/src/interface/efi/efi_settings.c
@@ -36,6 +36,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #include <ipxe/settings.h>
 #include <ipxe/init.h>
 #include <ipxe/efi/efi.h>
+#include <ipxe/efi/efi_uripath.h>
 #include <ipxe/efi/efi_strings.h>
 
 /** EFI variable settings scope */
@@ -220,7 +221,12 @@ static struct settings efivars = {
  *
  */
 static void efivars_init ( void ) {
-	int rc;
+	int rc;	
+	EFI_HANDLE device = efi_loaded_image->DeviceHandle;
+	EFI_DEVICE_PATH_PROTOCOL *devpath = efi_loaded_image_path;
+	
+	/* Locate uri-path, if any */
+	efi_set_uri_path ( device, devpath );
 
 	/* Register settings block */
 	if ( ( rc = register_settings ( &efivars, NULL, "efi" ) ) != 0 ) {

--- a/src/interface/efi/efi_uripath.c
+++ b/src/interface/efi/efi_uripath.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <string.h>
+#include <errno.h>
+#include <ipxe/uri.h>
+#include <ipxe/settings.h>
+#include <ipxe/efi/efi.h>
+#include <ipxe/efi/efi_path.h>
+#include <ipxe/efi/efi_uripath.h>
+
+
+/** @file
+ *
+ * EFI uri source
+ *
+ */
+
+/**
+ * Identify uri source 
+ *
+ * @v device		Device handle
+ * @v path		Device path
+ * @ret rc		Return status code
+ */
+int efi_set_uri_path ( EFI_HANDLE device,
+			       EFI_DEVICE_PATH_PROTOCOL *path ) {
+
+	EFI_DEVICE_PATH_PROTOCOL * next;
+	URI_DEVICE_PATH * uri;
+	size_t uri_len;
+	int rc;
+
+	/* Scan for uri device path */
+	for ( ; ( next = efi_path_next ( path ) ) ; path = next ) {
+		if ( ( path->Type == MESSAGING_DEVICE_PATH ) &&
+		     ( path->SubType == MSG_URI_DP ) ) {
+			uri = container_of ( path, URI_DEVICE_PATH, Header );
+			uri_len = strlen ( uri->Uri ) ;
+			DBGC ( device , "EFI found URI Device Path [%s] %ld\n",
+				uri->Uri, uri_len );
+
+			/* Store in 'uri-src-path' setting */
+			if ( (rc = store_setting ( NULL, &uri_path_setting ,
+				uri->Uri , uri_len ) ) != 0 ) {
+				DBGC ( device, "Unable to save URI path into settings %s\n" ,
+					strerror ( rc ));
+				return rc;
+			}
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
uEFI provides a method for retrieving the source path of the binary, even when an uEFI binary was booted over HTTPS.

The source is stored as a Device Path, and @mcp30 already has a solution in efi_int() to extract out the source Device Path from uEFI, it's just a matter of parsing and saving the result so any iPXE script can leverage the path.

This is of importance on machines like the Lenovo m80q, which will ONLY HTTPS boot from Secure Boot signed binaries. It becomes economically difficult to hard code a server address into the singed binary for each customer/site. It would be preferred to find the source uri using this method with a single signed file.

Tested and verified on my Dell Optiplex 7010. 

**Implementation Notes**: _The basic structure of this PR appears to be correct from my limited iPXE experience, although I'm not sure if `efivars_init()` is the best place to start. If there is feedback, I can work to fix, however I would not be offended if we dump my code, and choose to rewrite._ 

cc: @Hammarskjold 
Issue: #138 

