### PR TITLE
Fix C23 build, error "unterminated-string-initialization"

### DIFF
--- a/src/arch/x86/image/ucode.c
+++ b/src/arch/x86/image/ucode.c
@@ -67,7 +67,7 @@ union ucode_vendor_id {
 	/** CPUID registers */
 	uint32_t dword[3];
 	/** Human-readable string */
-	uint8_t string[12];
+	uint8_t string[13];
 };
 
 /** A CPU vendor */

--- a/src/arch/x86/interface/vmware/vmconsole.c
+++ b/src/arch/x86/interface/vmware/vmconsole.c
@@ -50,7 +50,7 @@ static int vmconsole_channel;
 
 /** VMware logfile console line buffer */
 static struct {
-	char prefix[4];
+	char prefix[5];
 	char message[VMCONSOLE_BUFSIZE];
 } vmconsole_buffer = {
 	.prefix = "log ",

--- a/src/core/version.c
+++ b/src/core/version.c
@@ -121,4 +121,4 @@ const char build_name_prefix[] __attribute__ (( section ( ".prefix.name" ) ))
 #define SBAT_DATA SBAT_HEADER "" SBAT_IPXE "" SBAT_PRODUCT
 
 /** SBAT data (without any NUL terminator) */
-const char sbat[ sizeof ( SBAT_DATA ) - 1 ] __sbat = SBAT_DATA;
+const char sbat[ sizeof ( SBAT_DATA ) ] __sbat = SBAT_DATA;

--- a/src/crypto/mschapv2.c
+++ b/src/crypto/mschapv2.c
@@ -96,11 +96,11 @@ union mschapv2_password_hash {
 };
 
 /** MS-CHAPv2 magic constant 1 */
-static const char mschapv2_magic1[39] =
+static const char mschapv2_magic1[40] =
 	"Magic server to client signing constant";
 
 /** MS-CHAPv2 magic constant 2 */
-static const char mschapv2_magic2[41] =
+static const char mschapv2_magic2[42] =
 	"Pad to make it do more than one iteration";
 
 /**

--- a/src/drivers/net/3c595.c
+++ b/src/drivers/net/3c595.c
@@ -342,8 +342,7 @@ eeprom_rdy()
  * before
  */
 static int
-get_e(offset)
-int offset;
+get_e(int offset)
 {
 	if (!eeprom_rdy())
 		return (0xffff);

--- a/src/include/ipxe/efi/Protocol/NetworkInterfaceIdentifier.h
+++ b/src/include/ipxe/efi/Protocol/NetworkInterfaceIdentifier.h
@@ -62,7 +62,7 @@ struct _EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL {
   UINT64     ImageAddr;     ///< The address of the first byte of the identifying structure for this
                             ///< network interface.  This is set to zero if there is no structure.
   UINT32     ImageSize;     ///< The size of unrelocated network interface image.
-  CHAR8      StringId[4];   ///< A four-character ASCII string that is sent in the class identifier field of
+  CHAR8      StringId[5];   ///< A four-character ASCII string that is sent in the class identifier field of
                             ///< option 60 in DHCP. For a Type of EfiNetworkInterfaceUndi, this field is UNDI.
   UINT8      Type;          ///< Network interface type. This will be set to one of the values
                             ///< in EFI_NETWORK_INTERFACE_TYPE.

--- a/src/include/ipxe/eltorito.h
+++ b/src/include/ipxe/eltorito.h
@@ -18,7 +18,7 @@ struct eltorito_descriptor_fixed {
 	/** Descriptor type */
 	uint8_t type;
 	/** Identifier ("CD001") */
-	uint8_t id[5];
+	uint8_t id[6];
 	/** Version, must be 1 */
 	uint8_t version;
 	/** Boot system indicator; must be "EL TORITO SPECIFICATION" */

--- a/src/include/ipxe/iso9660.h
+++ b/src/include/ipxe/iso9660.h
@@ -20,7 +20,7 @@ struct iso9660_primary_descriptor_fixed {
 	/** Descriptor type */
 	uint8_t type;
 	/** Identifier ("CD001") */
-	uint8_t id[5];
+	uint8_t id[6];
 } __attribute__ (( packed ));
 
 /** An ISO9660 Primary Volume Descriptor */

--- a/src/include/ipxe/mschapv2.h
+++ b/src/include/ipxe/mschapv2.h
@@ -44,7 +44,7 @@ struct mschapv2_auth {
 	 * hexadecimal encoding of the actual authenticator response
 	 * value.  Joy.
 	 */
-	char wtf[42];
+	char wtf[43];
 } __attribute__ (( packed ));
 
 extern void mschapv2_response ( const char *username, const char *password,

--- a/src/include/ipxe/pccrd.h
+++ b/src/include/ipxe/pccrd.h
@@ -23,7 +23,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 /** A PeerDist discovery reply block count */
 struct peerdist_discovery_block_count {
 	/** Count (as an eight-digit hex value) */
-	char hex[8];
+	char hex[9];
 } __attribute__ (( packed ));
 
 /** A PeerDist discovery reply */

--- a/src/tests/acpi_test.c
+++ b/src/tests/acpi_test.c
@@ -41,7 +41,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 /** An ACPI test table signature */
 union acpi_test_signature {
 	/** String */
-	char str[4];
+	char str[5];
 	/** Raw value */
 	uint32_t raw;
 };


### PR DESCRIPTION
In C23, a string literal must fit in its array including its NUL terminator.

In version.c, the comment says there should not be a NUL terminator in SBAT data. But it seems there was one, at least in sbat.h. So either this is an old bug, or the comment should be changed.

Fix typo in xenver.h.

Fixes: #1419
