### PR TITLE
Fix error when building with gcc 14.x due to uninitialized union in etherfabric.c

### DIFF
--- a/src/drivers/net/etherfabric.c
+++ b/src/drivers/net/etherfabric.c
@@ -2210,7 +2210,7 @@ falcon_reset_xaui ( struct efab_nic *efab )
 static int
 falcon_xaui_link_ok ( struct efab_nic *efab )
 {
-	efab_dword_t reg;
+	efab_dword_t reg = {0};
 	int align_done, lane_status, sync;
 	int has_phyxs;
 	int link_ok = 1;


### PR DESCRIPTION
Resolves #1219
This is a very minor change to explicitly initialize an efab_dword_t union to 0. I chose to initialize with {0} rather than {} to maintain compatibility back to C99. Otherwise, either initializer should effectively be the same since it's just a DWORD union.