### PR TITLE
[lkrnprefix] Support for longer version string

### DIFF
--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -54,7 +54,7 @@ jump:
 	/* Manually specify a two-byte jmp instruction here rather
 	 * than leaving it up to the assembler.
 	 */
-	.byte	0xeb, ( setup - header )
+	.byte	0xeb, ( _setup - header )
 header:
 	.byte	'H', 'd', 'r', 'S'
 version:
@@ -103,6 +103,9 @@ hardware_subarch:
 	.long	0
 hardware_subarch_data:
 	.byte	0, 0, 0, 0, 0, 0, 0, 0
+
+_setup:
+	jmp	setup
 
 version_string:
 	.asciz	VERSION


### PR DESCRIPTION
The lkrnprefix.S file contains a hardcoded 2-byte jump instruction to the setup function. When the version string is too long, the relative offset becomes larger than 127 bytes and the jump instruction is no longer valid. This patch fixes the issue by inserting a label _setup before the version string and the hardcoded jump instruction is changed to jump to _setup. We then jump to the setup function from _setup.