### PR TITLE
[bnxt] Allocate TX rings with firmware input

### DIFF
--- a/src/drivers/net/bnxt/bnxt.c
+++ b/src/drivers/net/bnxt/bnxt.c
@@ -1840,7 +1840,7 @@ static int bnxt_hwrm_ring_alloc ( struct bnxt *bp, u8 type )
 		req->page_size   = LM_PAGE_BITS ( 8 );
 		req->int_mode    = RING_ALLOC_REQ_INT_MODE_POLL;
 		req->length 	 = ( u32 )bp->tx.ring_cnt;
-		req->queue_id    = TX_RING_QID;
+		req->queue_id    = ( u16 )bp->queue_id;
 		req->stat_ctx_id = ( u32 )bp->stat_ctx_id;
 		req->cmpl_ring_id  = bp->cq_ring_id;
 		req->page_tbl_addr = virt_to_bus ( bp->tx.bd_virt );

--- a/src/drivers/net/bnxt/bnxt.h
+++ b/src/drivers/net/bnxt/bnxt.h
@@ -178,7 +178,6 @@ union dma_addr64_t {
 	RX_MASK_ACCEPT_MULTICAST)
 #define MAX_NQ_DESC_CNT                         64
 #define NQ_RING_BUFFER_SIZE (MAX_NQ_DESC_CNT * sizeof(struct cmpl_base))
-#define TX_RING_QID (FLAG_TEST(bp->flags, BNXT_FLAG_IS_CHIP_P5_PLUS) ? (u16)bp->queue_id : ((u16)bp->port_idx * 10))
 #define RX_RING_QID (FLAG_TEST(bp->flags, BNXT_FLAG_IS_CHIP_P5_PLUS) ? bp->queue_id : 0)
 #define STAT_CTX_ID ((bp->vf || FLAG_TEST(bp->flags, BNXT_FLAG_IS_CHIP_P5_PLUS)) ? bp->stat_ctx_id : 0)
 #define TX_AVAIL(r)                      (r - 1)


### PR DESCRIPTION
Use queue_id value, retrieved from firmware, unconditionally when allocating TX rings.

Signed-off by: Joseph Wong <joseph.wong@broadcom.com>