### PR TITLE
[tls] Remove current time from client random bytes

### DIFF
--- a/src/include/ipxe/tls.h
+++ b/src/include/ipxe/tls.h
@@ -309,10 +309,8 @@ struct tls_signature_hash_algorithm {
 
 /** TLS client random data */
 struct tls_client_random {
-	/** GMT Unix time */
-	uint32_t gmt_unix_time;
 	/** Random data */
-	uint8_t random[28];
+	uint8_t random[32];
 } __attribute__ (( packed ));
 
 /** An MD5+SHA1 context */

--- a/src/net/tls.c
+++ b/src/net/tls.c
@@ -30,7 +30,6 @@ FILE_SECBOOT ( PERMITTED );
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <time.h>
 #include <errno.h>
 #include <byteswap.h>
 #include <ipxe/pending.h>
@@ -3986,7 +3985,6 @@ int add_tls ( struct interface *xfer, const char *name,
 	tls_clear_cipher ( tls, &tls->rx.cipherspec.active );
 	tls_clear_cipher ( tls, &tls->rx.cipherspec.pending );
 	tls_clear_handshake ( tls );
-	tls->client.random.gmt_unix_time = time ( NULL );
 	iob_populate ( &tls->rx.iobuf, &tls->rx.header, 0,
 		       sizeof ( tls->rx.header ) );
 	INIT_LIST_HEAD ( &tls->rx.data );


### PR DESCRIPTION
As it turn out, the attempt at putting the timestamp in the client hello random bytes has been half broken since it's initial commit in 5da712385e07f0965a3f7548933c2bd3c4f254f6 over 13 years ago due to forgetting to run `htonl` on the value before encoding it. Resulting in the timestamp from little endian machines being unreadable by automated tools like Wireshark.
Before that the timestamp was simply set to 0.

Seeing as there have been 0 bug reports about this in the 13 years since the feature was introduced (that I can find) and current "general consensus" seems to be to no longer send the timestamp, go ahead and remove the broken feature.