### PR TITLE
[prefix] Add i386 support to unlzma.S

### DIFF
--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -45,7 +45,11 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
 	.section ".note.GNU-stack", "", @progbits
 	.code32
+#ifdef I386_SUPPORT
+	.arch i386
+#else
 	.arch i486
+#endif
 	.section ".prefix.lib", "ax", @progbits
 
 #ifdef CODE16
@@ -962,7 +966,24 @@ decompress:
 	ADDR32 lodsb	/* discard initial byte */
 	print_hex_byte %al
 	ADDR32 lodsl
+#ifdef I386_SUPPORT
+	/* "bswapl %eax" replacement for i386 */
+	pushl   %ebx
+	movb    %al, %bl
+	rorl	$8, %eax
+	roll	$8, %ebx
+	movb    %al, %bl
+	rorl	$8, %eax
+	roll	$8, %ebx
+	movb    %al, %bl
+	rorl	$8, %eax
+	roll	$8, %ebx
+	movb    %al, %bl
+	movl    %ebx, %eax
+	popl    %ebx
+#else
 	bswapl	%eax
+#endif
 	print_hex_dword %eax
 	print_character $('\n')
 	movl	%eax, rc_code(%ebp)


### PR DESCRIPTION
With -DI386_SUPPORT added to CFLAGS it is now possible to DEBUG on 386-class computers with image compression enabled. Previously the unlzma.S required 486-class computers due to the bswap instruction in use. The -DI386_SUPPORT replaces the bswap instruction with a sequence of moves and rotations.