### PR TITLE
[core] Add a new `isin` command

### DIFF
--- a/src/core/exec.c
+++ b/src/core/exec.c
@@ -549,6 +549,42 @@ struct command iseq_command __command = {
 	.exec = iseq_exec,
 };
 
+/** "isin" options */
+struct isin_options {};
+
+/** "isin" option list */
+static struct option_descriptor isin_opts[] = {};
+
+/** "isin" command descriptor */
+static struct command_descriptor isin_cmd =
+	COMMAND_DESC ( struct isin_options, isin_opts, 2, 2,
+					 "<string> <substring>");
+
+/**
+ * "isin" command
+ *
+ * @v argc    Argument count
+ * @v argv    Argument list
+ * @ret rc    Return status code
+ */
+static int isin_exec (int argc, char **argv ) {
+	struct isin_options opts;
+	int rc;
+
+	/* Parse options */
+	if ( ( rc = parse_options ( argc, argv, &isin_cmd, &opts ) ) != 0 )
+		return rc;
+
+	/* Return success if first string contains second string */
+	return ( ( strstr ( argv[optind], argv[ optind +1 ] ) != NULL ) ?
+		0: -ERANGE );
+}
+
+struct command isin_command __command = {
+	.name = "isin",
+	.exec = isin_exec,
+};
+
 /** "sleep" options */
 struct sleep_options {};
 


### PR DESCRIPTION
Hi everyone ! 

We recently started using iPXE, but we lacked a proper way to write script like we wanted to. Especially because for some reason the SMBIOS data where not correctly formatted (whitespaces and other misc...). 

One easy solution for us was to be able to check that a certain substring was present in another string. But the iPXE shell was missing a command for this. That's the problem I'm trying to address with this PR.

For this, I wrote a new `isin` command. It is quite similar to the `iseq` command, but instead of comparing equality, it will compare the presence of the second string (the substring) in the first string.

```
iPXE> isin --help
Usage:

  isin <string> <substring>

See https://ipxe.org/cmd/isin for further information
iPXE> isin ${product} Capri2 && echo is_in || echo is_not_in
is_in
iPXE> isin ${product} test && echo is_in || echo is_not_in
is_not_in
iPXE> echo ${product}
Capri2
```

This is my first time ever writing C code, but it was fairly easy to do since the `iseq` command is quite similar. However if I'm missing something, feel free to say it to me and I'll correct my code.

Also if I'm missing something like adding documentation : Please, let me know, and I'll add whatever is required for this PR to be accepted!

Thanks in advance for your time,
Renaud. 

