### PR TITLE
[SIL] Add Intel I22* PCI IDs

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -1193,6 +1193,14 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x1f41, "i354", "I354", INTEL_NO_ASDE ),
 	PCI_ROM ( 0x8086, 0x294c, "82566dc-2", "82566DC-2", 0 ),
 	PCI_ROM ( 0x8086, 0x2e6e, "cemedia", "CE Media Processor", 0 ),
+	PCI_ROM ( 0x8086, 0x0D9F, "i225it", "I225-IT", 0 ),
+	PCI_ROM ( 0x8086, 0x125B, "i226lm", "I226-LM", 0 ),
+	PCI_ROM ( 0x8086, 0x125C, "i226v", "I226-V", 0 ),
+	PCI_ROM ( 0x8086, 0x125D, "i226it", "I226-IT", 0 ),
+	PCI_ROM ( 0x8086, 0x125F, "i226", "I226 Empty FLASH", 0 ),
+	PCI_ROM ( 0x8086, 0x15F2, "i225lm", "I225-LM", 0 ),
+	PCI_ROM ( 0x8086, 0x15F3, "i225v", "I225-V", 0 ),
+	PCI_ROM ( 0x8086, 0x15FD, "i225", "I225 Empty FLASH", 0 ),
 };
 
 /** Intel PCI driver */


### PR DESCRIPTION
These PCI ID to work with the current iPXE Intel drivers. https://github.com/ipxe/ipxe/issues/1084