### PR TITLE
[test] Assign unique MAC addresses for test network devices

### DIFF
--- a/src/tests/ipv4_test.c
+++ b/src/tests/ipv4_test.c
@@ -186,36 +186,36 @@ static void ipv4_route_okx ( const char *dest, struct testnet *scope,
 			 __FILE__, __LINE__ )
 
 /** net0: Single address and gateway (DHCP assignment) */
-TESTNET ( net0,
+TESTNET ( net0, "52:54:00:59:ba:c9",
 	  { "dhcp/ip", "192.168.0.1" },
 	  { "dhcp/netmask", "255.255.255.0" },
 	  { "dhcp/gateway", "192.168.0.254" } );
 
 /** net1: Single address and gateway (DHCP assignment) */
-TESTNET ( net1,
+TESTNET ( net1, "52:54:00:1a:db:95",
 	  { "dhcp/ip", "192.168.0.2" },
 	  { "dhcp/netmask", "255.255.255.0" },
 	  { "dhcp/gateway", "192.168.0.254" } );
 
 /** net2: Small /31 subnet mask */
-TESTNET ( net2,
+TESTNET ( net2, "52:54:00:f9:ee:21",
 	  { "ip", "10.31.31.0" },
 	  { "netmask", "255.255.255.254" },
 	  { "gateway", "10.31.31.1" } );
 
 /** net3: Small /32 subnet mask */
-TESTNET ( net3,
+TESTNET ( net3, "52:54:00:4a:88:ec",
 	  { "ip", "10.32.32.32" },
 	  { "netmask", "255.255.255.255" },
 	  { "gateway", "192.168.32.254" } );
 
 /** net4: Local subnet with no gateway */
-TESTNET ( net4,
+TESTNET ( net4, "52:54:00:68:ad:cd",
 	  { "ip", "192.168.86.1" },
 	  { "netmask", "255.255.240.0" } );
 
 /** net5: Static routes */
-TESTNET ( net5,
+TESTNET ( net5, "52:54:00:b0:d5:07",
 	  { "ip", "10.42.0.1" },
 	  { "netmask", "255.255.0.0" },
 	  { "gateway", "10.42.0.254" /* should be ignored */ },

--- a/src/tests/netdev_test.c
+++ b/src/tests/netdev_test.c
@@ -36,6 +36,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #include <stdio.h>
 #include <ipxe/netdevice.h>
 #include <ipxe/ethernet.h>
+#include <ipxe/if_ether.h>
+#include <ipxe/base16.h>
 #include <ipxe/test.h>
 #include "netdev_test.h"
 
@@ -113,6 +115,8 @@ void testnet_okx ( struct testnet *testnet, const char *file,
 	testnet->netdev->dev = &testnet->dev;
 	snprintf ( testnet->netdev->name, sizeof ( testnet->netdev->name ),
 		   "%s", testnet->dev.name );
+	okx ( hex_decode ( ':', testnet->hwaddr, testnet->netdev->hw_addr,
+			   ETH_ALEN ) == ETH_ALEN, file, line );
 
 	/* Register device */
 	okx ( register_netdev ( testnet->netdev ) == 0, file, line );

--- a/src/tests/netdev_test.h
+++ b/src/tests/netdev_test.h
@@ -26,6 +26,8 @@ struct testnet {
 	struct net_device *netdev;
 	/** Dummy physical device */
 	struct device dev;
+	/** MAC address */
+	const char *hwaddr;
 	/** Initial settings */
 	struct testnet_setting *testset;
 	/** Number of initial settings */
@@ -36,9 +38,10 @@ struct testnet {
  * Declare a test network device
  *
  * @v NAME		Network device name
+ * @v HWADDR		MAC address
  * @v ...		Initial network device settings
  */
-#define TESTNET( NAME, ... )						\
+#define TESTNET( NAME, HWADDR, ... )					\
 	static struct testnet_setting NAME ## _setting[] = {		\
 		__VA_ARGS__						\
 	};								\
@@ -51,6 +54,7 @@ struct testnet {
 			.children =					\
 				LIST_HEAD_INIT ( NAME.dev.children ),	\
 		},							\
+		.hwaddr= HWADDR,					\
 		.testset = NAME ## _setting,				\
 		.count = ( sizeof ( NAME ## _setting ) /		\
 			   sizeof ( NAME ## _setting[0] ) ),		\


### PR DESCRIPTION
Commit 19dffdc ("[efi] Allow for creating devices with no EFI parent device") relaxed the restriction on attempting to create SNP devices when no EFI parent device is available, with the result that the test network devices created when running the IPv4 tests are now registered as SNP devices.

Since the dummy EFI parent device path is fixed and the test network device MAC addresses are empty, the SNP devices end up with identical constructed device paths and registration of the second and subsequent devices will fail since device paths must be unique.

Fix by assigning MAC addresses to the test network devices.

Fixes: #1645 

Reported-by: Miao Wang <shankerwangmiao@gmail.com>