### PR TITLE
[genfsimg] Add Ubuntu/Debian syslinux mbr search path

### DIFF
--- a/src/util/genfsimg
+++ b/src/util/genfsimg
@@ -124,14 +124,17 @@ find_syslinux_file() {
     for SRCDIR in \
 	/usr/lib/syslinux \
 	/usr/lib/syslinux/bios \
+	/usr/lib/syslinux/mbr \
 	/usr/lib/syslinux/modules/bios \
 	/usr/share/syslinux \
 	/usr/share/syslinux/bios \
+	/usr/share/syslinux/mbr \
 	/usr/share/syslinux/modules/bios \
 	/usr/local/share/syslinux \
 	/usr/local/share/syslinux/bios \
 	/usr/local/share/syslinux/bios/core \
 	/usr/local/share/syslinux/bios/com32/elflink/ldlinux \
+	/usr/local/share/syslinux/mbr \
 	/usr/local/share/syslinux/modules/bios \
 	/usr/lib/ISOLINUX \
 	; do


### PR DESCRIPTION
## Summary

On Ubuntu/Debian, `syslinux-common` installs `mbr.bin` to `/usr/lib/syslinux/mbr/mbr.bin`. This path is not included in the `find_syslinux_file()` search paths in `src/util/genfsimg`, causing USB `.img` generation to fail with:

```
./util/genfsimg: could not find mbr.bin
```

This was introduced by commit 2c84b686bcf6dfa77b82e27aa2df1f3ec30e902e which added partition table support to USB disk images, requiring `mbr.bin` for the first time in `.img` targets.

RedHat-based systems are unaffected as `syslinux` installs `mbr.bin` to `/usr/share/syslinux/mbr.bin` which is already in the search paths.

## Fix

Add `/usr/lib/syslinux/mbr` to the `find_syslinux_file()` search paths.

## Verified on

- Ubuntu 24.04 (`syslinux-common` 3:6.04~git20190206.bf6db5b4+dfsg1-3ubuntu3)
  - `mbr.bin` location: `/usr/lib/syslinux/mbr/mbr.bin`