### PR TITLE
Enhancements to digest_cmd.c

### DIFF
--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -429,6 +429,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define ERRFILE_usb_settings	      ( ERRFILE_OTHER | 0x00650000 )
 #define ERRFILE_weierstrass	      ( ERRFILE_OTHER | 0x00660000 )
 #define ERRFILE_efi_cacert	      ( ERRFILE_OTHER | 0x00670000 )
+#define ERRFILE_digest_cmd	      ( ERRFILE_OTHER | 0x00680000 )
 
 /** @} */
 


### PR DESCRIPTION
In a recent [post](https://techcommunity.microsoft.com/blog/hardwaredevcenter/ipxe-security-assurance-review/1062943) on iPXE Secure Boot signing, Microsoft stated that the `imgverify` command must be removed from ipxe SecureBoot submissions due to "Security Implications".

Although I disagree with Microsoft's findings on the `imgverify` command, there may still be the need to verify some level of integrity for files like boot.wim WinPE images.

This pull request makes two changes:

- Adds the command **sha256sum** to digest_cmd.c to allow for sha256 digests in addition to MD5 and sha1
- Add a single argument, allowing the computed digest to be compared with the argument

Example:
```
set myhash 014bafad85f31983aabd19ff000bf2336eb75995b0e7fa40d2d0ae4df80e6503
initrd -n boot.wim https://ftp.hp.com/pub/pcbios/CPR/sources/boot.wim || goto hpbootfail
echo expected hash: ${myhash}
sha256sum boot.wim ||
sha256sum -s ${myhash} boot.wim || goto bad_hash
```