### PR TITLE
[gve] Fix hang in gve_startup() if device is closed

### DIFF
--- a/src/drivers/net/gve.c
+++ b/src/drivers/net/gve.c
@@ -1050,6 +1050,9 @@ static void gve_startup ( struct gve_nic *gve ) {
 	struct net_device *netdev = gve->netdev;
 	int rc;
 
+	if ( ! netdev_is_open( netdev ) )
+		return;
+
 	/* Reset device */
 	if ( ( rc = gve_reset ( gve ) ) != 0 )
 		goto err_reset;


### PR DESCRIPTION
[gve] Fix hang in gve_startup() if device is closed

Ensure startup only happens on an open device, as queue resources are only valid when a device is open.

Fixes #1345.