### PR TITLE
[initrd] Use physical addresses for calculations on initrd locations

### DIFF
--- a/src/arch/x86/image/bzimage.c
+++ b/src/arch/x86/image/bzimage.c
@@ -416,7 +416,7 @@ static size_t bzimage_load_initrd ( struct image *image,
 static int bzimage_check_initrds ( struct image *image,
 				   struct bzimage_context *bzimg ) {
 	struct image *initrd;
-	userptr_t bottom;
+	physaddr_t bottom;
 	size_t len = 0;
 	int rc;
 
@@ -437,7 +437,7 @@ static int bzimage_check_initrds ( struct image *image,
 	}
 
 	/* Calculate lowest usable address */
-	bottom = ( bzimg->pm_kernel + bzimg->pm_sz );
+	bottom = virt_to_phys ( bzimg->pm_kernel + bzimg->pm_sz );
 
 	/* Check that total length fits within space available for
 	 * reshuffling.  This is a conservative check, since CPIO
@@ -451,7 +451,7 @@ static int bzimage_check_initrds ( struct image *image,
 	}
 
 	/* Check that total length fits within kernel's memory limit */
-	if ( ( virt_to_phys ( bottom ) + len ) > bzimg->mem_limit ) {
+	if ( ( bottom + len ) > bzimg->mem_limit ) {
 		DBGC ( image, "bzImage %s not enough space for initrds\n",
 		       image->name );
 		return -ENOBUFS;
@@ -477,7 +477,7 @@ static void bzimage_load_initrds ( struct image *image,
 	size_t len;
 
 	/* Reshuffle initrds into desired order */
-	initrd_reshuffle ( bzimg->pm_kernel + bzimg->pm_sz );
+	initrd_reshuffle ( virt_to_phys ( bzimg->pm_kernel + bzimg->pm_sz ) );
 
 	/* Find highest initrd */
 	for_each_image ( initrd ) {

--- a/src/arch/x86/include/initrd.h
+++ b/src/arch/x86/include/initrd.h
@@ -9,7 +9,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
-#include <ipxe/uaccess.h>
+#include <stdint.h>
 
 /** Minimum free space required to reshuffle initrds
  *
@@ -17,7 +17,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 #define INITRD_MIN_FREE_LEN ( 512 * 1024 )
 
-extern void initrd_reshuffle ( userptr_t bottom );
-extern int initrd_reshuffle_check ( size_t len, userptr_t bottom );
+extern void initrd_reshuffle ( physaddr_t bottom );
+extern int initrd_reshuffle_check ( size_t len, physaddr_t bottom );
 
 #endif /* _INITRD_H */


### PR DESCRIPTION
Commit ef03849 ("[uaccess] Remove redundant userptr_add() and userptr_diff()") exposed a signedness bug in the comparison of initrd locations, since the expression (initrd->data - current) was effectively no longer coerced to a signed type.

In particular, the common case will be that the top of the initrd region is the start of the iPXE .textdata region, which has virtual address zero.  This causes initrd->data to compare as being above the top of the initrd region for all images, when this bug would previously have been limited to affecting only initrds placed 2GB or more below the start of .textdata.

Fix by using physical addresses for all comparisons on initrd locations.

Fixes: #1454 

Reported-by: Sven Dreyer <sven@dreyer-net.de>
Reported-by: Harald Jensås <hjensas@redhat.com>
Reported-by: Jan ONDREJ (SAL) <ondrejj@salstar.sk>