### PR TITLE
[ena] Change reported operating system type to "iPXE"

### DIFF
--- a/src/drivers/net/ena.c
+++ b/src/drivers/net/ena.c
@@ -560,8 +560,11 @@ static int ena_create_cq ( struct ena_nic *ena, struct ena_cq *cq ) {
 	req->create_cq.address = cpu_to_le64 ( virt_to_bus ( cq->cqe.raw ) );
 
 	/* Issue request */
-	if ( ( rc = ena_admin ( ena, req, &rsp ) ) != 0 )
+	if ( ( rc = ena_admin ( ena, req, &rsp ) ) != 0 ) {
+		DBGC ( ena, "ENA %p CQ%d creation failed (broken firmware?)\n",
+		       ena, cq->id );
 		goto err_admin;
+	}
 
 	/* Parse response */
 	cq->id = le16_to_cpu ( rsp->create_cq.id );
@@ -1163,7 +1166,7 @@ static int ena_probe ( struct pci_device *pci ) {
 	}
 	ena->info = info;
 	memset ( info, 0, PAGE_SIZE );
-	info->type = cpu_to_le32 ( ENA_HOST_INFO_TYPE_LINUX );
+	info->type = cpu_to_le32 ( ENA_HOST_INFO_TYPE_IPXE );
 	snprintf ( info->dist_str, sizeof ( info->dist_str ), "%s",
 		   ( product_name[0] ? product_name : product_short_name ) );
 	snprintf ( info->kernel_str, sizeof ( info->kernel_str ), "%s",

--- a/src/drivers/net/ena.h
+++ b/src/drivers/net/ena.h
@@ -191,14 +191,17 @@ struct ena_host_info {
 	uint32_t features;
 } __attribute__ (( packed ));
 
-/** Linux operating system type
+/** Operating system type
  *
- * There is a defined "iPXE" operating system type (with value 5).
- * However, some very broken versions of the ENA firmware will refuse
- * to allow a completion queue to be created if the "iPXE" type is
- * used.
+ * Some very broken older versions of the ENA firmware will refuse to
+ * allow a completion queue to be created if "iPXE" (type 5) is used,
+ * and require us to pretend that we are "Linux" (type 1) instead.
+ *
+ * The ENA team at AWS assures us that the entire AWS fleet has been
+ * upgraded to fix this bug, and that we are now safe to use the
+ * correct operating system type value.
  */
-#define ENA_HOST_INFO_TYPE_LINUX 1
+#define ENA_HOST_INFO_TYPE_IPXE 5
 
 /** Driver version
  *


### PR DESCRIPTION
As described in commit 3b81a4e ("[ena] Provide a host information page"), we currently report an operating system type of "Linux" in order to work around broken versions of the ENA firmware that will fail to create a completion queue if we report the correct operating system type.

As of September 2024, the ENA team at AWS assures us that the entire AWS fleet has been upgraded to fix this bug, and that we are now safe to report the correct operating system type value in the "type" field of struct ena_host_info.

The ENA team has also clarified that at least some deployed versions of the ENA firmware still have the defect that requires us to report an operating system version number of 2 (regardless of operating system type), and so we continue to report ENA_HOST_INFO_VERSION_WTF in the "version" field of struct ena_host_info.

Add an explicit warning on the previous known failure path, in case some deployed versions of the ENA firmware turn out to not have been upgraded as expected.

Closes: #1294 