### PR TITLE
[misc] Fix spelling errors in comments

### DIFF
--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -56,7 +56,7 @@ undiisr:
 	cmpw	$PXENV_UNDI_ISR_OUT_OURS, funcflag
 	jne	eoi
 	
-trig:	/* Record interrupt occurence */
+trig:	/* Record interrupt occurrence */
 	incb	undiisr_trigger_count
 
 eoi:	/* Send EOI */

--- a/src/drivers/net/ath/ath5k/ath5k.h
+++ b/src/drivers/net/ath/ath5k/ath5k.h
@@ -521,7 +521,7 @@ struct ath5k_txq_info {
 /*
  * Transmit packet types.
  * used on tx control descriptor
- * TODO: Use them inside base.c corectly
+ * TODO: Use them inside base.c correctly
  */
 enum ath5k_pkt_type {
 	AR5K_PKT_TYPE_NORMAL		= 0,

--- a/src/drivers/net/ath/ath5k/ath5k_caps.c
+++ b/src/drivers/net/ath/ath5k/ath5k_caps.c
@@ -56,7 +56,7 @@ int ath5k_hw_set_capabilities(struct ath5k_hw *ah)
 		ah->ah_capabilities.cap_mode |= AR5K_MODE_BIT_11A_TURBO;
 	} else {
 		/*
-		 * XXX The tranceiver supports frequencies from 4920 to 6100GHz
+		 * XXX The transceiver supports frequencies from 4920 to 6100GHz
 		 * XXX and from 2312 to 2732GHz. There are problems with the
 		 * XXX current ieee80211 implementation because the IEEE
 		 * XXX channel mapping does not support negative channel

--- a/src/drivers/net/ath/ath5k/ath5k_phy.c
+++ b/src/drivers/net/ath/ath5k/ath5k_phy.c
@@ -151,7 +151,7 @@ static unsigned int ath5k_hw_rfb_op(struct ath5k_hw *ah,
  * http://madwifi-project.org/ticket/1659
  * with various measurements and diagrams
  *
- * TODO: Deal with power drops due to probes by setting an apropriate
+ * TODO: Deal with power drops due to probes by setting an appropriate
  * tx power on the probe packets ! Make this part of the calibration process.
  */
 
@@ -179,12 +179,12 @@ int ath5k_hw_rfgain_opt_init(struct ath5k_hw *ah)
 	return 0;
 }
 
-/* Schedule a gain probe check on the next transmited packet.
+/* Schedule a gain probe check on the next transmitted packet.
  * That means our next packet is going to be sent with lower
  * tx power and a Peak to Average Power Detector (PAPD) will try
  * to measure the gain.
  *
- * TODO: Use propper tx power setting for the probe packet so
+ * TODO: Use proper tx power setting for the probe packet so
  * that we don't observe a serious power drop on the receiver
  *
  * XXX:  How about forcing a tx packet (bypassing PCU arbitrator etc)
@@ -1574,7 +1574,7 @@ ath5k_create_power_curve(s16 pmin, s16 pmax,
 /*
  * Get the surrounding per-channel power calibration piers
  * for a given frequency so that we can interpolate between
- * them and come up with an apropriate dataset for our current
+ * them and come up with an appropriate dataset for our current
  * channel.
  */
 static void

--- a/src/drivers/net/ath/ath5k/reg.h
+++ b/src/drivers/net/ath/ath5k/reg.h
@@ -286,16 +286,16 @@ FILE_SECBOOT ( FORBIDDEN );
  */
 #define AR5K_ISR		0x001c			/* Register Address [5210] */
 #define AR5K_PISR		0x0080			/* Register Address [5211+] */
-#define AR5K_ISR_RXOK		0x00000001	/* Frame successfuly recieved */
+#define AR5K_ISR_RXOK		0x00000001	/* Frame successfully received */
 #define AR5K_ISR_RXDESC		0x00000002	/* RX descriptor request */
 #define AR5K_ISR_RXERR		0x00000004	/* Receive error */
 #define AR5K_ISR_RXNOFRM	0x00000008	/* No frame received (receive timeout) */
 #define AR5K_ISR_RXEOL		0x00000010	/* Empty RX descriptor */
 #define AR5K_ISR_RXORN		0x00000020	/* Receive FIFO overrun */
-#define AR5K_ISR_TXOK		0x00000040	/* Frame successfuly transmited */
+#define AR5K_ISR_TXOK		0x00000040	/* Frame successfully transmitted */
 #define AR5K_ISR_TXDESC		0x00000080	/* TX descriptor request */
 #define AR5K_ISR_TXERR		0x00000100	/* Transmit error */
-#define AR5K_ISR_TXNOFRM	0x00000200	/* No frame transmited (transmit timeout) */
+#define AR5K_ISR_TXNOFRM	0x00000200	/* No frame transmitted (transmit timeout) */
 #define AR5K_ISR_TXEOL		0x00000400	/* Empty TX descriptor */
 #define AR5K_ISR_TXURN		0x00000800	/* Transmit FIFO underrun */
 #define AR5K_ISR_MIB		0x00001000	/* Update MIB counters */
@@ -380,16 +380,16 @@ FILE_SECBOOT ( FORBIDDEN );
  */
 #define	AR5K_IMR		0x0020			/* Register Address [5210] */
 #define AR5K_PIMR		0x00a0			/* Register Address [5211+] */
-#define AR5K_IMR_RXOK		0x00000001	/* Frame successfuly recieved*/
+#define AR5K_IMR_RXOK		0x00000001	/* Frame successfully received*/
 #define AR5K_IMR_RXDESC		0x00000002	/* RX descriptor request*/
 #define AR5K_IMR_RXERR		0x00000004	/* Receive error*/
 #define AR5K_IMR_RXNOFRM	0x00000008	/* No frame received (receive timeout)*/
 #define AR5K_IMR_RXEOL		0x00000010	/* Empty RX descriptor*/
 #define AR5K_IMR_RXORN		0x00000020	/* Receive FIFO overrun*/
-#define AR5K_IMR_TXOK		0x00000040	/* Frame successfuly transmited*/
+#define AR5K_IMR_TXOK		0x00000040	/* Frame successfully transmitted*/
 #define AR5K_IMR_TXDESC		0x00000080	/* TX descriptor request*/
 #define AR5K_IMR_TXERR		0x00000100	/* Transmit error*/
-#define AR5K_IMR_TXNOFRM	0x00000200	/* No frame transmited (transmit timeout)*/
+#define AR5K_IMR_TXNOFRM	0x00000200	/* No frame transmitted (transmit timeout)*/
 #define AR5K_IMR_TXEOL		0x00000400	/* Empty TX descriptor*/
 #define AR5K_IMR_TXURN		0x00000800	/* Transmit FIFO underrun*/
 #define AR5K_IMR_MIB		0x00001000	/* Update MIB counters*/
@@ -783,7 +783,7 @@ FILE_SECBOOT ( FORBIDDEN );
  * and it's used for generating pseudo-random
  * number sequences.
  *
- * (If i understand corectly, random numbers are
+ * (If i understand correctly, random numbers are
  * used for idle sensing -multiplied with cwmin/max etc-)
  */
 #define AR5K_DCU_GBL_IFS_MISC			0x10f0			/* Register Address */
@@ -1399,7 +1399,7 @@ FILE_SECBOOT ( FORBIDDEN );
 #define AR5K_DIAG_SW_DIS_ENC		0x00000008	/* Disable encryption */
 #define AR5K_DIAG_SW_DIS_DEC		0x00000010	/* Disable decryption */
 #define AR5K_DIAG_SW_DIS_TX		0x00000020	/* Disable transmit [5210] */
-#define AR5K_DIAG_SW_DIS_RX_5210	0x00000040	/* Disable recieve */
+#define AR5K_DIAG_SW_DIS_RX_5210	0x00000040	/* Disable receive */
 #define AR5K_DIAG_SW_DIS_RX_5211	0x00000020
 #define	AR5K_DIAG_SW_DIS_RX		(ah->ah_version == AR5K_AR5210 ? \
 					AR5K_DIAG_SW_DIS_RX_5210 : AR5K_DIAG_SW_DIS_RX_5211)

--- a/src/drivers/net/bnx2.h
+++ b/src/drivers/net/bnx2.h
@@ -70,7 +70,7 @@ typedef int pci_power_t;
 #define PORT_FIBRE		0x03
 #define PORT_BNC		0x04
 
-/* Which tranceiver to use. */
+/* Which transceiver to use. */
 #define XCVR_INTERNAL		0x00
 #define XCVR_EXTERNAL		0x01
 #define XCVR_DUMMY1		0x02
@@ -118,7 +118,7 @@ typedef int pci_power_t;
 #define PORT_FIBRE              0x03
 #define PORT_BNC                0x04
 
-/* Which tranceiver to use. */
+/* Which transceiver to use. */
 #define XCVR_INTERNAL           0x00
 #define XCVR_EXTERNAL           0x01
 #define XCVR_DUMMY1             0x02

--- a/src/drivers/net/icplus.h
+++ b/src/drivers/net/icplus.h
@@ -149,7 +149,7 @@ struct icplus_descriptor {
 /** Sole transmit fragment */
 #define ICP_TX_SOLE_FRAG 0x01
 
-/** Recieve frame overrun error */
+/** Receive frame overrun error */
 #define ICP_RX_ERR_OVERRUN 0x01
 
 /** Receive runt frame error */
@@ -164,7 +164,7 @@ struct icplus_descriptor {
 /** Receive oversized frame error */
 #define ICP_RX_ERR_OVERSIZED 0x10
 
-/** Recieve length error */
+/** Receive length error */
 #define ICP_RX_ERR_LEN 0x20
 
 /** Descriptor ring */

--- a/src/drivers/net/igbvf/igbvf_mbx.c
+++ b/src/drivers/net/igbvf/igbvf_mbx.c
@@ -339,7 +339,7 @@ out_no_write:
  *  @size: Length of buffer
  *  @mbx_id: id of mailbox to read
  *
- *  returns SUCCESS if it successfuly read message from buffer
+ *  returns SUCCESS if it successfully read message from buffer
  **/
 static s32 igbvf_read_mbx_vf(struct e1000_hw *hw, u32 *msg, u16 size,
                              u16 mbx_id __unused)

--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -293,7 +293,7 @@ static int intel_reset ( struct intel_nic *intel ) {
 
 	/* The Intel I210's packet buffer size registers reset only on
 	 * power up.  If an operating system changes these but then
-	 * the computer recieves a reset signal without losing power,
+	 * the computer receives a reset signal without losing power,
 	 * the registers will stay the same (but be incompatible with
 	 * other register defaults), thus making the device unable to
 	 * pass traffic.

--- a/src/drivers/net/sis900.c
+++ b/src/drivers/net/sis900.c
@@ -1156,7 +1156,7 @@ sis900_transmit(struct nic  *nic,
     }
     
     if (tx_status & (ABORT | UNDERRUN | OWCOLL)) {
-        /* packet unsuccessfully transmited */
+        /* packet unsuccessfully transmitted */
         printf("sis900_transmit: Transmit error, Tx status %X.\n", 
 	       (unsigned int) tx_status);
     }

--- a/src/drivers/net/sundance.c
+++ b/src/drivers/net/sundance.c
@@ -262,13 +262,13 @@ static struct sundance_private {
 	unsigned int cur_rx;	/* Producer/consumer ring indices */
 	unsigned int mtu;
 
-	/* These values keep track of the tranceiver/media in use */
+	/* These values keep track of the transceiver/media in use */
 	unsigned int flowctrl:1;
 	unsigned int an_enable:1;
 
 	unsigned int speed;
 
-	/* MII tranceiver section */
+	/* MII transceiver section */
 	struct mii_if_info mii_if;
 	int mii_preamble_required;
 	unsigned char phys[MII_CNT];

--- a/src/drivers/net/tg3/tg3.h
+++ b/src/drivers/net/tg3/tg3.h
@@ -2421,7 +2421,7 @@
 #define TG3_CL45_D7_EEERES_STAT_LP_1000T	0x0004
 
 
-/* Fast Ethernet Tranceiver definitions */
+/* Fast Ethernet Transceiver definitions */
 #define MII_TG3_FET_PTEST		0x17
 #define  MII_TG3_FET_PTEST_FRC_TX_LINK	0x1000
 #define  MII_TG3_FET_PTEST_FRC_TX_LOCK	0x0800

--- a/src/drivers/net/tlan.c
+++ b/src/drivers/net/tlan.c
@@ -1404,7 +1404,7 @@ void TLan_PhyPowerDown(struct nic *nic)
 
 	/* Wait for 50 ms and powerup
 	 * This is abitrary.  It is intended to make sure the
-	 * tranceiver settles.
+	 * transceiver settles.
 	 */
 	/* TLan_SetTimer( dev, (HZ/20), TLAN_TIMER_PHY_PUP ); */
 	mdelay(50);
@@ -1423,7 +1423,7 @@ void TLan_PhyPowerUp(struct nic *nic)
 	TLan_MiiWriteReg(nic, priv->phy[priv->phyNum], MII_BMCR, value);
 	TLan_MiiSync(BASE);
 	/* Wait for 500 ms and reset the
-	 * tranceiver.  The TLAN docs say both 50 ms and
+	 * transceiver.  The TLAN docs say both 50 ms and
 	 * 500 ms, so do the longer, just in case.
 	 */
 	mdelay(500);
@@ -1543,7 +1543,7 @@ void TLan_PhyStartLink(struct nic *nic)
 		TLan_MiiWriteReg(nic, phy, TLAN_TLPHY_CTL, tctl);
 	}
 
-	/* Wait for 2 sec to give the tranceiver time
+	/* Wait for 2 sec to give the transceiver time
 	 * to establish link.
 	 */
 	/* TLan_SetTimer( dev, (4*HZ), TLAN_TIMER_FINISH_RESET ); */

--- a/src/drivers/net/w89c840.c
+++ b/src/drivers/net/w89c840.c
@@ -785,7 +785,7 @@ static int eeprom_read(long addr, int location)
 #define mdio_delay(mdio_addr) readl(mdio_addr)
 
 /* Set iff a MII transceiver on any interface requires mdio preamble.
-   This only set with older tranceivers, so the extra
+   This only set with older transceivers, so the extra
    code size of a per-interface flag is not worthwhile. */
 static char mii_preamble_required = 1;
 


### PR DESCRIPTION
Fix various spelling errors in driver comments and headers.

All changes are comment-only with no functional impact.

- "tranceiver" → "transceiver" (tlan, sundance, bnx2, tg3, ath5k, w89c840)
- "recieve" → "receive" (icplus, ath5k, intel)
- "occurence" → "occurrence" (undiisr)
- "apropriate" → "appropriate" (ath5k)
- "propper" → "proper" (ath5k)
- "corectly" → "correctly" (ath5k)
- "successfuly" → "successfully" (ath5k, igbvf)
- "transmited" → "transmitted" (ath5k, sis900)