### PR TITLE
[ci] Use arch matrix in GitHub actions builds to reduce duplication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,25 @@ jobs:
                            libc6-dev-i386 liblzma-dev valgrind \
                            gcc-arm-none-eabi gcc-aarch64-linux-gnu
 
-  x86:
-    name: x86
+  buildmatrix:
+    name: Build ${{ matrix.arch }}
     runs-on: ubuntu-24.04
     needs: cache
+    strategy:
+      matrix:
+        include:
+          - arch: x86
+            archpackages: |
+              libc6-dev-i386 liblzma-dev valgrind \
+              libgcc-s1:i386 libc6-dbg:i386
+          - arch: arm32
+            archpackages: gcc-arm-none-eabi
+            cross: arm-none-eabi-
+            target: intel
+          - arch: arm64
+            archpackages: gcc-aarch64-linux-gnu
+            cross: aarch64-linux-gnu-
+            target: ipxe
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -41,77 +56,33 @@ jobs:
         with:
           path: /var/cache/apt/archives/*.deb
           key: apt-cache-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Packages add-architecture i386
+        if: matrix.arch == 'x86'
+        run: sudo dpkg --add-architecture i386
       - name: Install packages
         run: |
-          sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y -o Acquire::Retries=50 \
                            mtools syslinux isolinux genisoimage \
-                           libc6-dev-i386 liblzma-dev valgrind \
-                           libgcc-s1:i386 libc6-dbg:i386
+                           ${{ matrix.archpackages }}
       - name: Build (BIOS)
+        if: matrix.arch == 'x86'
         run: |
           make -j 4 -C src
       - name: Build (Everything)
+        if: matrix.arch == 'x86'
         run: |
           make -j 4 -C src everything
       - name: Test
+        if: matrix.arch == 'x86'
         run: |
           valgrind ./src/bin-i386-linux/tests.linux
           valgrind ./src/bin-x86_64-linux/tests.linux
-
-  arm32:
-    name: ARM32
-    runs-on: ubuntu-24.04
-    needs: cache
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Cache permissions
+      - name: Build Cross ${{ matrix.arch }}
+        if: matrix.cross != ''
         run: |
-          sudo chown $(id -un) /var/cache/apt/archives
-      - name: Cache packages
-        uses: actions/cache/restore@v4
-        with:
-          path: /var/cache/apt/archives/*.deb
-          key: apt-cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - name: Install packages
-        run: |
-          sudo apt update
-          sudo apt install -y -o Acquire::Retries=50 \
-                           mtools syslinux isolinux genisoimage \
-                           gcc-arm-none-eabi
-      - name: Build
-        run: |
-          make -j 4 -C src CROSS=arm-none-eabi- \
-               bin-arm32-efi/intel.efi \
-               bin-arm32-efi/intel.usb \
-               bin-arm32-efi/intel.iso
-
-  arm64:
-    name: ARM64
-    runs-on: ubuntu-24.04
-    needs: cache
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Cache permissions
-        run: |
-          sudo chown $(id -un) /var/cache/apt/archives
-      - name: Cache packages
-        uses: actions/cache/restore@v4
-        with:
-          path: /var/cache/apt/archives/*.deb
-          key: apt-cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - name: Install packages
-        run: |
-          sudo apt update
-          sudo apt install -y -o Acquire::Retries=50 \
-                           mtools syslinux isolinux genisoimage \
-                           gcc-aarch64-linux-gnu
-      - name: Build
-        run: |
-          make -j 4 -C src CROSS=aarch64-linux-gnu- \
-               bin-arm64-efi/ipxe.efi \
-               bin-arm64-efi/ipxe.usb \
-               bin-arm64-efi/ipxe.iso
+          make -j 4 -C src CROSS=${{ matrix.cross }} \
+               bin-${{ matrix.arch }}-efi/${{ matrix.target }}.efi \
+               bin-${{ matrix.arch }}-efi/snponly.efi \
+               bin-${{ matrix.arch }}-efi/${{ matrix.target }}.usb \
+               bin-${{ matrix.arch }}-efi/${{ matrix.target }}.iso


### PR DESCRIPTION
Use matrix to reduce some of the duplications between the steps.
More of the logic could be broken out to properties, but keep the changes minimal in this original refactoring.

Add snponly.efi for arm32 and arm64 is only intended logic change

Originally implemented by @TomTucka in #1184

Example of action running: https://github.com/NiKiZe/ipxe/actions/runs/21208638499

Possible addition with checksums and artifact uploads: https://github.com/NiKiZe/ipxe/actions/runs/21249367210