### PR TITLE
[efi] Avoid dragging in IPv4, IPv6, and DNS support unconditionally

### DIFF
--- a/src/interface/efi/efi_path.c
+++ b/src/interface/efi/efi_path.c
@@ -994,6 +994,16 @@ static int efi_path_fetch_dns ( struct efi_path_setting *pathset,
 	return ( count * pathset->len );
 }
 
+/* Avoid dragging in IPv4, IPv6, and DNS support if not otherwise used */
+extern const struct setting ip_setting __attribute__ (( weak ));
+extern const struct setting netmask_setting __attribute__ (( weak ));
+extern const struct setting gateway_setting __attribute__ (( weak ));
+extern const struct setting ip6_setting __attribute__ (( weak ));
+extern const struct setting len6_setting __attribute__ (( weak ));
+extern const struct setting gateway6_setting __attribute__ (( weak ));
+extern const struct setting dns_setting __attribute__ (( weak ));
+extern const struct setting dns6_setting __attribute__ (( weak ));
+
 /** EFI device path settings */
 static struct efi_path_setting efi_path_settings[] = {
 	{ &ip_setting, efi_path_fetch_fixed, MESSAGING_DEVICE_PATH,
@@ -1047,6 +1057,8 @@ static int efi_path_fetch ( struct settings *settings, struct setting *setting,
 
 		/* Check for a matching setting */
 		pathset = &efi_path_settings[i];
+		if ( ! pathset->setting )
+			continue;
 		if ( setting_cmp ( setting, pathset->setting ) != 0 )
 			continue;
 


### PR DESCRIPTION
The efi_path_settings[] array includes symbol references to &ip_setting, &ip6_setting, &dns_setting (and others) that currently result in IPv4, IPv6, and DNS support being linked in even if disabled in the build configuration.

Provide weak versions of these symbols to avoid the unconditional inclusion of these features.

Fixes: #1604
Fixes: #1606
Fixes: #1607

Reported-by: Pavitter Ghotra <pavitterghotra@yahoo.de>
