### PR TITLE
fix: extraneous space prevents Makefile.housekeeping from generating local headers

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1469,7 +1469,7 @@ CONFIG_HEADERS := $(patsubst config/%,%,$(wildcard config/*.h))
 CONFIG_LOCAL_HEADERS := $(foreach HEADER,$(CONFIG_HEADERS),\
 				  config/local/$(HEADER))
 
-$(CONFIG_LOCAL_HEADERS) :
+$(CONFIG_LOCAL_HEADERS):
 	$(Q)$(TOUCH) $@
 
 .PRECIOUS : $(CONFIG_LOCAL_HEADERS)


### PR DESCRIPTION
```
root@3553668afe97:/ipxe/src# make bin-x86_64-efi/ipxe.efi
  [BUILD] bin-x86_64-efi/__divdi3.o
  [BUILD] bin-x86_64-efi/__divmoddi4.o
  [BUILD] bin-x86_64-efi/__moddi3.o
  [BUILD] bin-x86_64-efi/__udivdi3.o
  [BUILD] bin-x86_64-efi/__udivmoddi4.o
  [BUILD] bin-x86_64-efi/__umoddi3.o
  [BUILD] bin-x86_64-efi/icc.o
  [BUILD] bin-x86_64-efi/implicit.o
  [BUILD] bin-x86_64-efi/acpi.o
In file included from include/ipxe/acpi.h:20,
                 from core/acpi.c:29:
./config/general.h:218:10: fatal error: config/local/general.h: No such file or directory
  218 | #include <config/local/general.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile.housekeeping:964: bin-x86_64-efi/acpi.o] Error 1
```