### PR TITLE
[efi] Ensure local drives are connected when attempting a SAN boot

### DIFF
--- a/src/interface/efi/efi_block.c
+++ b/src/interface/efi/efi_block.c
@@ -990,6 +990,9 @@ static int efi_block_boot ( unsigned int drive,
 	EFI_STATUS efirc;
 	int rc;
 
+	/* Ensure that any local drives are connected */
+	efi_driver_reconnect_all();
+
 	/* Release SNP devices */
 	efi_snp_release();
 


### PR DESCRIPTION
UEFI systems may choose not to connect drivers for local disk drives when the boot policy is set to attempt a network boot.  This may cause the "sanboot" command to be unable to boot from a local drive, since the relevant block device and filesystem drivers may not have been connected.

Fix by ensuring that all available drivers are connected before attempting to boot from an EFI block device.

Fixes: #1334 

Reported-by: Andrew Cottrell <andrew.cottrell@xtxmarkets.com>
Tested-by: Andrew Cottrell <andrew.cottrell@xtxmarkets.com>