### PR TITLE
[iscsi] Fix reverse CHAP auth

### DIFF
--- a/src/net/tcp/iscsi.c
+++ b/src/net/tcp/iscsi.c
@@ -789,8 +789,12 @@ static void iscsi_start_login ( struct iscsi_session *iscsi ) {
 	iscsi_start_tx ( iscsi );
 	request->opcode = ( ISCSI_OPCODE_LOGIN_REQUEST |
 			    ISCSI_FLAG_IMMEDIATE );
-	request->flags = ( ( iscsi->status & ISCSI_STATUS_PHASE_MASK ) |
-			   ISCSI_LOGIN_FLAG_TRANSITION );
+	request->flags = ( ( iscsi->status & ISCSI_STATUS_PHASE_MASK ));
+	/* transition to next stage only on the final CHAP message */
+	if (!(iscsi->status & ISCSI_STATUS_STRINGS_SECURITY) || 
+		 (iscsi->status & ISCSI_STATUS_STRINGS_CHAP_RESPONSE) )  {
+		request->flags |= ISCSI_LOGIN_FLAG_TRANSITION; 
+	}
 	/* version_max and version_min left as zero */
 	len = iscsi_build_login_request_strings ( iscsi, NULL, 0 );
 	ISCSI_SET_LENGTHS ( request->lengths, 0, len );


### PR DESCRIPTION
The code currently failed on reversed authing on LIO target. The error message are :
  iSCSI %p nefarious target tried to bypass authentication

This error is caused by ipxe incorrectly setting the Transition bit.

Accoding to [RFC 7143](https://datatracker.ietf.org/doc/html/rfc7143#page-265), the Transition bit should only be set on the final round of CHAP login request. But ipxe set the Transition bit at all time.

This patch fix this issue by only setting the Transition bit on the final round of CHAP login request.