### PR TITLE
[bnxt]: Reduce RX BUFFERS to increase reliability

### DIFF
--- a/src/drivers/net/bnxt/bnxt.h
+++ b/src/drivers/net/bnxt/bnxt.h
@@ -143,7 +143,7 @@
 #define DEFAULT_NUMBER_OF_RX_RINGS              0x01
 #define DEFAULT_NUMBER_OF_RING_GRPS             0x01
 #define DEFAULT_NUMBER_OF_STAT_CTXS             0x01
-#define NUM_RX_BUFFERS                          8
+#define NUM_RX_BUFFERS                          2
 #define MAX_RX_DESC_CNT                         16
 #define MAX_TX_DESC_CNT                         64
 #define MAX_CQ_DESC_CNT                         128


### PR DESCRIPTION
As per issue #1023, some servers using Broadcom chips listed in the bnxt driver, freezes when downloading large files.

The issue was reproduced with a BCM57414 (14e4:16d7) loading a large ramfs (+500MB) file: ipxe remains stuck on a given (random) percentage of the file.

Enabling the debug, produced the following trace:

	RX Stat Total 1955 Good 1955 Drop err 0 LB 0 VLAN 0
	CQ Type (rx) cid 27
	RX desc_idx 3 PktLen 60
	RX Stat Total 1956 Good 1956 Drop err 0 LB 0 VLAN 0
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	CQ Type (rx) cid 29
	[...]

bnxt_rx_complete() returns NO_MORE_CQ_BD_TO_SERVICE in loop, driver loops on the same packet, not reading new packets and blocks the boot process.

It's unclear if it's a firmware or a driver issue.

As a workaround, reducing the number of RX buffers made all tested servers loading large file properly. This patch can affect the download speed but prevents the freeze.

For the reference, the card info where the patch was tested:
	FW Version : 226.0.145.0
	cmd timeout : 5000
	hwrm_max_req_len : 128
	hwrm_max_ext_req : 384
	chip_num : 16d7
	chip_id : 1010000
	Port Number : 0
	fid : 0x0001
	PF MAC : 14:23:f2:c3:e4:20
	min_hw_ring_grps : 169
	max_hw_ring_grps : 169
	min_tx_rings : 170
	max_tx_rings : 170
	min_rx_rings : 241
	max_rx_rings : 241
	min_cq_rings : 295
	max_cq_rings : 295
	min_stat_ctxs : 235
	max_stat_ctxs : 235
	ordinal_value : 0
	stat_ctx_id : 0
	num_cmpl_rings : 1
	num_tx_rings : 1
	num_rx_rings : 1
	num_ring_grps : 1
	num_stat_ctxs : 1