### PR TITLE
[efi] Fix operator precedence in autoexec network download

### DIFF
--- a/src/interface/efi/efi_autoexec.c
+++ b/src/interface/efi/efi_autoexec.c
@@ -132,10 +132,10 @@ static int efi_autoexec_network ( EFI_HANDLE handle, struct image **image ) {
 	}
 
 	/* Attempt download from current working URI, then from root */
-	if ( ( rc = imgacquire ( EFI_AUTOEXEC_NAME, EFI_AUTOEXEC_TIMEOUT,
-				 image ) != 0 ) &&
-	     ( rc = imgacquire ( "/" EFI_AUTOEXEC_NAME, EFI_AUTOEXEC_TIMEOUT,
-				 image ) != 0 ) ) {
+	if ( ( ( rc = imgacquire ( EFI_AUTOEXEC_NAME, EFI_AUTOEXEC_TIMEOUT,
+				   image ) ) != 0 ) &&
+	     ( ( rc = imgacquire ( "/" EFI_AUTOEXEC_NAME, EFI_AUTOEXEC_TIMEOUT,
+				   image ) ) != 0 ) ) {
 		DBGC ( device, "EFI %s could not download [/]%s: %s\n",
 		       efi_handle_name ( device ), EFI_AUTOEXEC_NAME,
 		       strerror ( rc ) );


### PR DESCRIPTION
## Bug

In `efi_autoexec_network()`, the `!=` operator has higher precedence than `=`, so:

```c
rc = imgacquire ( ..., image ) != 0
```

is parsed as:

```c
rc = ( imgacquire ( ..., image ) != 0 )
```

This assigns the boolean result (0 or 1) to `rc` instead of the actual return code from `imgacquire()`. When both downloads fail, `strerror(rc)` reports an incorrect error since `rc` is 1 rather than the real error code (e.g. `-ETIMEDOUT`).

Both assignments in the `if` condition on lines 135-138 have this problem.

## Fix

Add parentheses around each assignment to ensure `rc` captures the actual return value:

```c
if ( ( ( rc = imgacquire ( ... ) ) != 0 ) &&
     ( ( rc = imgacquire ( ... ) ) != 0 ) ) {
```

This matches the pattern already used correctly in `efi_autoexec_filesystem()` on lines 88-94 of the same file.