### PR TITLE
[netdevice] Add ll-protocol setting

### DIFF
--- a/src/include/ipxe/settings.h
+++ b/src/include/ipxe/settings.h
@@ -471,6 +471,8 @@ mac_setting __setting ( SETTING_NETDEV, mac );
 extern const struct setting
 busid_setting __setting ( SETTING_NETDEV, busid );
 extern const struct setting
+linktype_setting __setting ( SETTING_NETDEV, linktype );
+extern const struct setting
 user_class_setting __setting ( SETTING_HOST_EXTRA, user-class );
 extern const struct setting
 vendor_class_setting __setting ( SETTING_HOST_EXTRA, vendor-class );

--- a/src/net/netdev_settings.c
+++ b/src/net/netdev_settings.c
@@ -65,6 +65,11 @@ const struct setting busid_setting __setting ( SETTING_NETDEV, busid ) = {
 	.description = "Bus ID",
 	.type = &setting_type_hex,
 };
+const struct setting linktype_setting __setting ( SETTING_NETDEV, linktype ) = {
+	.name = "linktype",
+	.description = "Link-layer type",
+	.type = &setting_type_string,
+};
 const struct setting chip_setting __setting ( SETTING_NETDEV, chip ) = {
 	.name = "chip",
 	.description = "Chip",
@@ -220,6 +225,22 @@ static int netdev_fetch_busid ( struct net_device *netdev, void *data,
 }
 
 /**
+ * Fetch link layer type setting
+ *
+ * @v netdev		Network device
+ * @v data		Buffer to fill with setting data
+ * @v len		Length of buffer
+ * @ret len		Length of setting data, or negative error
+ */
+static int netdev_fetch_linktype ( struct net_device *netdev, void *data,
+				   size_t len ) {
+	const char *linktype = netdev->ll_protocol->name;
+
+	strncpy ( data, linktype, len );
+	return strlen ( linktype );
+}
+
+/**
  * Fetch chip setting
  *
  * @v netdev		Network device
@@ -281,6 +302,7 @@ static struct netdev_setting_operation netdev_setting_operations[] = {
 	{ &bustype_setting, NULL, netdev_fetch_bustype },
 	{ &busloc_setting, NULL, netdev_fetch_busloc },
 	{ &busid_setting, NULL, netdev_fetch_busid },
+	{ &linktype_setting, NULL, netdev_fetch_linktype },
 	{ &chip_setting, NULL, netdev_fetch_chip },
 	{ &ifname_setting, NULL, netdev_fetch_ifname },
 };


### PR DESCRIPTION
This PR continues the previous, accidentally closed PR https://github.com/ipxe/ipxe/pull/1047

Added a new setting that allows using this property in scripts. This can be useful in order to skip configuring
interfaces using their link layer protocol or, conversely, configure only selected interface type (Ethernet, IPoIB, etc.). In systems which have 8+ IB cards and one Eth card, this script can save 80+ seconds to boot by skipping await of IB's to be configured

Example script:
```
set idx:int32 0
:loop
isset ${net${idx}/mac} || exit 0
iseq ${net${idx}/ll-protocol} IPoIB && goto try_next ||
autoboot net${idx} ||
:try_next
inc idx && goto loop
```