### PR TITLE
Remove the Dhcp6Dxe driver veto

### DIFF
--- a/src/interface/efi/efi_veto.c
+++ b/src/interface/efi/efi_veto.c
@@ -480,30 +480,6 @@ efi_veto_vmware_uefipxebc ( EFI_DRIVER_BINDING_PROTOCOL *binding __unused,
 	return 1;
 }
 
-/**
- * Veto Dhcp6Dxe driver
- *
- * @v binding		Driver binding protocol
- * @v loaded		Loaded image protocol
- * @v manufacturer	Manufacturer name, if present
- * @v name		Driver name, if present
- * @ret vetoed		Driver is to be vetoed
- */
-static int efi_veto_dhcp6 ( EFI_DRIVER_BINDING_PROTOCOL *binding __unused,
-			    EFI_LOADED_IMAGE_PROTOCOL *loaded __unused,
-			    const char *manufacturer __unused,
-			    const CHAR16 *name ) {
-	static const CHAR16 dhcp6[] = L"DHCP6 Protocol Driver";
-
-	/* Check driver name */
-	if ( ! name )
-		return 0;
-	if ( memcmp ( name, dhcp6, sizeof ( dhcp6 ) ) != 0 )
-		return 0;
-
-	return 1;
-}
-
 /** Driver vetoes */
 static struct efi_veto_candidate efi_vetoes[] = {
 	{
@@ -517,10 +493,6 @@ static struct efi_veto_candidate efi_vetoes[] = {
 	{
 		.name = "VMware UefiPxeBc",
 		.veto = efi_veto_vmware_uefipxebc,
-	},
-	{
-		.name = "Dhcp6",
-		.veto = efi_veto_dhcp6,
 	},
 };
 


### PR DESCRIPTION
As of commit c3376f8 ("[efi] Drop to external TPL for calls to ConnectController()"), the veto mechanism will drop to TPL_APPLICATION for calls to DisconnectController().

Match this behaviour for calls to UnloadImage(), since that is likely to result in calls to DisconnectController().  For example, any EDK2 driver using NetLibDefaultUnload() as its unload handler will call DisconnectController() to disconnect itself from all handles.

Commit cb95b5b ("[efi] Veto the Dhcp6Dxe driver on all platforms") vetoed the Dhcp6Dxe driver to work around the bug described at https://github.com/tianocore/edk2/issues/10506 that results in EfiDhcp6Stop() getting stuck in a tight loop waiting for an event that will never occur.

Since we now call UnloadImage() at TPL_APPLICATION, we no longer trigger the bug in Dhcp6Dxe, and so the veto may be removed.

Fixes: #1358
