### PR TITLE
[serial] add dumb console support

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -24,6 +24,7 @@ FILE_SECBOOT ( PERMITTED );
 
 #include <config/general.h>
 #include <config/console.h>
+#include <config/serial.h>
 #include <config/sideband.h>
 #include <config/settings.h>
 
@@ -54,6 +55,9 @@ PROVIDE_REQUIRING_SYMBOL();
 
 #ifdef CONSOLE_SERIAL
 REQUIRE_OBJECT ( serial );
+#ifdef SERIAL_DUMB
+REQUIRE_OBJECT ( serial_dumb );
+#endif
 #endif
 #ifdef CONSOLE_DIRECT_VGA
 REQUIRE_OBJECT ( video_subr );

--- a/src/config/serial.h
+++ b/src/config/serial.h
@@ -30,6 +30,11 @@ FILE_LICENCE ( GPL2_OR_LATER );
 //#undef SERIAL_SPCR
 //#define SERIAL_FIXED
 
+/* Uncomment to suppress ANSI escape sequences on the serial console.
+ * Useful for environments (e.g. LAVA) that cannot handle escape sequences.
+ */
+//#define SERIAL_DUMB
+
 /* Early UART configuration (for bare metal prefix debugging only) */
 //#define EARLY_UART_MODEL	8250
 //#define EARLY_UART_REG_BASE	0x10000000

--- a/src/core/serial_dumb.c
+++ b/src/core/serial_dumb.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Daniel Wagner <wagi@monom.org>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** @file
+ *
+ * Dumb serial console
+ *
+ * Strips ANSI escape sequences from serial console output.  Useful
+ * for environments (e.g. LAVA) that cannot handle escape sequences.
+ *
+ */
+
+#include <ipxe/uart.h>
+#include <ipxe/ansiesc.h>
+#include <ipxe/console.h>
+#include <ipxe/serial.h>
+#include <ipxe/init.h>
+
+/** Serial console driver */
+extern struct console_driver serial_console_driver;
+
+/** Dumb serial console ANSI escape sequence handlers */
+static struct ansiesc_handler serial_dumb_ansiesc_handlers[] = {
+	{ 0, NULL }
+};
+
+/** Dumb serial console ANSI escape sequence context */
+static struct ansiesc_context serial_dumb_ansiesc_ctx = {
+	.handlers = serial_dumb_ansiesc_handlers,
+};
+
+/**
+ * Print a character to dumb serial console
+ *
+ * @v character		Character to be printed
+ */
+static void serial_dumb_putchar ( int character ) {
+
+	/* Do nothing if we have no UART */
+	if ( ! serial_console )
+		return;
+
+	/* Intercept ANSI escape sequences */
+	character = ansiesc_process ( &serial_dumb_ansiesc_ctx, character );
+	if ( character < 0 )
+		return;
+
+	/* Transmit character */
+	uart_transmit ( serial_console, character );
+}
+
+/**
+ * Initialise dumb serial console
+ *
+ * Replaces the default serial console putchar with a version that
+ * strips ANSI escape sequences before transmitting.  This runs at
+ * INIT_EARLY priority, before any console output takes place.
+ */
+static void serial_dumb_init ( void ) {
+	serial_console_driver.putchar = serial_dumb_putchar;
+}
+
+/** Dumb serial console initialisation function */
+struct init_fn serial_dumb_init_fn __init_fn ( INIT_EARLY ) = {
+	.name = "serial_dumb",
+	.initialise = serial_dumb_init,
+};


### PR DESCRIPTION
LAVA cannot handle escape sequences properly. Add a 'dumb' serial console option that filters out escape sequences to improve compatibility.

The LAVA project provides a 'hacked' version of iPXE (https://docs.lavasoftware.org/lava/ipxe.html) but I haven't really seen any upstreaming attempts of this version. Thus this is my attempt to get a 'dumb' serial console feature upstream. 

My first version use a ifdef inside serial.c but my understanding is that is not how the project handles this, but just in case you are wondering how it would look like: https://github.com/igaw/ipxe/commit/5882dbdf7c4c017ecaa8f4e0b7b59f28c823bbce

Anyway, with this feature I am able to use the current upstream version with LAVA. 