### PR TITLE
[golan] convert flexboot_nodnic to update DMA APIs

### DIFF
--- a/src/drivers/infiniband/golan.c
+++ b/src/drivers/infiniband/golan.c
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
 #include <ipxe/infiniband.h>
 #include <ipxe/ib_smc.h>
 #include <ipxe/iobuf.h>
+#include <ipxe/dma.h>
 #include <ipxe/netdevice.h>
 #include "flexboot_nodnic.h"
 #include <ipxe/ethernet.h>
@@ -2523,9 +2524,9 @@ static mlx_status shomron_fill_eth_send_wqe ( struct ib_device *ibdev,
 	MLX_FILL_1 ( &eth_wqe->data[0], 1, l_key,
 			flexboot_nodnic->device_priv.lkey );
 	MLX_FILL_H ( &eth_wqe->data[0], 2,
-		     local_address_h, virt_to_bus ( iobuf->data ) );
+		     local_address_h, iob_dma ( iobuf ) );
 	MLX_FILL_1 ( &eth_wqe->data[0], 3,
-		     local_address_l, virt_to_bus ( iobuf->data ) );
+		     local_address_l, iob_dma ( iobuf ) );
 err:
 	return status;
 }

--- a/src/drivers/infiniband/mlx_nodnic/include/mlx_nodnic_data_structures.h
+++ b/src/drivers/infiniband/mlx_nodnic/include/mlx_nodnic_data_structures.h
@@ -78,15 +78,15 @@ struct nodnic_send_wqbb {
 
 struct nodnic_doorbell {
 	mlx_physical_address doorbell_physical;
-	mlx_void *map;
 	nodnic_qp_db *qp_doorbell_record;
+	mlx_dma mapping;
 };
 struct nodnic_ring {
 	mlx_uint32 offset;
 	/** Work queue entries */
 	/* TODO: add to memory entity */
 	mlx_physical_address wqe_physical;
-	mlx_void *map;
+	mlx_dma mapping;
 	/** Size of work queue */
 	mlx_size wq_size;
 	/** Next work queue entry index
@@ -123,7 +123,7 @@ struct _nodnic_cq{
 	/** cq entries */
 	mlx_void *cq_virt;
 	mlx_physical_address cq_physical;
-	mlx_void *map;
+	mlx_dma cq_mapping;
 	/** cq */
 	mlx_size cq_size;
 	struct nodnic_doorbell arm_cq_doorbell;
@@ -132,7 +132,7 @@ struct _nodnic_cq{
 struct _nodnic_eq{
 	mlx_void *eq_virt;
 	mlx_physical_address eq_physical;
-	mlx_void *map;
+	mlx_dma mapping;
 	mlx_size eq_size;
 };
 struct _nodnic_device_capabilites{
@@ -204,6 +204,7 @@ struct _nodnic_port_priv{
 	nodnic_eq				eq;
 	mlx_mac_address			mac_filters[5];
 	nodnic_arm_cq_db		*arm_cq_doorbell_record;
+	mlx_dma				arm_cq_doorbell_mapping;
 	mlx_status (*send_doorbell)(
 			IN nodnic_port_priv		*port_priv,
 			IN struct nodnic_ring	*ring,

--- a/src/drivers/infiniband/mlx_utils/include/private/mlx_memory_priv.h
+++ b/src/drivers/infiniband/mlx_utils/include/private/mlx_memory_priv.h
@@ -48,28 +48,30 @@ mlx_memory_alloc_dma_priv(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
 					IN mlx_size align,
-					OUT mlx_void **ptr
+					OUT mlx_void **ptr,
+					OUT mlx_dma *mapping
 					);
 
 mlx_status
 mlx_memory_free_dma_priv(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
-					IN mlx_void *ptr
+					IN mlx_void *ptr,
+					IN mlx_dma *mapping
 					);
 mlx_status
 mlx_memory_map_dma_priv(
 					IN mlx_utils *utils,
 					IN mlx_void *addr ,
+					IN mlx_dma *mapping,
 					IN mlx_size number_of_bytes,
-					OUT mlx_physical_address *phys_addr,
-					OUT mlx_void **mapping
+					OUT mlx_physical_address *phys_addr
 					);
 
 mlx_status
 mlx_memory_ummap_dma_priv(
 					IN mlx_utils *utils,
-					IN mlx_void *mapping
+					IN mlx_dma *mapping
 					);
 
 mlx_status

--- a/src/drivers/infiniband/mlx_utils/include/public/mlx_memory.h
+++ b/src/drivers/infiniband/mlx_utils/include/public/mlx_memory.h
@@ -49,28 +49,30 @@ mlx_memory_alloc_dma(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
 					IN mlx_size align,
-					OUT mlx_void **ptr
+					OUT mlx_void **ptr,
+					OUT mlx_dma *mapping
 					);
 
 mlx_status
 mlx_memory_free_dma(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
-					IN mlx_void **ptr
+					IN mlx_void **ptr,
+					IN mlx_dma *mapping
 					);
 mlx_status
 mlx_memory_map_dma(
 					IN mlx_utils *utils,
 					IN mlx_void *Addr ,
+					IN mlx_dma *Mapping,
 					IN mlx_size NumberOfBytes,
-					OUT mlx_physical_address *PhysAddr,
-					OUT mlx_void **Mapping
+					OUT mlx_physical_address *PhysAddr
 					);
 
 mlx_status
 mlx_memory_ummap_dma(
 					IN mlx_utils *utils,
-					IN mlx_void *Mapping
+					IN mlx_dma *Mapping
 					);
 
 mlx_status

--- a/src/drivers/infiniband/mlx_utils/include/public/mlx_utils.h
+++ b/src/drivers/infiniband/mlx_utils/include/public/mlx_utils.h
@@ -46,6 +46,7 @@ typedef  struct{
 	mlx_pci_gw pci_gw;
 	mlx_icmd icmd;
 	void *lock;
+	void *dma;
 #ifdef DEVICE_CX3
 	/* ACCESS to BAR0 */
 	void *config;

--- a/src/drivers/infiniband/mlx_utils/src/public/mlx_memory.c
+++ b/src/drivers/infiniband/mlx_utils/src/public/mlx_memory.c
@@ -80,7 +80,8 @@ mlx_memory_alloc_dma(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
 					IN mlx_size align,
-					OUT mlx_void **ptr
+					OUT mlx_void **ptr,
+					OUT mlx_dma *mapping
 					)
 {
 	mlx_status status = MLX_SUCCESS;
@@ -89,7 +90,7 @@ mlx_memory_alloc_dma(
 		status = MLX_INVALID_PARAMETER;
 		goto bad_param;
 	}
-	status = mlx_memory_alloc_dma_priv(utils, size, align, ptr);
+	status = mlx_memory_alloc_dma_priv(utils, size, align, ptr, mapping);
 bad_param:
 	return status;
 }
@@ -98,7 +99,8 @@ mlx_status
 mlx_memory_free_dma(
 					IN mlx_utils *utils,
 					IN mlx_size size ,
-					IN mlx_void **ptr
+					IN mlx_void **ptr,
+					IN mlx_dma *mapping
 					)
 {
 	mlx_status status = MLX_SUCCESS;
@@ -106,7 +108,7 @@ mlx_memory_free_dma(
 		status = MLX_INVALID_PARAMETER;
 		goto bad_param;
 	}
-	status = mlx_memory_free_dma_priv(utils, size, *ptr);
+	status = mlx_memory_free_dma_priv(utils, size, *ptr, mapping);
 	*ptr = NULL;
 bad_param:
 	return status;
@@ -116,9 +118,9 @@ mlx_status
 mlx_memory_map_dma(
 					IN mlx_utils *utils,
 					IN mlx_void *addr ,
+					IN mlx_dma *mapping,
 					IN mlx_size number_of_bytes,
-					OUT mlx_physical_address *phys_addr,
-					OUT mlx_void **mapping
+					OUT mlx_physical_address *phys_addr
 					)
 {
 	mlx_status status = MLX_SUCCESS;
@@ -126,7 +128,7 @@ mlx_memory_map_dma(
 		status = MLX_INVALID_PARAMETER;
 		goto bad_param;
 	}
-	status = mlx_memory_map_dma_priv(utils, addr, number_of_bytes, phys_addr, mapping);
+	status = mlx_memory_map_dma_priv(utils, addr, mapping, number_of_bytes, phys_addr);
 bad_param:
 	return status;
 }
@@ -134,7 +136,7 @@ bad_param:
 mlx_status
 mlx_memory_ummap_dma(
 					IN mlx_utils *utils,
-					IN mlx_void *mapping
+					IN mlx_dma *mapping
 					)
 {
 	mlx_status status = MLX_SUCCESS;

--- a/src/drivers/infiniband/mlx_utils_flexboot/include/mlx_types_priv.h
+++ b/src/drivers/infiniband/mlx_utils_flexboot/include/mlx_types_priv.h
@@ -9,6 +9,7 @@
 #define A_MLXUTILS_INCLUDE_PUBLIC_TYPES_H_
 #include <stdint.h>
 //#include <errno.h>
+#include <ipxe/dma.h>
 #include <ipxe/pci.h>
 
 #define MLX_SUCCESS 0
@@ -46,6 +47,7 @@ typedef struct pci_device	mlx_pci;
 typedef size_t		mlx_size;
 
 typedef void		mlx_void;
+typedef struct dma_mapping	mlx_dma;
 
 #define MAC_ADDR_LEN 6
 typedef unsigned long	mlx_physical_address;

--- a/src/include/ipxe/infiniband.h
+++ b/src/include/ipxe/infiniband.h
@@ -13,6 +13,7 @@ FILE_SECBOOT ( PERMITTED );
 #include <stdint.h>
 #include <ipxe/refcnt.h>
 #include <ipxe/device.h>
+#include <ipxe/dma.h>
 #include <ipxe/tables.h>
 #include <ipxe/ib_packet.h>
 #include <ipxe/ib_mad.h>
@@ -194,7 +195,8 @@ struct ib_queue_pair {
 /** Infiniband completion queue operations */
 struct ib_completion_queue_operations {
 	/**
-	 * Complete Send WQE
+	 * Complete Send WQE. Should take care of any DMA unmapping since it
+	 * takes ownership of the iobuf.
 	 *
 	 * @v ibdev		Infiniband device
 	 * @v qp		Queue pair
@@ -205,7 +207,8 @@ struct ib_completion_queue_operations {
 				   struct ib_queue_pair *qp,
 				   struct io_buffer *iobuf, int rc );
 	/**
-	 * Complete Receive WQE
+	 * Complete Receive WQE. Should take care of any DMA unmapping since it
+	 * takes ownership of the iobuf.
 	 *
 	 * @v ibdev		Infiniband device
 	 * @v qp		Queue pair
@@ -409,6 +412,8 @@ struct ib_device {
 	char name[IBDEV_NAME_LEN];
 	/** Underlying device */
 	struct device *dev;
+	/** DMA device */
+	struct dma_device *dma;
 	/** List of completion queues */
 	struct list_head cqs;
 	/** List of queue pairs */


### PR DESCRIPTION
This does not convert the full golan driver, only the flexboot_nodnic mode, to use the new DMA APIs, allowing the driver to work even if the BIOS is enabling the IOMMU.

It was tested on an HPE DL380a, with the option "Pre-boot DMA protection" enabled.

This converts the infiniband layer to allow having drivers with and without the new DMA API, by adding an alloc_rx_iob op next to alloc_iob. Once all drivers have been converted, the latter can be removed.

Fixes #1585 