### PR TITLE
[snp] Pad transmit buffer length to work around buggy vendor drivers

### DIFF
--- a/src/drivers/net/efi/nii.c
+++ b/src/drivers/net/efi/nii.c
@@ -30,6 +30,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #include <errno.h>
 #include <ipxe/netdevice.h>
 #include <ipxe/ethernet.h>
+#include <ipxe/if_ether.h>
 #include <ipxe/umalloc.h>
 #include <ipxe/efi/efi.h>
 #include <ipxe/efi/efi_driver.h>
@@ -997,6 +998,12 @@ static int nii_transmit ( struct net_device *netdev,
 		netdev_tx_defer ( netdev, iobuf );
 		return 0;
 	}
+
+	/* Pad to minimum Ethernet length, to work around underlying
+	 * drivers that do not correctly handle frame padding
+	 * themselves.
+	 */
+	iob_pad ( iobuf, ETH_ZLEN );
 
 	/* Construct parameter block */
 	memset ( &cpb, 0, sizeof ( cpb ) );

--- a/src/drivers/net/efi/snpnet.c
+++ b/src/drivers/net/efi/snpnet.c
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
 #include <ipxe/iobuf.h>
 #include <ipxe/netdevice.h>
 #include <ipxe/ethernet.h>
+#include <ipxe/if_ether.h>
 #include <ipxe/vsprintf.h>
 #include <ipxe/timer.h>
 #include <ipxe/efi/efi.h>
@@ -186,6 +187,12 @@ static int snpnet_transmit ( struct net_device *netdev,
 		netdev_tx_defer ( netdev, iobuf );
 		return 0;
 	}
+
+	/* Pad to minimum Ethernet length, to work around underlying
+	 * drivers that do not correctly handle frame padding
+	 * themselves.
+	 */
+	iob_pad ( iobuf, ETH_ZLEN );
 
 	/* Transmit packet */
 	if ( ( efirc = snp->snp->Transmit ( snp->snp, 0, iob_len ( iobuf ),


### PR DESCRIPTION
The Mellanox/Nvidia UEFI SNP driver is built from the same codebase as the iPXE driver, and appears to contain the bug that was fixed in commit c11734e ("[golan] Use ETH_HLEN for inline header size").  This results in identical failures when using the SNP interface (via e.g. snponly.efi) to drive a Mellanox card while EAPoL is enabled.

Work around the underlying UEFI SNP driver bug by padding transmit I/O buffers to the minimum Ethernet frame length before passing them to the underlying SNP driver's Transmit() function.

This padding is not technically necessary, since almost all modern hardware will insert transmit padding as necessary (and where the hardware does not support doing so, the underlying SNP driver is responsible for adding any necessary padding).  However, it is guaranteed to be harmless (other than a miniscule performance impact): the Ethernet specification requires zero padding up to the minimum frame length for packets that are transmitted onto the wire, and so the receiver will see the same packet whether or not we manually insert this padding in software.

The additional padding causes the underlying Mellanox SNP driver to avoid its faulty code path, since it will never be asked to transmit a very short packet.

Fixes: #1091 