### PR TITLE
[menu] Allow a post-activity timeout to be defined

### DIFF
--- a/src/hci/commands/dynui_cmd.c
+++ b/src/hci/commands/dynui_cmd.c
@@ -207,8 +207,10 @@ static int item_exec ( int argc, char **argv ) {
 struct choose_options {
 	/** Dynamic user interface name */
 	char *dynui;
-	/** Timeout */
+	/** Initial timeout */
 	unsigned long timeout;
+	/** Post-activity timeout */
+	unsigned long retimeout;
 	/** Default selection */
 	char *select;
 	/** Keep dynamic user interface */
@@ -223,6 +225,8 @@ static struct option_descriptor choose_opts[] = {
 		      struct choose_options, select, parse_string ),
 	OPTION_DESC ( "timeout", 't', required_argument,
 		      struct choose_options, timeout, parse_timeout ),
+	OPTION_DESC ( "retimeout", 'r', required_argument,
+		      struct choose_options, retimeout, parse_timeout ),
 	OPTION_DESC ( "keep", 'k', no_argument,
 		      struct choose_options, keep, parse_flag ),
 };
@@ -259,8 +263,8 @@ static int choose_exec ( int argc, char **argv ) {
 		goto err_parse_dynui;
 
 	/* Show as menu */
-	if ( ( rc = show_menu ( dynui, opts.timeout, opts.select,
-				&item ) ) != 0 )
+	if ( ( rc = show_menu ( dynui, opts.timeout, opts.retimeout,
+				opts.select, &item ) ) != 0 )
 		goto err_show_menu;
 
 	/* Apply default type if necessary */

--- a/src/include/ipxe/dynui.h
+++ b/src/include/ipxe/dynui.h
@@ -60,7 +60,8 @@ extern struct dynamic_item * dynui_item ( struct dynamic_ui *dynui,
 extern struct dynamic_item * dynui_shortcut ( struct dynamic_ui *dynui,
 					      int key );
 extern int show_menu ( struct dynamic_ui *dynui, unsigned long timeout,
-		       const char *select, struct dynamic_item **selected );
+		       unsigned long retimeout, const char *select,
+		       struct dynamic_item **selected );
 extern int show_form ( struct dynamic_ui *dynui );
 
 #endif /* _IPXE_DYNUI_H */


### PR DESCRIPTION
Allow the "--retimeout" option to be used to specify a timeout value that will be (re)applied after each keypress activity.  This allows script authors to ensure that a single (potentially accidental) keypress will not pause the boot process indefinitely.

Fixes: #1412 