### PR TITLE
[ena] Set iPXE as the OS type for iPXE driver

### DIFF
--- a/src/drivers/net/ena.c
+++ b/src/drivers/net/ena.c
@@ -1163,7 +1163,7 @@ static int ena_probe ( struct pci_device *pci ) {
 	}
 	ena->info = info;
 	memset ( info, 0, PAGE_SIZE );
-	info->type = cpu_to_le32 ( ENA_HOST_INFO_TYPE_LINUX );
+	info->type = cpu_to_le32 ( ENA_HOST_INFO_TYPE_IPXE );
 	snprintf ( info->dist_str, sizeof ( info->dist_str ), "%s",
 		   ( product_name[0] ? product_name : product_short_name ) );
 	snprintf ( info->kernel_str, sizeof ( info->kernel_str ), "%s",

--- a/src/drivers/net/ena.h
+++ b/src/drivers/net/ena.h
@@ -191,14 +191,7 @@ struct ena_host_info {
 	uint32_t features;
 } __attribute__ (( packed ));
 
-/** Linux operating system type
- *
- * There is a defined "iPXE" operating system type (with value 5).
- * However, some very broken versions of the ENA firmware will refuse
- * to allow a completion queue to be created if the "iPXE" type is
- * used.
- */
-#define ENA_HOST_INFO_TYPE_LINUX 1
+#define ENA_HOST_INFO_TYPE_IPXE 5
 
 /** Driver version
  *


### PR DESCRIPTION
The Nitro card supports different OSs, each OS has a unique identifier.
Updating the iPXE OS identifier to the correct one.
Newer versions of Nitro properly identify iPXE OS.