### PR TITLE
[pci] Ignore invalid subordinate bus numbers

### DIFF
--- a/src/drivers/bus/pci.c
+++ b/src/drivers/bus/pci.c
@@ -352,13 +352,20 @@ int pci_find_next ( struct pci_device *pci, uint32_t *busdevfn ) {
 		hdrtype &= PCI_HEADER_TYPE_MASK;
 		if ( hdrtype == PCI_HEADER_TYPE_BRIDGE ) {
 			pci_read_config_byte ( pci, PCI_SUBORDINATE, &sub );
-			end = PCI_BUSDEVFN ( PCI_SEG ( *busdevfn ),
-					     ( sub + 1 ), 0, 0 );
-			count = ( end - range.start );
-			if ( count > range.count ) {
-				DBGC ( pci, PCI_FMT " found subordinate bus "
-				       "%#02x\n", PCI_ARGS ( pci ), sub );
-				range.count = count;
+			if ( sub <= PCI_BUS ( *busdevfn ) ) {
+				DBGC ( pci, PCI_FMT " ignoring invalid "
+				       "subordinate bus %#02x\n",
+				       PCI_ARGS ( pci ), sub );
+			} else {
+				end = PCI_BUSDEVFN ( PCI_SEG ( *busdevfn ),
+						     ( sub + 1 ), 0, 0 );
+				count = ( end - range.start );
+				if ( count > range.count ) {
+					DBGC ( pci, PCI_FMT " found "
+					       "subordinate bus %#02x\n",
+					       PCI_ARGS ( pci ), sub );
+					range.count = count;
+				}
 			}
 		}
 


### PR DESCRIPTION
Some systems (observed on a Dell C6615) fail to correctly populate the subordinate PCI bus number on some PCI bridges.  We do not currently guard against this behaviour, causing us to subsequently scan through a huge expanse of the PCI bus:dev.fn address range.

Fix by ignoring the subordinate bus number if it is lower than the bridge's own bus number.

Fixes: #1618 

Reported-by: Anisse Astier <an.astier@criteo.com>
Reported-by: Ahmad Mahagna <ahmhad@nvidia.com>