### PR TITLE
[ipv6] Change ULA route scope to global for interoperability

### DIFF
--- a/src/net/ipv6.c
+++ b/src/net/ipv6.c
@@ -107,7 +107,7 @@ static unsigned int ipv6_scope ( const struct in6_addr *addr ) {
 	 * global.
 	 */
 	if ( IN6_IS_ADDR_ULA ( addr ) )
-		return IPV6_SCOPE_ORGANISATION_LOCAL;
+		return IPV6_SCOPE_GLOBAL;
 
 	/* All other addresses are assumed to be global */
 	return IPV6_SCOPE_GLOBAL;


### PR DESCRIPTION
IPv6 miniroute filters out routes that are out of scope

https://github.com/ipxe/ipxe/blob/f88761ef491c16a33078e46ad9d49ebd8f36fd47/src/net/ipv6.c#L320-L338

It breaks the global scope reachability if there is some mechanism implemented at subsequent hops that ensures the global reachability, like NPTv6 which is common in multihoming networks.

![Typical multihoming NPTv6](https://github.com/user-attachments/assets/bfc62f67-a517-4513-bda5-3607ff6f8ad5)

```
iPXE> route
net0: 10.1.16.171/255.255.255.0 gw 10.1.16.1
net0: fd00:dead:beef:10:5054:ff:feca:4f05/64 gw fe80::3a22:d6ff:fee2:3a76
net0: fe80::5054:ff:feca:4f05/64
iPXE> ping 2001:4860:4860::8888
IPv6 has no route to 2001:4860:4860::8888
0 bytes from <none>: seq=1: Connection timed out (https://ipxe.org/4c1b2092)
IPv6 has no route to 2001:4860:4860::8888
0 bytes from <none>: seq=2: Connection timed out (https://ipxe.org/4c1b2092)
IPv6 has no route to 2001:4860:4860::8888
0 bytes from <none>: seq=3: Connection timed out (https://ipxe.org/4c1b2092)
IPv6 has no route to 2001:4860:4860::8888
Finished: Operation canceled (https://ipxe.org/0b072095)
```

The workaround is changing the ULA route scope to global. **It might not be the best final solution.**

```
iPXE> route
net0: 10.1.16.171/255.255.255.0 gw 10.1.16.1
net0: fd00:dead:beef:10:5054:ff:feca:4f05/64 gw fe80::3a22:d6ff:fee2:3a76
net0: fe80::5054:ff:feca:4f05/64
iPXE> ping 2001:4860:4860::8888
64 bytes from 2001:4860:4860::8888: seq=1
64 bytes from 2001:4860:4860::8888: seq=2
64 bytes from 2001:4860:4860::8888: seq=3
64 bytes from 2001:4860:4860::8888: seq=4
Finished: Operation canceled (https://ipxe.org/0b072095)
```