### PR TITLE
[crypto] Start up RBG on demand if needed

### DIFF
--- a/src/include/ipxe/rbg.h
+++ b/src/include/ipxe/rbg.h
@@ -16,28 +16,13 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 struct random_bit_generator {
 	/** DRBG state */
 	struct drbg_state state;
+	/** Startup has been attempted */
+	int started;
 };
 
 extern struct random_bit_generator rbg;
 
-/**
- * Generate bits using RBG
- *
- * @v additional	Additional input
- * @v additional_len	Length of additional input
- * @v prediction_resist	Prediction resistance is required
- * @v data		Output buffer
- * @v len		Length of output buffer
- * @ret rc		Return status code
- *
- * This is the RBG_Generate function defined in ANS X9.82 Part 4
- * (April 2011 Draft) Section 9.1.2.2.
- */
-static inline int rbg_generate ( const void *additional, size_t additional_len,
-				 int prediction_resist, void *data,
-				 size_t len ) {
-	return drbg_generate ( &rbg.state, additional, additional_len,
-			       prediction_resist, data, len );
-}
+extern int rbg_generate ( const void *additional, size_t additional_len,
+			  int prediction_resist, void *data, size_t len );
 
 #endif /* _IPXE_RBG_H */


### PR DESCRIPTION
The ANS X9.82 specification implicitly assumes that the RBG_Startup function will be called before it is needed, and includes checks to make sure that Generate_function fails if this has not happened. However, there is no well-defined point at which the RBG_Startup function is to be called: it's just assumed that this happens as part of system startup.

We currently call RBG_Startup to instantiate the DRBG as an iPXE startup function, with the corresponding shutdown function uninstantiating the DRBG.  This works for most use cases, and avoids an otherwise unexpected user-visible delay when a caller first attempts to use the DRBG (e.g. by attempting an HTTPS download).

The download of autoexec.ipxe for UEFI is triggered by the EFI root bus probe in efi_probe().  Both the root bus probe and the RBG startup function run at STARTUP_NORMAL, so there is no defined ordering between them.  If the base URI for autoexec.ipxe uses HTTPS, then this may cause random bits to be requested before the RBG has been started.

Extend the logic in rbg_generate() to automatically start up the RBG if startup has not already been attempted.  If startup fails (e.g. because the entropy source is broken), then do not automatically retry since this could result in extremely long delays waiting for entropy that will never arrive.

Fixes: #1408 

Reported-by: Michael Niehaus <niehaus@live.com>