### PR TITLE
Disable SIMD and optimize tcpip_continue_chksum on LoongArch

### DIFF
--- a/src/arch/loong64/Makefile
+++ b/src/arch/loong64/Makefile
@@ -12,6 +12,16 @@ ASM_TCHAR_OPS	:= @
 CFLAGS		+= -fstrength-reduce -fomit-frame-pointer
 CFLAGS		+= -falign-jumps=1 -falign-loops=1 -falign-functions=1
 
+## Check if the follow options is valid for current toolchains
+# -mno-lsx: Disable 128-bit SIMD instructions, added after gcc-14
+# -mno-lasx: Disable 256-bit SIMD instructions, added after gcc-14
+CHECK_CC_FLAGS := -mno-lsx -mno-lasx
+
+define check_cc_flag
+  $(shell $(CC) $(1) -x c -c /dev/null -o /dev/null > /dev/null 2>&1 && echo $(1))
+endef
+CFLAGS += $(foreach flag,$(CHECK_CC_FLAGS),$(call check_cc_flag,$(flag)))
+
 # Check if -mno-explicit-relocs is valid
 ifeq ($(CCTYPE),gcc)
 MNER_TEST = $(CC) -mno-explicit-relocs -x c -c /dev/null -o /dev/null >/dev/null 2>&1

--- a/src/arch/loong64/core/loong64_tcpip.S
+++ b/src/arch/loong64/core/loong64_tcpip.S
@@ -1,0 +1,134 @@
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+FILE_SECBOOT ( PERMITTED );
+
+	.section ".note.GNU-stack", "", @progbits
+
+	.text
+	.section ".text.tcpip_continue_chksum", "ax", @progbits
+	.globl tcpip_continue_chksum
+	.type tcpip_continue_chksum, @function
+
+/**
+ * Calculate continued TCP/IP checksum
+ *
+ * ABI Call Mappings (Strict):
+ *   $a0 = partial (Current 16-bit partial checksum)
+ *   $a1 = data    (Data buffer pointer)
+ *   $a2 = len     (Length of data buffer)
+ *   Ret: $a0 = Updated 16-bit checksum
+ *
+ * Register Allocation Table:
+ *   $t4 = Loop guard bound for 16-byte unrolled trunk (end - 16)
+ *   $a3 = Loop guard bound for 8-byte standard trunk (end - 8)
+ *   $a4 = Upper carry bank accumulator register
+ *   $a5 = Temporary data load / unsigned branch condition evaluation register
+ *   $t7 = Temporary secondary data load register for 16-byte unrolling
+ *   $t8 = Constant mask register cached with 0xffff
+ */
+tcpip_continue_chksum:
+
+	/* Step 1: Pre-invert the initial checksum accumulator */
+	nor	$a0, $a0, $zero
+
+	/* Register Initialization: Pre-cache mask to erase final negation latencies */
+	li.d	$t8, 0xffff
+
+	/* Step 2: Compute the absolute ending boundary pointer */
+	add.d	$a2, $a2, $a1
+
+	/* Optimization: Pre-calculate end markers for 16-byte and 8-byte segments */
+	addi.d	$t4, $a2, -16
+	addi.d	$a3, $a2, -8
+
+	/* Step 3: Initialize the upper overflow carry bank register */
+	move	$a4, $zero
+
+	/* Guard: Skip direct word alignments if data chunk is below 8 bytes */
+	bltu	$a3, $a1, post_aligned
+	b	2f
+
+	/* Step 4: Pre-alignment Loop - Stride via 16-bit words until 8-byte aligned */
+1:	ld.hu	$a5, $a1, 0
+	addi.d	$a1, $a1, 2
+	add.d	$a4, $a4, $a5
+
+2:	bstrpick.d $a5, $a1, 2, 1
+	bnez	$a5, 1b
+	b	main_loop_check
+
+	/* Step 5: 16-byte Super-scalar Loop Unrolling (Doubleword parallel path) */
+unroll_16byte_loop:
+	ld.d	$a5, $a1, 0
+	ld.d	$t7, $a1, 8
+	addi.d	$a1, $a1, 16
+
+	/* Two-way parallel aggregation using tree-reduction */
+	add.d	$a5, $a5, $t7
+	sltu	$t7, $a5, $t7
+	add.d	$a4, $a4, $t7
+
+	/* Feed results and secondary carries back into primary registers */
+	add.d	$a0, $a0, $a5
+	sltu	$a5, $a0, $a5
+	add.d	$a4, $a4, $a5
+
+main_loop_check:
+	bgeu	$t4, $a1, unroll_16byte_loop
+	b	2f
+
+	/* Step 6: 8-byte Standard Main Trunk Loop (Residual doublewords) */
+1:	ld.d	$a5, $a1, 0
+	addi.d	$a1, $a1, 8
+	add.d	$a0, $a0, $a5
+	sltu	$a5, $a0, $a5
+	add.d	$a4, $a4, $a5
+
+2:	bgeu	$a3, $a1, 1b
+
+post_aligned:
+	/* Step 7: Post-alignment Loop - Consume residual trailing 16-bit chunks */
+	addi.d	$a3, $a2, -2
+	b	2f
+
+1:	ld.hu	$a5, $a1, 0
+	addi.d	$a1, $a1, 2
+	add.d	$a4, $a4, $a5
+
+2:	bgeu	$a3, $a1, 1b
+
+	/* Step 8: Tail Fragmentation - Consume standalone odd single byte if present */
+	beq	$a1, $a2, 1f
+	ld.bu	$a5, $a1, 0
+	add.d	$a4, $a4, $a5
+
+1:
+	/* Step 9: Carry Bank Consolidation - Collapse accumulated overflow back into a0 */
+	add.d	$a0, $a0, $a4
+	sltu	$a4, $a0, $a4
+
+	/* Step 10: 32-bit Cross Fold - Split upper/lower halves into separate slots */
+	slli.d	$a5, $a0, 32
+	srli.d	$a0, $a0, 32
+	srli.d	$a5, $a5, 32
+
+	/* Concurrently fuse upper bit extensions alongside remaining carry markers */
+	add.d	$a0, $a0, $a4
+	add.d	$a0, $a0, $a5
+
+	/* Step 11: End-around Carry Fold - Lock out implicit sign-extension via bstrpick.d */
+fold_carry_loop:
+	bstrpick.d $a5, $a0, 63, 16
+	beqz	$a5, final_negate
+	bstrpick.d $a0, $a0, 15, 0
+	add.d   $a0, $a0, $a5
+	b       fold_carry_loop
+
+final_negate:
+	/* Step 12: Complement Phase - Conclude 16-bit negation against pre-cached mask */
+	xor	$a0, $a0, $t8
+
+	/* Step 13: ABI Isolation - Clear upper register lines before execution exit */
+	bstrpick.d $a0, $a0, 15, 0
+	jirl	$zero, $ra, 0
+
+	.size tcpip_continue_chksum, . - tcpip_continue_chksum

--- a/src/arch/loong64/include/bits/tcpip.h
+++ b/src/arch/loong64/include/bits/tcpip.h
@@ -1,0 +1,16 @@
+#ifndef _BITS_TCPIP_H
+#define _BITS_TCPIP_H
+
+/** @file
+ *
+ * Transport-network layer interface
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+FILE_SECBOOT ( PERMITTED );
+
+extern uint16_t tcpip_continue_chksum ( uint16_t sum, const void *data,
+					size_t len );
+
+#endif /* _BITS_TCPIP_H */


### PR DESCRIPTION
Disable SIMD and optimize tcpip_continue_chksum on LoongArch

```
$ make bin-loong64-linux/tests.linux && ./bin-loong64-linux/tests.linux
...
  [FINISH] bin-loong64-linux/tests.linux
rm bin-loong64-linux/version.tests.linux.o
iPXE initialising devices...



iPXE 2.0.0+ (g22704) -- Open Source Network Boot Firmware -- https://ipxe.org
Features: DNS HTTP HTTPS iSCSI TFTP VLAN AoE Menu
Starting loong64 self-tests
OK: "time" 102 tests passed
OK: "uri" 770 tests passed
OK: "utf8" 116 tests passed
OK: "uuid" 13 tests passed
OK: "vsprintf" 56 tests passed
OK: "x25519" 126 tests passed
OK: "x509" 173 tests passed
OK: "zlib" 7 tests passed
OK: "acpi" 6 tests passed
OK: "aes" 90 tests passed
OK: "base16" 21 tests passed
OK: "base64" 21 tests passed
OK: "bigint" 223 tests passed
OK: "bitops" 28 tests passed
OK: "byteswap" 6 tests passed
OK: "cms" 33 tests passed
OK: "cpio" 231 tests passed
OK: "crc32" 4 tests passed
OK: "deflate" 191 tests passed
OK: "der" 12 tests passed
OK: "des" 3570 tests passed
OK: "dhe" 32 tests passed
OK: "dns" 86 tests passed
OK: "ecdsa" 36 tests passed
OK: "editstring" 290 tests passed
OK: "efisig" 9 tests passed
OK: "fdt" 100 tests passed
OK: "gcm" 288 tests passed
OK: "gzip" 21 tests passed
OK: "hash_df" 40 tests passed
OK: "hkdf" 28 tests passed
OK: "hmac_drbg" 208 tests passed
OK: "hmac" 18 tests passed
OK: "iobuf" 82 tests passed
OK: "ipv4" 429 tests passed
OK: "ipv6" 303 tests passed
OK: "linebuf" 165 tests passed
OK: "list" 156 tests passed
OK: "math" 108 tests passed
OK: "md4" 24 tests passed
OK: "md5" 24 tests passed
OK: "memcpy" 217 tests passed
OK: "memset" 192 tests passed
OK: "mschapv2" 2 tests passed
OK: "nap" 1 tests passed
OK: "ntlm" 31 tests passed
OK: "ocsp" 33 tests passed
OK: "p256" 62 tests passed
OK: "p384" 62 tests passed
OK: "pccrc" 89 tests passed
OK: "pem" 27 tests passed
OK: "png" 224 tests passed
OK: "pnm" 49 tests passed
OK: "profile" 14 tests passed
OK: "rsa" 82 tests passed
OK: "setjmp" 20 tests passed
OK: "settings" 187 tests passed
OK: "sha1" 24 tests passed
OK: "sha256" 48 tests passed
OK: "sha512" 96 tests passed
OK: "string" 166 tests passed
OK: "tcpip" 24 tests passed
OK: all 9896 tests passed
```