### PR TITLE
[build] Exclude local named config headers from annotation checks

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1553,6 +1553,8 @@ $(CONFIG_LOCAL_NAMED_HEADERS) :
 
 .PRECIOUS : $(CONFIG_LOCAL_NAMED_HEADERS)
 
+UNANNOTATED	+= $(CONFIG_LOCAL_NAMED_HEADERS)
+
 endif
 
 ###############################################################################


### PR DESCRIPTION
In dee71adda84cddc9feaecbdec1a748b1b3fb35da Local config headers was excluded. But named Local configs was not. These are generated if missing when building with `CONFIG=` and are most of the time empty.

Named configs used with Secure Boot can be annotated with FILE_SECBOOT()