### PR TITLE
[riscv] Add support for the RISC-V CPU architecture

### DIFF
--- a/src/arch/riscv/Makefile
+++ b/src/arch/riscv/Makefile
@@ -1,0 +1,20 @@
+# Assembler section type character
+#
+ASM_TCHAR	:= @
+ASM_TCHAR_OPS	:= @
+
+# Include RISCV-specific headers
+#
+INCDIRS		:= arch/$(ARCH)/include arch/riscv/include $(INCDIRS)
+
+# RISCV-specific directories containing source files
+#
+SRCDIRS		+= arch/riscv/core
+
+# RISCV-specific flags
+#
+CFLAGS		+= -mno-strict-align -mno-plt
+
+# EFI requires -fshort-wchar, and nothing else currently uses wchar_t
+#
+CFLAGS          += -fshort-wchar

--- a/src/arch/riscv/Makefile.efi
+++ b/src/arch/riscv/Makefile.efi
@@ -1,0 +1,10 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# RISCV-specific flags
+#
+CFLAGS		+= -mcmodel=medany
+
+# Include generic EFI Makefile
+#
+MAKEDEPS	+= Makefile.efi
+include Makefile.efi

--- a/src/arch/riscv/Makefile.linux
+++ b/src/arch/riscv/Makefile.linux
@@ -1,0 +1,6 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# Include generic Linux Makefile
+#
+MAKEDEPS	+= Makefile.linux
+include Makefile.linux

--- a/src/arch/riscv/core/riscv_bigint.c
+++ b/src/arch/riscv/core/riscv_bigint.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+#include <string.h>
+#include <ipxe/bigint.h>
+
+/** @file
+ *
+ * Big integer support
+ */
+
+/**
+ * Multiply big integers
+ *
+ * @v multiplicand0	Element 0 of big integer to be multiplied
+ * @v multiplicand_size	Number of elements in multiplicand
+ * @v multiplier0	Element 0 of big integer to be multiplied
+ * @v multiplier_size	Number of elements in multiplier
+ * @v result0		Element 0 of big integer to hold result
+ */
+void bigint_multiply_raw ( const unsigned long *multiplicand0,
+			   unsigned int multiplicand_size,
+			   const unsigned long *multiplier0,
+			   unsigned int multiplier_size,
+			   unsigned long *result0 ) {
+	unsigned int result_size = ( multiplicand_size + multiplier_size );
+	const bigint_t ( multiplicand_size ) __attribute__ (( may_alias ))
+		*multiplicand = ( ( const void * ) multiplicand0 );
+	const bigint_t ( multiplier_size ) __attribute__ (( may_alias ))
+		*multiplier = ( ( const void * ) multiplier0 );
+	bigint_t ( result_size ) __attribute__ (( may_alias ))
+		*result = ( ( void * ) result0 );
+	unsigned int i;
+	unsigned int j;
+	unsigned long multiplicand_element;
+	unsigned long multiplier_element;
+	unsigned long *result_elements;
+	unsigned long discard_low;
+	unsigned long discard_high;
+	unsigned long discard_temp;
+	unsigned long discard_carry;
+
+	/* Zero result */
+	memset ( result, 0, sizeof ( *result ) );
+
+	/* Multiply integers one element at a time */
+	for ( i = 0 ; i < multiplicand_size ; i++ ) {
+		multiplicand_element = multiplicand->element[i];
+		for ( j = 0 ; j < multiplier_size ; j++ ) {
+			multiplier_element = multiplier->element[j];
+			result_elements = &result->element[ i + j ];
+			/* Perform a single multiply, and add the
+			 * resulting double-element into the result,
+			 * carrying as necessary.  The carry can
+			 * never overflow beyond the end of the
+			 * result, since:
+			 *
+			 *     a < 2^{n}, b < 2^{m} => ab < 2^{n+m}
+			 */
+			__asm__ __volatile__ ( /* Perform multiplication */
+					       "mulhu %2, %6, %7\n\t"
+					       "mul %1, %6, %7\n\t"
+					       /* Accumulate low half */
+					       LOADN " %3, (%0)\n\t"
+					       "add %3, %3, %1\n\t"
+					       "sltu %4, %3, %1\n\t"
+					       STOREN " %3, 0(%0)\n\t"
+					       /* Carry into high half */
+					       "add %4, %4, %2\n\t"
+					       /* Propagate as necessary */
+					       "\n1:\n\t"
+					       "addi %0, %0, %8\n\t"
+					       LOADN " %3, 0(%0)\n\t"
+					       "add %3, %3, %4\n\t"
+					       "sltu %4, %3, %4\n\t"
+					       STOREN " %3, 0(%0)\n\t"
+					       "bnez %4, 1b\n\t"
+					       : "+r" ( result_elements ),
+						 "=r" ( discard_low ),
+						 "=r" ( discard_high ),
+						 "=r" ( discard_temp ),
+						 "=r" ( discard_carry ),
+						 "+m" ( *result )
+					       : "r" ( multiplicand_element ),
+						 "r" ( multiplier_element ),
+						 "i" ( sizeof ( *result0 ) ) );
+		}
+	}
+}

--- a/src/arch/riscv/core/riscv_io.c
+++ b/src/arch/riscv/core/riscv_io.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <ipxe/io.h>
+#include <ipxe/riscv_io.h>
+
+/** @file
+ *
+ * iPXE I/O API for RISC-V
+ *
+ */
+
+PROVIDE_IOAPI_INLINE ( riscv, phys_to_bus );
+PROVIDE_IOAPI_INLINE ( riscv, bus_to_phys );
+PROVIDE_IOAPI_INLINE ( riscv, readb );
+PROVIDE_IOAPI_INLINE ( riscv, readw );
+PROVIDE_IOAPI_INLINE ( riscv, readl );
+PROVIDE_IOAPI_INLINE ( riscv, writeb );
+PROVIDE_IOAPI_INLINE ( riscv, writew );
+PROVIDE_IOAPI_INLINE ( riscv, writel );
+PROVIDE_IOAPI_INLINE ( riscv, readq );
+PROVIDE_IOAPI_INLINE ( riscv, writeq );
+PROVIDE_IOAPI_INLINE ( riscv, mb );
+PROVIDE_DUMMY_PIO ( riscv );

--- a/src/arch/riscv/core/riscv_string.c
+++ b/src/arch/riscv/core/riscv_string.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+/** @file
+ *
+ * Optimised string operations
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <string.h>
+
+/**
+ * Copy memory area
+ *
+ * @v dest		Destination address
+ * @v src		Source address
+ * @v len		Length
+ * @ret dest		Destination address
+ */
+void riscv_memcpy ( void *dest, const void *src, size_t len ) {
+	size_t len_pre;
+	size_t len_mid;
+	size_t len_post;
+	unsigned long discard_data;
+
+	/* Calculate pre-aligned, aligned, and post-aligned lengths.
+	 * (Align on the destination address, on the assumption that
+	 * misaligned stores are likely to be more expensive than
+	 * misaligned loads.)
+	 */
+	len_pre = ( ( sizeof ( unsigned long ) - ( ( intptr_t ) dest ) ) &
+		    ( sizeof ( unsigned long ) - 1 ) );
+	if ( len_pre > len )
+		len_pre = len;
+	len -= len_pre;
+	len_mid = ( len & ~( sizeof ( unsigned long ) - 1 ) );
+	len -= len_mid;
+	len_post = len;
+
+	/* Copy pre-aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       "lb %2, (%1)\n\t"
+			       "sb %2, (%0)\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "addi %1, %1, 1\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %3, 1b\n\t"
+			       : "+r" ( dest ), "+r" ( src ),
+				 "=&r" ( discard_data )
+			       : "r" ( dest + len_pre )
+			       : "memory" );
+
+	/* Copy aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       LOADN " %2, (%1)\n\t"
+			       STOREN " %2, (%0)\n\t"
+			       "addi %0, %0, %4\n\t"
+			       "addi %1, %1, %4\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %3, 1b\n\t"
+			       : "+r" ( dest ), "+r" ( src ),
+				 "=&r" ( discard_data )
+			       : "r" ( dest + len_mid ),
+				 "i" ( sizeof ( unsigned long ) )
+			       : "memory" );
+
+	/* Copy post-aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       "lb %2, (%1)\n\t"
+			       "sb %2, (%0)\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "addi %1, %1, 1\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %3, 1b\n\t"
+			       : "+r" ( dest ), "+r" ( src ),
+				 "=&r" ( discard_data )
+			       : "r" ( dest + len_post )
+			       : "memory" );
+}
+
+/**
+ * Zero memory region
+ *
+ * @v dest		Destination region
+ * @v len		Length
+ */
+void riscv_bzero ( void *dest, size_t len ) {
+	size_t len_pre;
+	size_t len_mid;
+	size_t len_post;
+
+	/* Calculate pre-aligned, aligned, and post-aligned lengths */
+	len_pre = ( ( sizeof ( unsigned long ) - ( ( intptr_t ) dest ) ) &
+		    ( sizeof ( unsigned long ) - 1 ) );
+	if ( len_pre > len )
+		len_pre = len;
+	len -= len_pre;
+	len_mid = ( len & ~( sizeof ( unsigned long ) - 1 ) );
+	len -= len_mid;
+	len_post = len;
+
+	/* Zero pre-aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       "sb zero, (%0)\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %1, 1b\n\t"
+			       : "+r" ( dest )
+			       : "r" ( dest + len_pre )
+			       : "memory" );
+
+	/* Zero aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       STOREN " zero, (%0)\n\t"
+			       "addi %0, %0, %2\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %1, 1b\n\t"
+			       : "+r" ( dest )
+			       : "r" ( dest + len_mid ),
+				 "i" ( sizeof ( unsigned long ) )
+			       : "memory" );
+
+	/* Zero post-aligned section */
+	__asm__ __volatile__ ( "j 2f\n\t"
+			       "\n1:\n\t"
+			       "sb zero, (%0)\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "\n2:\n\t"
+			       "bne %0, %1, 1b\n\t"
+			       : "+r" ( dest )
+			       : "r" ( dest + len_post )
+			       : "memory" );
+}
+
+/**
+ * Fill memory region
+ *
+ * @v dest		Destination region
+ * @v len		Length
+ * @v character		Fill character
+ *
+ * The unusual parameter order is to allow for more efficient
+ * tail-calling to riscv_bzero() when zeroing a region.
+ */
+void riscv_memset ( void *dest, size_t len, int character ) {
+
+	/* Do nothing if length is zero */
+	if ( ! len )
+		return;
+
+	/* Use optimised zeroing code if applicable */
+	if ( character == 0 ) {
+		riscv_bzero ( dest, len );
+		return;
+	}
+
+	/* Fill one byte at a time.  Calling memset() with a non-zero
+	 * value is relatively rare and unlikely to be
+	 * performance-critical.
+	 */
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       "sb %2, (%0)\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "bne %0, %1, 1b\n\t"
+			       : "+r" ( dest )
+			       : "r" ( dest + len ), "r" ( character )
+			       : "memory" );
+}
+
+/**
+ * Copy (possibly overlapping) memory region forwards
+ *
+ * @v dest		Destination region
+ * @v src		Source region
+ * @v len		Length
+ */
+void riscv_memmove_forwards ( void *dest, const void *src, size_t len ) {
+	unsigned long discard_data;
+
+	/* Do nothing if length is zero */
+	if ( ! len )
+		return;
+
+	/* Assume memmove() is not performance-critical, and perform a
+	 * bytewise copy for simplicity.
+	 */
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       "lb %2, (%1)\n\t"
+			       "sb %2, (%0)\n\t"
+			       "addi %1, %1, 1\n\t"
+			       "addi %0, %0, 1\n\t"
+			       "bne %0, %3, 1b\n\t"
+			       : "+r" ( dest ), "+r" ( src ),
+				 "=&r" ( discard_data )
+			       : "r" ( dest + len )
+			       : "memory" );
+}
+
+/**
+ * Copy (possibly overlapping) memory region backwards
+ *
+ * @v dest		Destination region
+ * @v src		Source region
+ * @v len		Length
+ */
+void riscv_memmove_backwards ( void *dest, const void *src, size_t len ) {
+	void *orig_dest = dest;
+	unsigned long discard_data;
+
+	/* Do nothing if length is zero */
+	if ( ! len )
+		return;
+
+	/* Assume memmove() is not performance-critical, and perform a
+	 * bytewise copy for simplicity.
+	 */
+	dest += len;
+	src += len;
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       "addi %1, %1, -1\n\t"
+			       "addi %0, %0, -1\n\t"
+			       "lb %2, (%1)\n\t"
+			       "sb %2, (%0)\n\t"
+			       "bne %0, %3, 1b\n\t"
+			       : "+r" ( dest ), "+r" ( src ),
+				 "=&r" ( discard_data )
+			       : "r" ( orig_dest )
+			       : "memory" );
+}
+
+/**
+ * Copy (possibly overlapping) memory region
+ *
+ * @v dest		Destination region
+ * @v src		Source region
+ * @v len		Length
+ */
+void riscv_memmove ( void *dest, const void *src, size_t len ) {
+
+	if ( dest <= src ) {
+		riscv_memmove_forwards ( dest, src, len );
+	} else {
+		riscv_memmove_backwards ( dest, src, len );
+	}
+}

--- a/src/arch/riscv/core/riscv_strings.S
+++ b/src/arch/riscv/core/riscv_strings.S
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+	FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+/** @file
+ *
+ * Byte swapping
+ *
+ */
+
+	.section ".note.GNU-stack", "", @progbits
+	.text
+
+/**
+ * Find first (i.e. least significant) set bit
+ *
+ * @v value		Value
+ * @ret lsb		Least significant bit set in value (LSB=1), or zero
+ */
+	.section ".text.riscv_ffs"
+	.globl	riscv_ffs
+riscv_ffs:
+	beqz	a0, 2f
+	mv	t0, a0
+	li	a0, ( __riscv_xlen + 1 )
+1:	slli	t0, t0, 1
+	addi	a0, a0, -1
+	bnez	t0, 1b
+2:	ret
+	.size	riscv_ffs, . - riscv_ffs
+
+/**
+ * Find last (i.e. most significant) set bit
+ *
+ * @v value		Value
+ * @ret msb		Most significant bit set in value (LSB=1), or zero
+ */
+	.section ".text.riscv_fls"
+	.globl	riscv_fls
+riscv_fls:
+	beqz	a0, 2f
+	mv	t0, a0
+	li	a0, __riscv_xlen
+	bltz	t0, 2f
+1:	slli	t0, t0, 1
+	addi	a0, a0, -1
+	bgez	t0, 1b
+2:	ret
+	.size	riscv_fls, . - riscv_fls

--- a/src/arch/riscv/core/setjmp.S
+++ b/src/arch/riscv/core/setjmp.S
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+	FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+/** @file
+ *
+ * Long jumps
+ *
+ */
+
+	.section ".note.GNU-stack", "", @progbits
+	.text
+
+	/* Must match jmp_buf structure layout */
+	.struct 0
+env_ra:		.space ( __riscv_xlen / 8 )
+env_sp:		.space ( __riscv_xlen / 8 )
+env_s0:		.space ( __riscv_xlen / 8 )
+env_s1:		.space ( __riscv_xlen / 8 )
+env_s2:		.space ( __riscv_xlen / 8 )
+env_s3:		.space ( __riscv_xlen / 8 )
+env_s4:		.space ( __riscv_xlen / 8 )
+env_s5:		.space ( __riscv_xlen / 8 )
+env_s6:		.space ( __riscv_xlen / 8 )
+env_s7:		.space ( __riscv_xlen / 8 )
+env_s8:		.space ( __riscv_xlen / 8 )
+env_s9:		.space ( __riscv_xlen / 8 )
+env_s10:	.space ( __riscv_xlen / 8 )
+env_s11:	.space ( __riscv_xlen / 8 )
+	.previous
+
+/*
+ * Save stack context for non-local goto
+ */
+	.section ".text.setjmp", "ax", @progbits
+	.globl	setjmp
+setjmp:
+	/* Save registers */
+	STOREN	ra, env_ra(a0)
+	STOREN	sp, env_sp(a0)
+	STOREN	s0, env_s0(a0)
+	STOREN	s1, env_s1(a0)
+	STOREN	s2, env_s2(a0)
+	STOREN	s3, env_s3(a0)
+	STOREN	s4, env_s4(a0)
+	STOREN	s5, env_s5(a0)
+	STOREN	s6, env_s6(a0)
+	STOREN	s7, env_s7(a0)
+	STOREN	s8, env_s8(a0)
+	STOREN	s9, env_s9(a0)
+	STOREN	s10, env_s10(a0)
+	STOREN	s11, env_s11(a0)
+	/* Return zero when returning as setjmp() */
+	mv	a0, zero
+	ret
+	.size	setjmp, . - setjmp
+
+/*
+ * Non-local jump to a saved stack context
+ */
+	.section ".text.longjmp", "ax", @progbits
+	.globl	longjmp
+longjmp:
+	/* Restore registers */
+	LOADN	s11, env_s11(a0)
+	LOADN	s10, env_s10(a0)
+	LOADN	s9, env_s9(a0)
+	LOADN	s8, env_s8(a0)
+	LOADN	s7, env_s7(a0)
+	LOADN	s6, env_s6(a0)
+	LOADN	s5, env_s5(a0)
+	LOADN	s4, env_s4(a0)
+	LOADN	s3, env_s3(a0)
+	LOADN	s2, env_s2(a0)
+	LOADN	s1, env_s1(a0)
+	LOADN	s0, env_s0(a0)
+	LOADN	sp, env_sp(a0)
+	LOADN	ra, env_ra(a0)
+	/* Force result to non-zero */
+	seqz	a0, a1
+	or	a0, a0, a1
+	/* Return to setjmp() caller */
+	ret
+	.size	longjmp, . - longjmp

--- a/src/arch/riscv/include/bits/bigint.h
+++ b/src/arch/riscv/include/bits/bigint.h
@@ -1,0 +1,362 @@
+#ifndef _BITS_BIGINT_H
+#define _BITS_BIGINT_H
+
+/** @file
+ *
+ * Big integer support
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+
+/** Element of a big integer */
+typedef unsigned long bigint_element_t;
+
+/**
+ * Initialise big integer
+ *
+ * @v value0		Element 0 of big integer to initialise
+ * @v size		Number of elements
+ * @v data		Raw data
+ * @v len		Length of raw data
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_init_raw ( unsigned long *value0, unsigned int size,
+		  const void *data, size_t len ) {
+	size_t pad_len = ( sizeof ( bigint_t ( size ) ) - len );
+	uint8_t *value_byte = ( ( void * ) value0 );
+	const uint8_t *data_byte = ( data + len );
+
+	/* Copy raw data in reverse order, padding with zeros */
+	while ( len-- )
+		*(value_byte++) = *(--data_byte);
+	while ( pad_len-- )
+		*(value_byte++) = 0;
+}
+
+/**
+ * Add big integers
+ *
+ * @v addend0		Element 0 of big integer to add
+ * @v value0		Element 0 of big integer to be added to
+ * @v size		Number of elements
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_add_raw ( const unsigned long *addend0, unsigned long *value0,
+		 unsigned int size ) {
+	bigint_t ( size ) __attribute__ (( may_alias )) *value =
+		( ( void * ) value0 );
+	unsigned long *valueN = ( value0 + size );
+	unsigned long *discard_addend;
+	unsigned long *discard_value;
+	unsigned long discard_addend_i;
+	unsigned long discard_value_i;
+	unsigned long discard_carry;
+	unsigned long discard_temp;
+
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       /* Load addend[i] and value[i] */
+			       LOADN " %2, (%0)\n\t"
+			       LOADN " %3, (%1)\n\t"
+			       /* Add carry flag and addend */
+			       "add %3, %3, %4\n\t"
+			       "sltu %5, %3, %4\n\t"
+			       "add %3, %3, %2\n\t"
+			       "sltu %4, %3, %2\n\t"
+			       "or %4, %4, %5\n\t"
+			       /* Store value[i] */
+			       STOREN " %3, (%1)\n\t"
+			       /* Loop */
+			       "addi %0, %0, %8\n\t"
+			       "addi %1, %1, %8\n\t"
+			       "bne %1, %7, 1b\n\t"
+			       : "=&r" ( discard_addend ),
+				 "=&r" ( discard_value ),
+				 "=&r" ( discard_addend_i ),
+				 "=&r" ( discard_value_i ),
+				 "=&r" ( discard_carry ),
+				 "=&r" ( discard_temp ),
+				 "+m" ( *value )
+			       : "r" ( valueN ),
+				 "i" ( sizeof ( unsigned long ) ),
+				 "0" ( addend0 ), "1" ( value0 ), "4" ( 0 ) );
+}
+
+/**
+ * Subtract big integers
+ *
+ * @v subtrahend0	Element 0 of big integer to subtract
+ * @v value0		Element 0 of big integer to be subtracted from
+ * @v size		Number of elements
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_subtract_raw ( const unsigned long *subtrahend0, unsigned long *value0,
+		      unsigned int size ) {
+	bigint_t ( size ) __attribute__ (( may_alias )) *value =
+		( ( void * ) value0 );
+	unsigned long *valueN = ( value0 + size );
+	unsigned long *discard_subtrahend;
+	unsigned long *discard_value;
+	unsigned long discard_subtrahend_i;
+	unsigned long discard_value_i;
+	unsigned long discard_carry;
+	unsigned long discard_temp;
+
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       /* Load subtrahend[i] and value[i] */
+			       LOADN " %2, (%0)\n\t"
+			       LOADN " %3, (%1)\n\t"
+			       /* Subtract carry flag and subtrahend */
+			       "sltu %5, %3, %4\n\t"
+			       "sub %3, %3, %4\n\t"
+			       "sltu %4, %3, %2\n\t"
+			       "sub %3, %3, %2\n\t"
+			       "or %4, %4, %5\n\t"
+			       /* Store value[i] */
+			       STOREN " %3, (%1)\n\t"
+			       /* Loop */
+			       "addi %0, %0, %8\n\t"
+			       "addi %1, %1, %8\n\t"
+			       "bne %1, %7, 1b\n\t"
+			       : "=&r" ( discard_subtrahend ),
+				 "=&r" ( discard_value ),
+				 "=&r" ( discard_subtrahend_i ),
+				 "=&r" ( discard_value_i ),
+				 "=&r" ( discard_carry ),
+				 "=&r" ( discard_temp ),
+				 "+m" ( *value )
+			       : "r" ( valueN ),
+				 "i" ( sizeof ( unsigned long ) ),
+				 "0" ( subtrahend0 ), "1" ( value0 ),
+				 "4" ( 0 ) );
+}
+
+/**
+ * Rotate big integer left
+ *
+ * @v value0		Element 0 of big integer
+ * @v size		Number of elements
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_rol_raw ( unsigned long *value0, unsigned int size ) {
+	bigint_t ( size ) __attribute__ (( may_alias )) *value =
+		( ( void * ) value0 );
+	unsigned long *valueN = ( value0 + size );
+	unsigned long *discard_value;
+	unsigned long discard_value_i;
+	unsigned long discard_carry;
+	unsigned long discard_temp;
+
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       /* Load value[i] */
+			       LOADN " %1, (%0)\n\t"
+			       /* Shift left */
+			       "slli %3, %1, 1\n\t"
+			       "or %3, %3, %2\n\t"
+			       "srli %2, %1, %7\n\t"
+			       /* Store value[i] */
+			       STOREN " %3, (%0)\n\t"
+			       /* Loop  */
+			       "addi %0, %0, %6\n\t"
+			       "bne %0, %5, 1b\n\t"
+			       : "=&r" ( discard_value ),
+				 "=&r" ( discard_value_i ),
+				 "=&r" ( discard_carry ),
+				 "=&r" ( discard_temp ),
+				 "+m" ( *value )
+			       : "r" ( valueN ),
+				 "i" ( sizeof ( unsigned long ) ),
+				 "i" ( ( 8 * sizeof ( unsigned long ) - 1 ) ),
+				 "0" ( value0 ), "2" ( 0 ) );
+}
+
+/**
+ * Rotate big integer right
+ *
+ * @v value0		Element 0 of big integer
+ * @v size		Number of elements
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_ror_raw ( unsigned long *value0, unsigned int size ) {
+	bigint_t ( size ) __attribute__ (( may_alias )) *value =
+		( ( void * ) value0 );
+	unsigned long *valueN = ( value0 + size );
+	unsigned long *discard_value;
+	unsigned long discard_value_i;
+	unsigned long discard_carry;
+	unsigned long discard_temp;
+
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       /* Load value[i] */
+			       LOADN " %1, %6(%0)\n\t"
+			       /* Shift right */
+			       "srli %3, %1, 1\n\t"
+			       "or %3, %3, %2\n\t"
+			       "slli %2, %1, %7\n\t"
+			       /* Store value[i] */
+			       STOREN " %3, %6(%0)\n\t"
+			       /* Loop  */
+			       "addi %0, %0, %6\n\t"
+			       "bne %0, %5, 1b\n\t"
+			       : "=&r" ( discard_value ),
+				 "=&r" ( discard_value_i ),
+				 "=&r" ( discard_carry ),
+				 "=&r" ( discard_temp ),
+				 "+m" ( *value )
+			       : "r" ( value0 ),
+				 "i" ( -( sizeof ( unsigned long ) ) ),
+				 "i" ( ( 8 * sizeof ( unsigned long ) - 1 ) ),
+				 "0" ( valueN ), "2" ( 0 ) );
+}
+
+/**
+ * Test if big integer is equal to zero
+ *
+ * @v value0		Element 0 of big integer
+ * @v size		Number of elements
+ * @ret is_zero		Big integer is equal to zero
+ */
+static inline __attribute__ (( always_inline, pure )) int
+bigint_is_zero_raw ( const unsigned long *value0, unsigned int size ) {
+	const unsigned long *value = value0;
+	unsigned long value_i;
+
+	do {
+		value_i = *(value++);
+		if ( value_i )
+			break;
+	} while ( --size );
+
+	return ( value_i == 0 );
+}
+
+/**
+ * Compare big integers
+ *
+ * @v value0		Element 0 of big integer
+ * @v reference0	Element 0 of reference big integer
+ * @v size		Number of elements
+ * @ret geq		Big integer is greater than or equal to the reference
+ */
+static inline __attribute__ (( always_inline, pure )) int
+bigint_is_geq_raw ( const unsigned long *value0,
+		    const unsigned long *reference0, unsigned int size ) {
+	const unsigned long *value = ( value0 + size );
+	const unsigned long *reference = ( reference0 + size );
+	unsigned long value_i;
+	unsigned long reference_i;
+
+	do {
+		value_i = *(--value);
+		reference_i = *(--reference);
+		if ( value_i != reference_i )
+			break;
+	} while ( --size );
+
+	return ( value_i >= reference_i );
+}
+
+/**
+ * Test if bit is set in big integer
+ *
+ * @v value0		Element 0 of big integer
+ * @v size		Number of elements
+ * @v bit		Bit to test
+ * @ret is_set		Bit is set
+ */
+static inline __attribute__ (( always_inline )) int
+bigint_bit_is_set_raw ( const unsigned long *value0, unsigned int size,
+			unsigned int bit ) {
+	const bigint_t ( size ) __attribute__ (( may_alias )) *value =
+		( ( const void * ) value0 );
+	unsigned int index = ( bit / ( 8 * sizeof ( *value0 ) ) );
+	unsigned int subindex = ( bit % ( 8 * sizeof ( *value0 ) ) );
+
+	return ( !! ( value->element[index] & ( 1UL << subindex ) ) );
+}
+
+/**
+ * Find highest bit set in big integer
+ *
+ * @v value0		Element 0 of big integer
+ * @v size		Number of elements
+ * @ret max_bit		Highest bit set + 1 (or 0 if no bits set)
+ */
+static inline __attribute__ (( always_inline )) int
+bigint_max_set_bit_raw ( const unsigned long *value0, unsigned int size ) {
+	const unsigned long *value = ( value0 + size );
+	int max_bit = ( 8 * sizeof ( bigint_t ( size ) ) );
+	unsigned long value_i;
+
+	do {
+		value_i = *(--value);
+		max_bit -= ( ( 8 * sizeof ( *value0 ) ) - fls ( value_i ) );
+		if ( value_i )
+			break;
+	} while ( --size );
+
+	return max_bit;
+}
+
+/**
+ * Grow big integer
+ *
+ * @v source0		Element 0 of source big integer
+ * @v source_size	Number of elements in source big integer
+ * @v dest0		Element 0 of destination big integer
+ * @v dest_size		Number of elements in destination big integer
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_grow_raw ( const unsigned long *source0, unsigned int source_size,
+		  unsigned long *dest0, unsigned int dest_size ) {
+	unsigned int pad_size = ( dest_size - source_size );
+
+	memcpy ( dest0, source0, sizeof ( bigint_t ( source_size ) ) );
+	memset ( ( dest0 + source_size ), 0, sizeof ( bigint_t ( pad_size ) ) );
+}
+
+/**
+ * Shrink big integer
+ *
+ * @v source0		Element 0 of source big integer
+ * @v source_size	Number of elements in source big integer
+ * @v dest0		Element 0 of destination big integer
+ * @v dest_size		Number of elements in destination big integer
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_shrink_raw ( const unsigned long *source0,
+		    unsigned int source_size __unused,
+		    unsigned long *dest0, unsigned int dest_size ) {
+
+	memcpy ( dest0, source0, sizeof ( bigint_t ( dest_size ) ) );
+}
+
+/**
+ * Finalise big integer
+ *
+ * @v value0		Element 0 of big integer to finalise
+ * @v size		Number of elements
+ * @v out		Output buffer
+ * @v len		Length of output buffer
+ */
+static inline __attribute__ (( always_inline )) void
+bigint_done_raw ( const unsigned long *value0, unsigned int size __unused,
+		  void *out, size_t len ) {
+	const uint8_t *value_byte = ( ( const void * ) value0 );
+	uint8_t *out_byte = ( out + len );
+
+	/* Copy raw data in reverse order */
+	while ( len-- )
+		*(--out_byte) = *(value_byte++);
+}
+
+extern void bigint_multiply_raw ( const unsigned long *multiplicand0,
+				  unsigned int multiplicand_size,
+				  const unsigned long *multiplier0,
+				  unsigned int multiplier_size,
+				  unsigned long *value0 );
+
+#endif /* _BITS_BIGINT_H */

--- a/src/arch/riscv/include/bits/bitops.h
+++ b/src/arch/riscv/include/bits/bitops.h
@@ -1,0 +1,82 @@
+#ifndef _BITS_BITOPS_H
+#define _BITS_BITOPS_H
+
+/** @file
+ *
+ * RISC-V bit operations
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+
+/**
+ * Test and set bit atomically
+ *
+ * @v bit		Bit to set
+ * @v bits		Bit field
+ * @ret old		Old value of bit (zero or non-zero)
+ */
+static inline __attribute__ (( always_inline )) int
+test_and_set_bit ( unsigned int bit, volatile void *bits ) {
+	unsigned int index = ( bit / 32 );
+	unsigned int offset = ( bit % 32 );
+	volatile uint32_t *word = ( ( ( volatile uint32_t * ) bits ) + index );
+	uint32_t mask = ( 1U << offset );
+	uint32_t old;
+
+	__asm__ __volatile__ ( "amoor.w %0, %2, %1"
+			       : "=r" ( old ), "+A" ( *word )
+			       : "r" ( mask ) );
+
+	return ( !! ( old & mask ) );
+}
+
+/**
+ * Test and clear bit atomically
+ *
+ * @v bit		Bit to set
+ * @v bits		Bit field
+ * @ret old		Old value of bit (zero or non-zero)
+ */
+static inline __attribute__ (( always_inline )) int
+test_and_clear_bit ( unsigned int bit, volatile void *bits ) {
+	unsigned int index = ( bit / 32 );
+	unsigned int offset = ( bit % 32 );
+	volatile uint32_t *word = ( ( ( volatile uint32_t * ) bits ) + index );
+	uint32_t mask = ( 1U << offset );
+	uint32_t old;
+
+	__asm__ __volatile__ ( "amoand.w %0, %2, %1"
+			       : "=r" ( old ), "+A" ( *word )
+			       : "r" ( ~mask ) );
+
+	return ( !! ( old & mask ) );
+}
+
+/**
+ * Set bit atomically
+ *
+ * @v bit		Bit to set
+ * @v bits		Bit field
+ */
+static inline __attribute__ (( always_inline )) void
+set_bit ( unsigned int bit, volatile void *bits ) {
+
+	test_and_set_bit ( bit, bits );
+}
+
+/**
+ * Clear bit atomically
+ *
+ * @v bit		Bit to set
+ * @v bits		Bit field
+ */
+static inline __attribute__ (( always_inline )) void
+clear_bit ( unsigned int bit, volatile void *bits ) {
+
+	test_and_clear_bit ( bit, bits );
+}
+
+#endif /* _BITS_BITOPS_H */

--- a/src/arch/riscv/include/bits/byteswap.h
+++ b/src/arch/riscv/include/bits/byteswap.h
@@ -1,0 +1,48 @@
+#ifndef _BITS_BYTESWAP_H
+#define _BITS_BYTESWAP_H
+
+/** @file
+ *
+ * Byte-order swapping functions
+ *
+ */
+
+#include <stdint.h>
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+extern __asmcall uint64_t riscv_swap_word ( uint64_t x );
+extern __asmcall unsigned long riscv_swap_half ( unsigned long x );
+extern __asmcall unsigned long riscv_swap_byte ( unsigned long x );
+
+static inline __attribute__ (( always_inline, const )) uint16_t
+__bswap_variable_16 ( uint16_t x ) {
+	return riscv_swap_byte ( x );
+}
+
+static inline __attribute__ (( always_inline )) void
+__bswap_16s ( uint16_t *x ) {
+	*x = riscv_swap_byte ( *x );
+}
+
+static inline __attribute__ (( always_inline, const )) uint32_t
+__bswap_variable_32 ( uint32_t x ) {
+	return riscv_swap_half ( x );
+}
+
+static inline __attribute__ (( always_inline )) void
+__bswap_32s ( uint32_t *x ) {
+	*x = riscv_swap_half ( *x );
+}
+
+static inline __attribute__ (( always_inline, const )) uint64_t
+__bswap_variable_64 ( uint64_t x ) {
+	return riscv_swap_word ( x );
+}
+
+static inline __attribute__ (( always_inline )) void
+__bswap_64s ( uint64_t *x ) {
+	*x = riscv_swap_word ( *x );
+}
+
+#endif /* _BITS_BYTESWAP_H */

--- a/src/arch/riscv/include/bits/compiler.h
+++ b/src/arch/riscv/include/bits/compiler.h
@@ -1,0 +1,40 @@
+#ifndef _BITS_COMPILER_H
+#define _BITS_COMPILER_H
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** Dummy relocation type */
+#define RELOC_TYPE_NONE R_RISCV_NONE
+
+/* Determine load/store instructions for natural bit width */
+#if __riscv_xlen == 128
+#define NATURAL_SUFFIX q
+#elif __riscv_xlen == 64
+#define NATURAL_SUFFIX d
+#elif __riscv_xlen == 32
+#define NATURAL_SUFFIX w
+#else
+#error "Unsupported bit width"
+#endif
+#ifdef ASSEMBLY
+#define LOADN _C2 ( L, NATURAL_SUFFIX )
+#define STOREN _C2 ( S, NATURAL_SUFFIX )
+#else
+#define LOADN "L" _S2 ( NATURAL_SUFFIX )
+#define STOREN "S" _S2 ( NATURAL_SUFFIX )
+#endif
+
+#ifndef ASSEMBLY
+
+/** Unprefixed constant operand modifier */
+#define ASM_NO_PREFIX ""
+
+/** Declare a function with standard calling conventions */
+#define __asmcall
+
+/** Declare a function with libgcc implicit linkage */
+#define __libgcc
+
+#endif /* ASSEMBLY */
+
+#endif /* _BITS_COMPILER_H */

--- a/src/arch/riscv/include/bits/endian.h
+++ b/src/arch/riscv/include/bits/endian.h
@@ -1,0 +1,8 @@
+#ifndef _BITS_ENDIAN_H
+#define _BITS_ENDIAN_H
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#define __BYTE_ORDER __LITTLE_ENDIAN
+
+#endif /* _BITS_ENDIAN_H */

--- a/src/arch/riscv/include/bits/errfile.h
+++ b/src/arch/riscv/include/bits/errfile.h
@@ -1,0 +1,19 @@
+#ifndef _BITS_ERRFILE_H
+#define _BITS_ERRFILE_H
+
+/** @file
+ *
+ * RISC-V error file identifiers
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/**
+ * @addtogroup errfile Error file identifiers
+ * @{
+ */
+
+/** @} */
+
+#endif /* _BITS_ERRFILE_H */

--- a/src/arch/riscv/include/bits/io.h
+++ b/src/arch/riscv/include/bits/io.h
@@ -1,0 +1,17 @@
+#ifndef _BITS_IO_H
+#define _BITS_IO_H
+
+/** @file
+ *
+ * RISCV-specific I/O API implementations
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** Page shift */
+#define PAGE_SHIFT 12
+
+#include <ipxe/riscv_io.h>
+
+#endif /* _BITS_IO_H */

--- a/src/arch/riscv/include/bits/nap.h
+++ b/src/arch/riscv/include/bits/nap.h
@@ -1,0 +1,20 @@
+#ifndef _BITS_NAP_H
+#define _BITS_NAP_H
+
+/** @file
+ *
+ * RISCV-specific CPU sleeping API implementations
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/**
+ * Sleep until next CPU interrupt
+ *
+ */
+static inline __attribute__ (( always_inline )) void cpu_halt ( void ) {
+	__asm__ __volatile__ ( "wfi" );
+}
+
+#endif /* _BITS_NAP_H */

--- a/src/arch/riscv/include/bits/setjmp.h
+++ b/src/arch/riscv/include/bits/setjmp.h
@@ -1,0 +1,16 @@
+#ifndef _BITS_SETJMP_H
+#define _BITS_SETJMP_H
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** A jump buffer */
+typedef struct {
+	/** Return address (ra) */
+	unsigned long ra;
+	/** Stack pointer (sp) */
+	unsigned long sp;
+	/** Callee-saved registers (s0-s11) */
+	unsigned long s[12];
+} jmp_buf[1];
+
+#endif /* _BITS_SETJMP_H */

--- a/src/arch/riscv/include/bits/stdint.h
+++ b/src/arch/riscv/include/bits/stdint.h
@@ -1,0 +1,23 @@
+#ifndef _BITS_STDINT_H
+#define _BITS_STDINT_H
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+typedef __SIZE_TYPE__		size_t;
+typedef signed long		ssize_t;
+typedef signed long		off_t;
+
+typedef unsigned char		uint8_t;
+typedef unsigned short		uint16_t;
+typedef unsigned int		uint32_t;
+typedef unsigned long long	uint64_t;
+
+typedef signed char		int8_t;
+typedef signed short		int16_t;
+typedef signed int		int32_t;
+typedef signed long long	int64_t;
+
+typedef unsigned long		physaddr_t;
+typedef unsigned long		intptr_t;
+
+#endif /* _BITS_STDINT_H */

--- a/src/arch/riscv/include/bits/string.h
+++ b/src/arch/riscv/include/bits/string.h
@@ -1,0 +1,89 @@
+#ifndef _BITS_STRING_H
+#define _BITS_STRING_H
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** @file
+ *
+ * String functions
+ *
+ */
+
+extern void riscv_bzero ( void *dest, size_t len );
+extern void riscv_memset ( void *dest, size_t len, int character );
+extern void riscv_memcpy ( void *dest, const void *src, size_t len );
+extern void riscv_memmove_forwards ( void *dest, const void *src, size_t len );
+extern void riscv_memmove_backwards ( void *dest, const void *src, size_t len );
+extern void riscv_memmove ( void *dest, const void *src, size_t len );
+
+/**
+ * Fill memory region
+ *
+ * @v dest		Destination region
+ * @v character		Fill character
+ * @v len		Length
+ * @ret dest		Destination region
+ */
+static inline __attribute__ (( always_inline )) void *
+memset ( void *dest, int character, size_t len ) {
+
+	/* For zeroing larger or non-constant lengths, use the
+	 * optimised variable-length zeroing code.
+	 */
+	if ( __builtin_constant_p ( character ) && ( character == 0 ) ) {
+		riscv_bzero ( dest, len );
+		return dest;
+	}
+
+	/* Not necessarily zeroing: use basic variable-length code */
+	riscv_memset ( dest, len, character );
+	return dest;
+}
+
+/**
+ * Copy memory region
+ *
+ * @v dest		Destination region
+ * @v src		Source region
+ * @v len		Length
+ * @ret dest		Destination region
+ */
+static inline __attribute__ (( always_inline )) void *
+memcpy ( void *dest, const void *src, size_t len ) {
+
+	/* Otherwise, use variable-length code */
+	riscv_memcpy ( dest, src, len );
+	return dest;
+}
+
+/**
+ * Copy (possibly overlapping) memory region
+ *
+ * @v dest		Destination region
+ * @v src		Source region
+ * @v len		Length
+ * @ret dest		Destination region
+ */
+static inline __attribute__ (( always_inline )) void *
+memmove ( void *dest, const void *src, size_t len ) {
+	ssize_t offset = ( dest - src );
+
+	/* If required direction of copy is known at build time, then
+	 * use the appropriate forwards/backwards copy directly.
+	 */
+	if ( __builtin_constant_p ( offset ) ) {
+		if ( offset <= 0 ) {
+			riscv_memmove_forwards ( dest, src, len );
+			return dest;
+		} else {
+			riscv_memmove_backwards ( dest, src, len );
+			return dest;
+		}
+	}
+
+	/* Otherwise, use ambidirectional copy */
+	riscv_memmove ( dest, src, len );
+	return dest;
+}
+
+#endif /* _BITS_STRING_H */

--- a/src/arch/riscv/include/bits/strings.h
+++ b/src/arch/riscv/include/bits/strings.h
@@ -1,0 +1,91 @@
+#ifndef _BITS_STRINGS_H
+#define _BITS_STRINGS_H
+
+/** @file
+ *
+ * String functions
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+extern __asmcall unsigned long riscv_ffs ( unsigned long value );
+extern __asmcall unsigned long riscv_fls ( unsigned long value );
+
+/**
+ * Find first (i.e. least significant) set bit
+ *
+ * @v value		Value
+ * @ret lsb		Least significant bit set in value (LSB=1), or zero
+ */
+static inline __attribute__ (( always_inline )) int __ffsl ( long value ) {
+
+	return riscv_ffs ( value );
+}
+
+/**
+ * Find first (i.e. least significant) set bit
+ *
+ * @v value		Value
+ * @ret lsb		Least significant bit set in value (LSB=1), or zero
+ */
+static inline __attribute__ (( always_inline )) int __ffsll ( long long value ){
+	unsigned long low = value;
+	unsigned long high;
+
+	/* Check machine word size */
+	if ( sizeof ( value ) > sizeof ( low ) ) {
+		/* 32-bit */
+		high = ( value >> 32 );
+		if ( low ) {
+			return ( __ffsl ( low ) );
+		} else if ( high ) {
+			return ( 32 + __ffsl ( high ) );
+		} else {
+			return 0;
+		}
+	} else {
+		/* 64-bit */
+		return ( __ffsl ( low ) );
+	}
+}
+
+/**
+ * Find last (i.e. most significant) set bit
+ *
+ * @v value		Value
+ * @ret msb		Most significant bit set in value (LSB=1), or zero
+ */
+static inline __attribute__ (( always_inline )) int __flsl ( long value ) {
+
+	return riscv_fls ( value );
+}
+
+/**
+ * Find last (i.e. most significant) set bit
+ *
+ * @v value		Value
+ * @ret msb		Most significant bit set in value (LSB=1), or zero
+ */
+static inline __attribute__ (( always_inline )) int __flsll ( long long value ){
+	unsigned long low = value;
+	unsigned long high;
+
+	/* Check machine word size */
+	if ( sizeof ( value ) > sizeof ( low ) ) {
+		/* 32-bit */
+		high = ( value >> 32 );
+		if ( high ) {
+			return ( 32 + __flsl ( high ) );
+		} else if ( low ) {
+			return ( __flsl ( low ) );
+		} else {
+			return 0;
+		}
+	} else {
+		/* 64-bit */
+		return ( __flsl ( low ) );
+	}
+}
+
+#endif /* _BITS_STRINGS_H */

--- a/src/arch/riscv/include/ipxe/riscv_io.h
+++ b/src/arch/riscv/include/ipxe/riscv_io.h
@@ -1,0 +1,137 @@
+#ifndef _IPXE_RISCV_IO_H
+#define _IPXE_RISCV_IO_H
+
+/** @file
+ *
+ * iPXE I/O API for RISC-V
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#ifdef IOAPI_RISCV
+#define IOAPI_PREFIX_riscv
+#else
+#define IOAPI_PREFIX_riscv __riscv_
+#endif
+
+#include <ipxe/dummy_pio.h>
+
+/*
+ * Memory space mappings
+ *
+ */
+
+/*
+ * Physical<->Bus address mappings
+ *
+ */
+
+static inline __always_inline unsigned long
+IOAPI_INLINE ( riscv, phys_to_bus ) ( unsigned long phys_addr ) {
+	return phys_addr;
+}
+
+static inline __always_inline unsigned long
+IOAPI_INLINE ( riscv, bus_to_phys ) ( unsigned long bus_addr ) {
+	return bus_addr;
+}
+
+/*
+ * MMIO reads and writes
+ *
+ */
+
+/* Single-register read */
+#define RISCV_READX( _suffix, _type, _insn_suffix )			\
+static inline __always_inline _type					\
+IOAPI_INLINE ( riscv, read ## _suffix ) ( volatile _type *io_addr ) {	\
+	unsigned long data;						\
+	__asm__ __volatile__ ( "l" _insn_suffix " %0, %1"		\
+			       : "=r" ( data ) : "m" ( *io_addr ) );	\
+	return data;							\
+}
+
+/* Single-register write */
+#define RISCV_WRITEX( _suffix, _type, _insn_suffix)			\
+static inline __always_inline void					\
+IOAPI_INLINE ( riscv, write ## _suffix ) ( _type data,			\
+					   volatile _type *io_addr ) {	\
+	__asm__ __volatile__ ( "s" _insn_suffix " %0, %1"		\
+			       : : "r" ( data ), "m" ( *io_addr ) );	\
+}
+
+/* Double-register hopefully-fused read */
+#define RISCV_READX_FUSED( _suffix, _type, _insn_suffix )		\
+static inline __always_inline _type					\
+IOAPI_INLINE ( riscv, read ## _suffix ) ( volatile _type *io_addr ) {	\
+	union {								\
+		unsigned long half[2];					\
+	        _type data;						\
+	} u;								\
+	__asm__ __volatile__ ( "l" _insn_suffix " %0, 0(%2)\n\t"	\
+			       "l" _insn_suffix " %1, %3(%2)\n\t"	\
+			       : "=&r" ( u.half[0] ),			\
+				 "=&r" ( u.half[1] )			\
+			       : "r" ( io_addr ),			\
+				 "i" ( sizeof ( u.half[0] ) ) );	\
+	return u.data;							\
+}
+
+/* Double-register hopefully-fused write */
+#define RISCV_WRITEX_FUSED( _suffix, _type, _insn_suffix )		\
+static inline __always_inline void					\
+IOAPI_INLINE ( riscv, write ## _suffix ) ( _type data,			\
+					   volatile _type *io_addr ) {	\
+	union {								\
+		unsigned long half[2];					\
+		_type data;						\
+	} u = { .data = data };						\
+	__asm__ __volatile__ ( "s" _insn_suffix " %0, 0(%2)\n\t"	\
+			       "s" _insn_suffix " %1, %3(%2)\n\t" :	\
+			       : "r" ( u.half[0] ),			\
+				 "r" ( u.half[1] ),			\
+				 "r" ( io_addr ),			\
+				 "i" ( sizeof ( u.half[0] ) ) );	\
+}
+
+RISCV_READX ( b, uint8_t, "bu" );
+RISCV_WRITEX ( b, uint8_t, "b" );
+
+RISCV_READX ( w, uint16_t, "hu" );
+RISCV_WRITEX ( w, uint16_t, "h" );
+
+#if __riscv_xlen > 32
+  RISCV_READX ( l, uint32_t, "wu" );
+  RISCV_WRITEX ( l, uint32_t, "w" );
+#else
+  RISCV_READX ( l, uint32_t, "w" );
+  RISCV_WRITEX ( l, uint32_t, "w" );
+#endif
+
+#if __riscv_xlen >= 64
+  #if __riscv_xlen > 64
+    RISCV_READX ( q, uint64_t, "du" );
+    RISCV_WRITEX ( q, uint64_t, "d" );
+  #else
+    RISCV_READX ( q, uint64_t, "d" );
+    RISCV_WRITEX ( q, uint64_t, "d" );
+  #endif
+#else
+  RISCV_READX_FUSED ( q, uint64_t, "w" );
+  RISCV_WRITEX_FUSED ( q, uint64_t, "w" );
+#endif
+
+/*
+ * Memory barrier
+ *
+ */
+static inline __always_inline void
+IOAPI_INLINE ( riscv, mb ) ( void ) {
+	__asm__ __volatile__ ( "fence rw, rw" );
+}
+
+/* Dummy PIO */
+DUMMY_PIO ( riscv );
+
+#endif /* _IPXE_RISCV_IO_H */

--- a/src/arch/riscv32/Makefile
+++ b/src/arch/riscv32/Makefile
@@ -1,0 +1,20 @@
+# RISCV32-specific directories containing source files
+#
+SRCDIRS		+= arch/riscv32/core
+SRCDIRS		+= arch/riscv32/libgcc
+
+# RISCV32-specific flags
+#
+CFLAGS		+= -march=rv32gc -mabi=ilp32d
+ASFLAGS		+= -march=rv32gc -mabi=ilp32d
+LDFLAGS		+= -m elf32lriscv
+
+# Include common RISCV Makefile
+#
+MAKEDEPS	+= arch/riscv/Makefile
+include arch/riscv/Makefile
+
+# Include platform-specific Makefile
+#
+MAKEDEPS	+= arch/riscv32/Makefile.$(PLATFORM)
+include arch/riscv32/Makefile.$(PLATFORM)

--- a/src/arch/riscv32/Makefile.efi
+++ b/src/arch/riscv32/Makefile.efi
@@ -1,0 +1,14 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# Specify EFI image builder
+#
+ELF2EFI		= $(ELF2EFI32)
+
+# Specify EFI boot file
+#
+EFI_BOOT_FILE	= bootriscv32.efi
+
+# Include generic EFI Makefile
+#
+MAKEDEPS	+= arch/riscv/Makefile.efi
+include arch/riscv/Makefile.efi

--- a/src/arch/riscv32/Makefile.linux
+++ b/src/arch/riscv32/Makefile.linux
@@ -1,0 +1,14 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# Starting virtual address
+#
+LDFLAGS += -Ttext=0x10000
+
+# Compiler flags for building host API wrapper
+#
+LINUX_CFLAGS += -march=rv32gc -mabi=ilp32d
+
+# Include generic Linux Makefile
+#
+MAKEDEPS += arch/riscv/Makefile.linux
+include arch/riscv/Makefile.linux

--- a/src/arch/riscv32/core/riscv32_byteswap.S
+++ b/src/arch/riscv32/core/riscv32_byteswap.S
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+	FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+/** @file
+ *
+ * Byte swapping
+ *
+ */
+
+	.section ".note.GNU-stack", "", @progbits
+	.text
+
+	.section ".text.riscv_swap", "ax", @progbits
+riscv_swap:
+	.globl	riscv_swap_word
+	.globl	riscv_swap_half
+	.globl	riscv_swap_byte
+riscv_swap_word:
+	/* Swap all bytes in a0 */
+	mv	t0, ra
+	jal	riscv_swap_half
+	mv	ra, t0
+	/* Swap words a0 and a1 */
+	mv	t1, a0
+	mv	a0, a1
+	mv	a1, t1
+riscv_swap_half:
+	/* Swap half-words within a0 */
+	slli	t2, a0, 16
+	srli	a0, a0, 16
+	or	a0, a0, t2
+riscv_swap_byte:
+	/* Swap bytes within each half-word of a0 */
+	li	t3, 0xff00ff00
+	slli	t4, a0, 8
+	and	a0, a0, t3
+	and	t4, t4, t3
+	srli	a0, a0, 8
+	or	a0, a0, t4
+	ret
+	.size	riscv_swap, . - riscv_swap

--- a/src/arch/riscv32/include/bits/profile.h
+++ b/src/arch/riscv32/include/bits/profile.h
@@ -1,0 +1,36 @@
+#ifndef _BITS_PROFILE_H
+#define _BITS_PROFILE_H
+
+/** @file
+ *
+ * Profiling
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+
+/**
+ * Get profiling timestamp
+ *
+ * @ret timestamp	Timestamp
+ */
+static inline __attribute__ (( always_inline )) uint64_t
+profile_timestamp ( void ) {
+	uint32_t cycles_lo;
+	uint32_t cycles_hi;
+	uint32_t tmp;
+
+	/* Read timestamp counter */
+	__asm__ __volatile__ ( "\n1:\n\t"
+			       "rdcycleh %1\n\t"
+			       "rdcycle %0\n\t"
+			       "rdcycleh %2\n\t"
+			       "bne %1, %2, 1b\n\t"
+			       : "=r" ( cycles_lo ), "=r" ( cycles_hi ),
+				 "=r" ( tmp ) );
+	return ( ( ( ( uint64_t ) cycles_hi ) << 32 ) | cycles_lo );
+}
+
+#endif /* _BITS_PROFILE_H */

--- a/src/arch/riscv32/include/ipxe/efi/dhcparch.h
+++ b/src/arch/riscv32/include/ipxe/efi/dhcparch.h
@@ -1,0 +1,20 @@
+#ifndef _IPXE_EFI_DHCPARCH_H
+#define _IPXE_EFI_DHCPARCH_H
+
+/** @file
+ *
+ * DHCP client architecture definitions
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <ipxe/dhcp.h>
+
+/** DHCP client architecture */
+#define DHCP_ARCH_CLIENT_ARCHITECTURE DHCP_CLIENT_ARCHITECTURE_RISCV32
+
+/** DHCP client network device interface */
+#define DHCP_ARCH_CLIENT_NDI 1 /* UNDI */ , 3, 10 /* v3.10 */
+
+#endif /* _IPXE_EFI_DHCPARCH_H */

--- a/src/arch/riscv32/include/limits.h
+++ b/src/arch/riscv32/include/limits.h
@@ -1,0 +1,61 @@
+#ifndef LIMITS_H
+#define LIMITS_H	1
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/* Number of bits in a `char' */
+#define CHAR_BIT	8
+
+/* Minimum and maximum values a `signed char' can hold */
+#define SCHAR_MIN	(-128)
+#define SCHAR_MAX	127
+
+/* Maximum value an `unsigned char' can hold. (Minimum is 0.) */
+#define UCHAR_MAX	255
+
+/* Minimum and maximum values a `char' can hold */
+#define CHAR_MIN	SCHAR_MIN
+#define CHAR_MAX	SCHAR_MAX
+
+/* Minimum and maximum values a `signed short int' can hold */
+#define SHRT_MIN	(-32768)
+#define SHRT_MAX	32767
+
+/* Maximum value an `unsigned short' can hold. (Minimum is 0.) */
+#define USHRT_MAX	65535
+
+
+/* Minimum and maximum values a `signed int' can hold */
+#define INT_MIN		(-INT_MAX - 1)
+#define INT_MAX		2147483647
+
+/* Maximum value an `unsigned int' can hold. (Minimum is 0.) */
+#define UINT_MAX	4294967295U
+
+
+/* Minimum and maximum values a `signed int' can hold */
+#define INT_MAX		2147483647
+#define INT_MIN		(-INT_MAX - 1)
+
+
+/* Maximum value an `unsigned int' can hold. (Minimum is 0.) */
+#define UINT_MAX	4294967295U
+
+
+/* Minimum and maximum values a `signed long' can hold */
+#define LONG_MAX	2147483647
+#define LONG_MIN	(-LONG_MAX - 1L)
+
+/* Maximum value an `unsigned long' can hold. (Minimum is 0.) */
+#define ULONG_MAX	4294967295UL
+
+/* Minimum and maximum values a `signed long long' can hold */
+#define LLONG_MAX	9223372036854775807LL
+#define LLONG_MIN	(-LONG_MAX - 1LL)
+
+
+/* Maximum value an `unsigned long long' can hold. (Minimum is 0.) */
+#define ULLONG_MAX	18446744073709551615ULL
+
+
+#endif /* LIMITS_H */

--- a/src/arch/riscv32/libgcc/llshift.S
+++ b/src/arch/riscv32/libgcc/llshift.S
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+	FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+/** @file
+ *
+ * Long shifts
+ *
+ */
+
+	.section ".note.GNU-stack", "", @progbits
+	.text
+
+/**
+ * Shift left
+ *
+ * @v a1:a0		Value to shift
+ * @v a2		Shift amount
+ * @ret a1:a0		Shifted value
+ */
+	.section ".text.__ashldi3", "ax", @progbits
+	.globl	__ashldi3
+__ashldi3:
+	/* Perform shift by 32 bits, if applicable */
+	li	t0, 32
+	sub	t1, t0, a2
+	bgtz	t1, 1f
+	mv	a1, a0
+	mv	a0, zero
+1:	/* Perform shift by modulo-32 bits, if applicable */
+	andi	a2, a2, 0x1f
+	beqz	a2, 2f
+	srl	t2, a0, t1
+	sll	a0, a0, a2
+	sll	a1, a1, a2
+	or	a1, a1, t2
+2:	ret
+	.size	__ashldi3, . - __ashldi3
+
+/**
+ * Logical shift right
+ *
+ * @v a1:a0		Value to shift
+ * @v a2		Shift amount
+ * @ret a1:a0		Shifted value
+ */
+	.section ".text.__lshrdi3", "ax", @progbits
+	.globl	__lshrdi3
+__lshrdi3:
+	/* Perform shift by 32 bits, if applicable */
+	li	t0, 32
+	sub	t1, t0, a2
+	bgtz	t1, 1f
+	mv	a0, a1
+	mv	a1, zero
+1:	/* Perform shift by modulo-32 bits, if applicable */
+	andi	a2, a2, 0x1f
+	beqz	a2, 2f
+	sll	t2, a1, t1
+	srl	a1, a1, a2
+	srl	a0, a0, a2
+	or	a0, a0, t2
+2:	ret
+	.size	__lshrdi3, . - __lshrdi3
+
+/**
+ * Arithmetic shift right
+ *
+ * @v a1:a0		Value to shift
+ * @v a2		Shift amount
+ * @ret a1:a0		Shifted value
+ */
+	.section ".text.__ashrdi3", "ax", @progbits
+	.globl	__ashrdi3
+__ashrdi3:
+	/* Perform shift by 32 bits, if applicable */
+	li	t0, 32
+	sub	t1, t0, a2
+	bgtz	t1, 1f
+	mv	a0, a1
+	srai	a1, a1, 16
+	srai	a1, a1, 16
+1:	/* Perform shift by modulo-32 bits, if applicable */
+	andi	a2, a2, 0x1f
+	beqz	a2, 2f
+	sll	t2, a1, t1
+	sra	a1, a1, a2
+	srl	a0, a0, a2
+	or	a0, a0, t2
+2:	ret
+	.size	__ashrdi3, . - __ashrdi3

--- a/src/arch/riscv64/Makefile
+++ b/src/arch/riscv64/Makefile
@@ -1,0 +1,19 @@
+# RISCV64-specific directories containing source files
+#
+SRCDIRS		+= arch/riscv64/core
+
+# RISCV64-specific flags
+#
+CFLAGS		+= -march=rv64gc -mabi=lp64d
+ASFLAGS		+= -march=rv64gc -mabi=lp64d
+LDFLAGS		+= -m elf64lriscv
+
+# Include common RISCV Makefile
+#
+MAKEDEPS	+= arch/riscv/Makefile
+include arch/riscv/Makefile
+
+# Include platform-specific Makefile
+#
+MAKEDEPS	+= arch/riscv64/Makefile.$(PLATFORM)
+include arch/riscv64/Makefile.$(PLATFORM)

--- a/src/arch/riscv64/Makefile.efi
+++ b/src/arch/riscv64/Makefile.efi
@@ -1,0 +1,14 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# Specify EFI image builder
+#
+ELF2EFI		= $(ELF2EFI64)
+
+# Specify EFI boot file
+#
+EFI_BOOT_FILE	= bootriscv64.efi
+
+# Include generic EFI Makefile
+#
+MAKEDEPS	+= arch/riscv/Makefile.efi
+include arch/riscv/Makefile.efi

--- a/src/arch/riscv64/Makefile.linux
+++ b/src/arch/riscv64/Makefile.linux
@@ -1,0 +1,10 @@
+# -*- makefile -*- : Force emacs to use Makefile mode
+
+# Starting virtual address
+#
+LDFLAGS += -Ttext=0x10000
+
+# Include generic Linux Makefile
+#
+MAKEDEPS += arch/riscv/Makefile.linux
+include arch/riscv/Makefile.linux

--- a/src/arch/riscv64/core/riscv64_byteswap.S
+++ b/src/arch/riscv64/core/riscv64_byteswap.S
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Michael Brown <mbrown@fensystems.co.uk>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+	FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+/** @file
+ *
+ * Byte swapping
+ *
+ */
+
+	.section ".note.GNU-stack", "", @progbits
+	.text
+
+	.section ".text.riscv_swap", "ax", @progbits
+riscv_swap:
+	.globl	riscv_swap_word
+	.globl	riscv_swap_half
+	.globl	riscv_swap_byte
+riscv_swap_word:
+	/* Swap low and high words of a0 */
+	slli	t0, a0, 32
+	srli	a0, a0, 32
+	or	a0, a0, t0
+riscv_swap_half:
+	/* Swap half-words within each word of a0 */
+	ld	t1, mask16
+	slli	t2, a0, 16
+	and	a0, a0, t1
+	and	t2, t2, t1
+	srli	a0, a0, 16
+	or	a0, a0, t2
+riscv_swap_byte:
+	/* Swap bytes within each half-word of a0 */
+	ld	t3, mask8
+	slli	t4, a0, 8
+	and	a0, a0, t3
+	and	t4, t4, t3
+	srli	a0, a0, 8
+	or	a0, a0, t4
+	ret
+mask16:	.dword 0xffff0000ffff0000
+mask8:	.dword 0xff00ff00ff00ff00
+	.size	riscv_swap, . - riscv_swap

--- a/src/arch/riscv64/include/bits/profile.h
+++ b/src/arch/riscv64/include/bits/profile.h
@@ -1,0 +1,28 @@
+#ifndef _BITS_PROFILE_H
+#define _BITS_PROFILE_H
+
+/** @file
+ *
+ * Profiling
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+
+/**
+ * Get profiling timestamp
+ *
+ * @ret timestamp	Timestamp
+ */
+static inline __attribute__ (( always_inline )) uint64_t
+profile_timestamp ( void ) {
+	uint64_t cycles;
+
+	/* Read timestamp counter */
+	__asm__ __volatile__ ( "rdcycle %0" : "=r" ( cycles ) );
+	return cycles;
+}
+
+#endif /* _BITS_PROFILE_H */

--- a/src/arch/riscv64/include/ipxe/efi/dhcparch.h
+++ b/src/arch/riscv64/include/ipxe/efi/dhcparch.h
@@ -1,0 +1,20 @@
+#ifndef _IPXE_EFI_DHCPARCH_H
+#define _IPXE_EFI_DHCPARCH_H
+
+/** @file
+ *
+ * DHCP client architecture definitions
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <ipxe/dhcp.h>
+
+/** DHCP client architecture */
+#define DHCP_ARCH_CLIENT_ARCHITECTURE DHCP_CLIENT_ARCHITECTURE_RISCV64
+
+/** DHCP client network device interface */
+#define DHCP_ARCH_CLIENT_NDI 1 /* UNDI */ , 3, 10 /* v3.10 */
+
+#endif /* _IPXE_EFI_DHCPARCH_H */

--- a/src/arch/riscv64/include/limits.h
+++ b/src/arch/riscv64/include/limits.h
@@ -1,0 +1,61 @@
+#ifndef LIMITS_H
+#define LIMITS_H	1
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/* Number of bits in a `char' */
+#define CHAR_BIT	8
+
+/* Minimum and maximum values a `signed char' can hold */
+#define SCHAR_MIN	(-128)
+#define SCHAR_MAX	127
+
+/* Maximum value an `unsigned char' can hold. (Minimum is 0.) */
+#define UCHAR_MAX	255
+
+/* Minimum and maximum values a `char' can hold */
+#define CHAR_MIN	SCHAR_MIN
+#define CHAR_MAX	SCHAR_MAX
+
+/* Minimum and maximum values a `signed short int' can hold */
+#define SHRT_MIN	(-32768)
+#define SHRT_MAX	32767
+
+/* Maximum value an `unsigned short' can hold. (Minimum is 0.) */
+#define USHRT_MAX	65535
+
+
+/* Minimum and maximum values a `signed int' can hold */
+#define INT_MIN		(-INT_MAX - 1)
+#define INT_MAX		2147483647
+
+/* Maximum value an `unsigned int' can hold. (Minimum is 0.) */
+#define UINT_MAX	4294967295U
+
+
+/* Minimum and maximum values a `signed int' can hold */
+#define INT_MAX		2147483647
+#define INT_MIN		(-INT_MAX - 1)
+
+
+/* Maximum value an `unsigned int' can hold. (Minimum is 0.) */
+#define UINT_MAX	4294967295U
+
+
+/* Minimum and maximum values a `signed long' can hold */
+#define LONG_MAX	9223372036854775807L
+#define LONG_MIN	(-LONG_MAX - 1L)
+
+/* Maximum value an `unsigned long' can hold. (Minimum is 0.) */
+#define ULONG_MAX	18446744073709551615UL
+
+/* Minimum and maximum values a `signed long long' can hold */
+#define LLONG_MAX	9223372036854775807LL
+#define LLONG_MIN	(-LONG_MAX - 1LL)
+
+
+/* Maximum value an `unsigned long long' can hold. (Minimum is 0.) */
+#define ULLONG_MAX	18446744073709551615ULL
+
+
+#endif /* LIMITS_H */

--- a/src/config/defaults/efi.h
+++ b/src/config/defaults/efi.h
@@ -71,4 +71,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define IOAPI_LOONG64
 #endif
 
+#if defined ( __riscv )
+#define IOAPI_RISCV
+#endif
+
 #endif /* CONFIG_DEFAULTS_EFI_H */

--- a/src/include/ipxe/efi/ProcessorBind.h
+++ b/src/include/ipxe/efi/ProcessorBind.h
@@ -65,6 +65,10 @@ typedef uint8_t BOOLEAN;
 #include <ipxe/efi/LoongArch64/ProcessorBind.h>
 #endif
 
+#ifdef __riscv
+#include <ipxe/efi/RiscV64/ProcessorBind.h>
+#endif
+
 #endif /* EFI_HOSTONLY */
 
 #endif /* _IPXE_EFI_PROCESSOR_BIND_H */

--- a/src/include/ipxe/efi/RiscV64/ProcessorBind.h
+++ b/src/include/ipxe/efi/RiscV64/ProcessorBind.h
@@ -1,0 +1,175 @@
+/** @file
+  Processor or Compiler specific defines and types for RISC-V
+
+  Copyright (c) 2016 - 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef PROCESSOR_BIND_H__
+#define PROCESSOR_BIND_H__
+
+FILE_LICENCE ( BSD2_PATENT );
+
+///
+/// Define the processor type so other code can make processor based choices
+///
+#define MDE_CPU_RISCV64
+
+//
+// Make sure we are using the correct packing rules per EFI specification
+//
+#if !defined (__GNUC__)
+  #pragma pack()
+#endif
+
+///
+/// 8-byte unsigned value
+///
+typedef unsigned long long UINT64  __attribute__ ((aligned (8)));
+///
+/// 8-byte signed value
+///
+typedef long long INT64  __attribute__ ((aligned (8)));
+///
+/// 4-byte unsigned value
+///
+typedef unsigned int UINT32 __attribute__ ((aligned (4)));
+///
+/// 4-byte signed value
+///
+typedef int INT32  __attribute__ ((aligned (4)));
+///
+/// 2-byte unsigned value
+///
+typedef unsigned short UINT16  __attribute__ ((aligned (2)));
+///
+/// 2-byte Character.  Unless otherwise specified all strings are stored in the
+/// UTF-16 encoding format as defined by Unicode 2.1 and ISO/IEC 10646 standards.
+///
+typedef unsigned short CHAR16  __attribute__ ((aligned (2)));
+///
+/// 2-byte signed value
+///
+typedef short INT16  __attribute__ ((aligned (2)));
+///
+/// Logical Boolean.  1-byte value containing 0 for FALSE or a 1 for TRUE.  Other
+/// values are undefined.
+///
+typedef unsigned char BOOLEAN;
+///
+/// 1-byte unsigned value
+///
+typedef unsigned char UINT8;
+///
+/// 1-byte Character
+///
+typedef char CHAR8;
+///
+/// 1-byte signed value
+///
+typedef signed char INT8;
+///
+/// Unsigned value of native width.  (4 bytes on supported 32-bit processor instructions,
+/// 8 bytes on supported 64-bit processor instructions)
+///
+typedef UINT64 UINTN __attribute__ ((aligned (8)));
+///
+/// Signed value of native width.  (4 bytes on supported 32-bit processor instructions,
+/// 8 bytes on supported 64-bit processor instructions)
+///
+typedef INT64 INTN __attribute__ ((aligned (8)));
+
+//
+// Processor specific defines
+//
+
+///
+/// A value of native width with the highest bit set.
+///
+#define MAX_BIT  0x8000000000000000ULL
+///
+/// A value of native width with the two highest bits set.
+///
+#define MAX_2_BITS  0xC000000000000000ULL
+
+///
+/// Maximum legal RV64 address
+///
+#define MAX_ADDRESS  0xFFFFFFFFFFFFFFFFULL
+
+///
+/// Maximum usable address at boot time (48 bits using 4 KB pages in Supervisor mode)
+///
+#define MAX_ALLOC_ADDRESS  0xFFFFFFFFFFFFULL
+
+///
+/// Maximum legal RISC-V INTN and UINTN values.
+///
+#define MAX_INTN   ((INTN)0x7FFFFFFFFFFFFFFFULL)
+#define MAX_UINTN  ((UINTN)0xFFFFFFFFFFFFFFFFULL)
+
+///
+/// The stack alignment required for RISC-V
+///
+#define CPU_STACK_ALIGNMENT  16
+
+///
+/// Page allocation granularity for RISC-V
+///
+#define DEFAULT_PAGE_ALLOCATION_GRANULARITY  (0x1000)
+#define RUNTIME_PAGE_ALLOCATION_GRANULARITY  (0x1000)
+
+//
+// Modifier to ensure that all protocol member functions and EFI intrinsics
+// use the correct C calling convention. All protocol member functions and
+// EFI intrinsics are required to modify their member functions with EFIAPI.
+//
+#ifdef EFIAPI
+///
+/// If EFIAPI is already defined, then we use that definition.
+///
+#elif defined (__GNUC__)
+///
+/// Define the standard calling convention regardless of optimization level
+/// The GCC support assumes a GCC compiler that supports the EFI ABI. The EFI
+/// ABI is much closer to the x64 Microsoft* ABI than standard x64 (x86-64)
+/// GCC ABI. Thus a standard x64 (x86-64) GCC compiler can not be used for
+/// x64. Warning the assembly code in the MDE x64 does not follow the correct
+/// ABI for the standard x64 (x86-64) GCC.
+///
+#define EFIAPI
+#else
+///
+/// The default for a non Microsoft* or GCC compiler is to assume the EFI ABI
+/// is the standard.
+///
+#define EFIAPI
+#endif
+
+#if defined (__GNUC__)
+///
+/// For GNU assembly code, .global or .globl can declare global symbols.
+/// Define this macro to unify the usage.
+///
+#define ASM_GLOBAL  .globl
+#endif
+
+/**
+  Return the pointer to the first instruction of a function given a function pointer.
+  On x64 CPU architectures, these two pointer values are the same,
+  so the implementation of this macro is very simple.
+
+  @param  FunctionPointer   A pointer to a function.
+
+  @return The pointer to the first instruction of a function given a function pointer.
+
+**/
+#define FUNCTION_ENTRY_POINT(FunctionPointer)  (VOID *)(UINTN)(FunctionPointer)
+
+#ifndef __USER_LABEL_PREFIX__
+#define __USER_LABEL_PREFIX__
+#endif
+
+#endif

--- a/src/util/efirom.c
+++ b/src/util/efirom.c
@@ -91,11 +91,13 @@ static void read_pe_info ( void *pe, uint16_t *machine,
 	switch ( *machine ) {
 	case EFI_IMAGE_MACHINE_IA32:
 	case EFI_IMAGE_MACHINE_ARMTHUMB_MIXED:
+	case EFI_IMAGE_MACHINE_RISCV32:
 		*subsystem = nt->nt32.OptionalHeader.Subsystem;
 		break;
 	case EFI_IMAGE_MACHINE_X64:
 	case EFI_IMAGE_MACHINE_AARCH64:
 	case EFI_IMAGE_MACHINE_LOONGARCH64:
+	case EFI_IMAGE_MACHINE_RISCV64:
 		*subsystem = nt->nt64.OptionalHeader.Subsystem;
 		break;
 	default:

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -83,6 +83,9 @@
 #ifndef EM_AARCH64
 #define EM_AARCH64 183
 #endif
+#ifndef EM_RISCV
+#define EM_RISCV 243
+#endif
 #ifndef EM_LOONGARCH
 #define EM_LOONGARCH 258
 #endif
@@ -166,6 +169,45 @@
 #endif
 #ifndef R_LARCH_PCREL20_S2
 #define R_LARCH_PCREL20_S2 103
+#endif
+#ifndef R_RISCV_NONE
+#define R_RISCV_NONE 0
+#endif
+#ifndef R_RISCV_32
+#define R_RISCV_32 1
+#endif
+#ifndef R_RISCV_64
+#define R_RISCV_64 2
+#endif
+#ifndef R_RISCV_BRANCH
+#define R_RISCV_BRANCH 16
+#endif
+#ifndef R_RISCV_JAL
+#define R_RISCV_JAL 17
+#endif
+#ifndef R_RISCV_PCREL_HI20
+#define R_RISCV_PCREL_HI20 23
+#endif
+#ifndef R_RISCV_PCREL_LO12_I
+#define R_RISCV_PCREL_LO12_I 24
+#endif
+#ifndef R_RISCV_PCREL_LO12_S
+#define R_RISCV_PCREL_LO12_S 25
+#endif
+#ifndef R_RISCV_ADD32
+#define R_RISCV_ADD32 35
+#endif
+#ifndef R_RISCV_SUB32
+#define R_RISCV_SUB32 39
+#endif
+#ifndef R_RISCV_RVC_BRANCH
+#define R_RISCV_RVC_BRANCH 44
+#endif
+#ifndef R_RISCV_RVC_JUMP
+#define R_RISCV_RVC_JUMP 45
+#endif
+#ifndef R_RISCV_RELAX
+#define R_RISCV_RELAX 51
 #endif
 #ifndef R_X86_64_GOTPCRELX
 #define R_X86_64_GOTPCRELX 41
@@ -596,6 +638,11 @@ static void set_machine ( struct elf_file *elf, struct pe_header *pe_header ) {
 	case EM_LOONGARCH:
 		machine = EFI_IMAGE_MACHINE_LOONGARCH64;
 		break;
+	case EM_RISCV:
+		machine = ( ( ELFCLASS == ELFCLASS64 ) ?
+			    EFI_IMAGE_MACHINE_RISCV64 :
+			    EFI_IMAGE_MACHINE_RISCV32 );
+		break;
 	default:
 		eprintf ( "Unknown ELF architecture %d\n", ehdr->e_machine );
 		exit ( 1 );
@@ -828,16 +875,19 @@ static void process_reloc ( struct elf_file *elf, const Elf_Shdr *shdr,
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_NONE ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_NULL ) :
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_NONE ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_NONE ) :
 			/* Ignore dummy relocations used by REQUIRE_SYMBOL() */
 			break;
 		case ELF_MREL ( EM_386, R_386_32 ) :
 		case ELF_MREL ( EM_ARM, R_ARM_ABS32 ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_32 ) :
 			/* Generate a 4-byte PE relocation */
 			generate_pe_reloc ( pe_reltab, offset, 4 );
 			break;
 		case ELF_MREL ( EM_X86_64, R_X86_64_64 ) :
 		case ELF_MREL ( EM_AARCH64, R_AARCH64_ABS64 ) :
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_64 ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_64 ) :
 			/* Generate an 8-byte PE relocation */
 			generate_pe_reloc ( pe_reltab, offset, 8 );
 			break;
@@ -869,14 +919,29 @@ static void process_reloc ( struct elf_file *elf, const Elf_Shdr *shdr,
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_GOT_PC_HI20 ):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_GOT_PC_LO12 ):
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_PCREL20_S2 ):
+		case ELF_MREL ( EM_RISCV, R_RISCV_BRANCH ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_JAL ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_PCREL_HI20 ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_PCREL_LO12_I ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_PCREL_LO12_S ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_RVC_BRANCH ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_RVC_JUMP ) :
 			/* Skip PC-relative relocations; all relative
 			 * offsets remain unaltered when the object is
 			 * loaded.
 			 */
 			break;
 		case ELF_MREL ( EM_LOONGARCH, R_LARCH_RELAX ):
+		case ELF_MREL ( EM_RISCV, R_RISCV_RELAX ) :
 			/* Relocation can be relaxed (optimized out).
 			 * Ignore it for now.
+			 */
+			break;
+		case ELF_MREL ( EM_RISCV, R_RISCV_ADD32 ) :
+		case ELF_MREL ( EM_RISCV, R_RISCV_SUB32 ) :
+			/* Ignore label difference relocations since
+			 * we do not perform any relocations that can
+			 * result in altered label differences.
 			 */
 			break;
 		case ELF_MREL ( EM_X86_64, R_X86_64_32 ) :

--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -78,6 +78,12 @@ efi_boot_name() {
 	"64aa" )
 	    echo "BOOTAA64.EFI"
 	    ;;
+	"6450" )
+	    echo "BOOTRISCV64.EFI"
+	    ;;
+	"3250" )
+	    echo "BOOTRISCV32.EFI"
+	    ;;
 	* )
 	    echo "${FILENAME}: unrecognised EFI architecture ${ARCH}" >&2
 	    exit 1


### PR DESCRIPTION
Add support for building iPXE as a 64-bit or 32-bit RISC-V binary, for either UEFI or Linux userspace platforms.  For example:
```
# RISC-V 64-bit UEFI
make CROSS=riscv64-linux-gnu- bin-riscv64-efi/ipxe.efi
```
```
# RISC-V 32-bit UEFI
make CROSS=riscv64-linux-gnu- bin-riscv32-efi/ipxe.efi
```
```
# RISC-V 64-bit Linux
make CROSS=riscv64-linux-gnu- bin-riscv64-linux/tests.linux
qemu-riscv64 -L /usr/riscv64-linux-gnu/sys-root \
             ./bin-riscv64-linux/tests.linux
```
```
# RISC-V 32-bit Linux
make CROSS=riscv64-linux-gnu- SYSROOT=/usr/riscv32-linux-gnu/sys-root \
     bin-riscv32-linux/tests.linux
qemu-riscv32 -L /usr/riscv32-linux-gnu/sys-root \
             ./bin-riscv32-linux/tests.linux
```