### PR TITLE
[bnxt] Add a delay when Tx buffers are not available

### DIFF
--- a/src/drivers/net/bnxt/bnxt.h
+++ b/src/drivers/net/bnxt/bnxt.h
@@ -145,8 +145,8 @@
 #define DEFAULT_NUMBER_OF_STAT_CTXS             0x01
 #define NUM_RX_BUFFERS                          8
 #define MAX_RX_DESC_CNT                         16
-#define MAX_TX_DESC_CNT                         16
-#define MAX_CQ_DESC_CNT                         64
+#define MAX_TX_DESC_CNT                         64
+#define MAX_CQ_DESC_CNT                         128
 #define TX_RING_BUFFER_SIZE (MAX_TX_DESC_CNT * sizeof(struct tx_bd_short))
 #define RX_RING_BUFFER_SIZE \
 	(MAX_RX_DESC_CNT * sizeof(struct rx_prod_pkt_bd))


### PR DESCRIPTION
Add a wait  when buffers are not available for TX. Execute a PCI read to flush pending transactions when the condition is detected. Increase buffer and descriptor counts.