### PR TITLE
[ipv6] MTU setting from NDP

### DIFF
--- a/src/include/ipxe/ndp.h
+++ b/src/include/ipxe/ndp.h
@@ -68,6 +68,19 @@ struct ndp_prefix_information_option {
 /** NDP autonomous address configuration flag */
 #define NDP_PREFIX_AUTONOMOUS 0x40
 
+/** NDP MTU option */
+#define NDP_OPT_MTU 5
+
+/** NDP MTU */
+struct ndp_mtu_option {
+	/** NDP option header */
+	struct ndp_option_header header;
+	/** Reserved */
+	uint16_t reserved;
+	/** MTU */
+	uint32_t mtu;
+} __attribute__ (( packed ));
+
 /** NDP recursive DNS server option */
 #define NDP_OPT_RDNSS 25
 
@@ -106,6 +119,8 @@ union ndp_option {
 	struct ndp_ll_addr_option ll_addr;
 	/** Prefix information option */
 	struct ndp_prefix_information_option prefix;
+	/** MTU option */
+	struct ndp_mtu_option mtu;
 	/** Recursive DNS server option */
 	struct ndp_rdnss_option rdnss;
 	/** DNS search list option */

--- a/src/net/ndp.c
+++ b/src/net/ndp.c
@@ -1046,6 +1046,16 @@ static int ndp_register_settings ( struct net_device *netdev,
 	return rc;
 }
 
+/** MTU setting */
+const struct setting ndp_mtu_setting __setting ( SETTING_NETDEV, mtu ) = {
+	.name = "mtu",
+	.description = "MTU",
+	.tag = NDP_TAG ( NDP_OPT_MTU, offsetof ( struct ndp_mtu_option, mtu ),
+			 sizeof ( uint32_t ) ),
+	.type = &setting_type_int16,
+	.scope = &ndp_settings_scope,
+};
+
 /** DNS server setting */
 const struct setting ndp_dns6_setting __setting ( SETTING_IP6_EXTRA, dns6 ) = {
 	.name = "dns6",


### PR DESCRIPTION
RA contains MTU setting, this is especially needed in some networks which don't have a a full 1500 MTU link to IPv6 internet. Mostly due to some providers (such as Microsoft Azure) not having a working pMTUd setup.

Fixes #1580