### PR TITLE
[console] Flush line-based console after each progress update

### DIFF
--- a/src/core/lineconsole.c
+++ b/src/core/lineconsole.c
@@ -60,6 +60,12 @@ size_t line_putchar ( struct line_console *line, int character ) {
 	if ( character == CR )
 		return 0;
 
+	/* Handle unit separator (to print without resetting) */
+	if ( character == US ) {
+		line->buffer[line->index] = 0;
+		return 1;
+	}
+
 	/* Treat newline as a terminator */
 	if ( character == LF )
 		character = 0;

--- a/src/core/monojob.c
+++ b/src/core/monojob.c
@@ -156,6 +156,7 @@ int monojob_wait ( const char *string, unsigned long timeout ) {
 				clear_len += printf ( " [%s]",
 						      progress.message );
 			}
+			putchar ( US );
 			last_display = now;
 		}
 	}

--- a/src/include/ipxe/keys.h
+++ b/src/include/ipxe/keys.h
@@ -48,6 +48,7 @@ FILE_SECBOOT ( PERMITTED );
 #define LF		CTRL_J
 #define CR		CTRL_M
 #define ESC		0x1b
+#define US		0x1f
 #define DEL		0x7f
 
 /*


### PR DESCRIPTION
Download progress messages will not currently appear via the syslog console (or any other line buffering console) until the download completes and the newline character is printed.

Use the ASCII unit separator (US) character to indicate the end of each per-second progress message, and modify the line console to react to this character by sending out the incomplete line.
    
Suggested-by: Christian I. Nilsson <nikize@gmail.com>

