### PR TITLE
[cloud] Add IMDSv2 support for EC2 cloud boot

### DIFF
--- a/src/config/cloud/aws.ipxe
+++ b/src/config/cloud/aws.ipxe
@@ -19,6 +19,7 @@ exit
 
 :dhcp_ok
 route ||
+fetchvar --method PUT ec2token http://169.254.169.254/latest/api/token ||
 chain -ar http://169.254.169.254/latest/user-data ||
 ifstat ||
 exit

--- a/src/config/cloud/general.h
+++ b/src/config/cloud/general.h
@@ -11,3 +11,8 @@
  * incurring unnecessary costs.
  */
 #define POWEROFF_CMD
+
+/* Allow scripts to fetch a URI and store the response body in a
+ * named setting for use in subsequent commands.
+ */
+#define FETCHVAR_CMD

--- a/src/config/cloud/general.h
+++ b/src/config/cloud/general.h
@@ -7,6 +7,11 @@
  */
 #define HTTP_HACK_GCE
 
+/* Allow retrieval of metadata from Amazon EC2 Instance Metadata
+ * Service using IMDSv2 session tokens.
+ */
+#define HTTP_HACK_EC2
+
 /* Allow scripts to handle errors by powering down the VM to avoid
  * incurring unnecessary costs.
  */

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -270,6 +270,9 @@ REQUIRE_OBJECT ( shell );
 #ifdef NSLOOKUP_CMD
 REQUIRE_OBJECT ( nslookup_cmd );
 #endif
+#ifdef FETCHVAR_CMD
+REQUIRE_OBJECT ( fetchvar_cmd );
+#endif
 #ifdef PARAM_CMD
 REQUIRE_OBJECT ( param_cmd );
 #endif

--- a/src/config/config_http.c
+++ b/src/config/config_http.c
@@ -50,3 +50,6 @@ REQUIRE_OBJECT ( peerdist );
 #ifdef HTTP_HACK_GCE
 REQUIRE_OBJECT ( httpgce );
 #endif
+#ifdef HTTP_HACK_EC2
+REQUIRE_OBJECT ( httpec2 );
+#endif

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -108,6 +108,7 @@ FILE_SECBOOT ( PERMITTED );
 //#define LOTEST_CMD		/* Loopback testing commands */
 #define MENU_CMD		/* Menu commands */
 //#define NEIGHBOUR_CMD		/* Neighbour management commands */
+//#define FETCHVAR_CMD		/* Fetch URI to setting command */
 //#define NSLOOKUP_CMD		/* DNS resolving command */
 #define NTP_CMD			/* NTP commands */
 #define NVO_CMD			/* Non-volatile option storage commands */

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -58,6 +58,7 @@ FILE_SECBOOT ( PERMITTED );
 #define HTTP_AUTH_NTLM		/* NTLM authentication */
 //#define HTTP_ENC_PEERDIST	/* PeerDist content encoding */
 //#define HTTP_HACK_GCE		/* Google Compute Engine hacks */
+//#define HTTP_HACK_EC2		/* Amazon EC2 hacks */
 
 /* Disable protocols not historically included in BIOS builds */
 #if defined ( PLATFORM_pcbios )

--- a/src/hci/commands/fetchvar_cmd.c
+++ b/src/hci/commands/fetchvar_cmd.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Huzaifa Ali Zar <huzaifazar@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER );
+FILE_SECBOOT ( PERMITTED );
+
+#include <stdio.h>
+#include <getopt.h>
+#include <ipxe/command.h>
+#include <ipxe/parseopt.h>
+#include <usr/fetchvar.h>
+
+/** @file
+ *
+ * fetchvar command
+ *
+ */
+
+/** "fetchvar" options */
+struct fetchvar_options {};
+
+/** "fetchvar" option list */
+static struct option_descriptor fetchvar_opts[] = {};
+
+/** "fetchvar" command descriptor */
+static struct command_descriptor fetchvar_cmd =
+	COMMAND_DESC ( struct fetchvar_options, fetchvar_opts, 2, 2,
+		       "<setting> <uri>" );
+
+/**
+ * The "fetchvar" command
+ *
+ * @v argc		Argument count
+ * @v argv		Argument list
+ * @ret rc		Return status code
+ */
+static int fetchvar_exec ( int argc, char **argv ) {
+	struct fetchvar_options opts;
+	const char *setting_name;
+	const char *uri_string;
+	int rc;
+
+	/* Parse options */
+	if ( ( rc = parse_options ( argc, argv, &fetchvar_cmd, &opts ) ) != 0 )
+		return rc;
+
+	/* Parse setting name */
+	setting_name = argv[optind];
+
+	/* Parse URI */
+	uri_string = argv[ optind + 1 ];
+
+	/* Fetch URI and store in setting */
+	if ( ( rc = fetchvar ( uri_string, setting_name ) ) != 0 )
+		return rc;
+
+	return 0;
+}
+
+/** The "fetchvar" command */
+COMMAND ( fetchvar, fetchvar_exec );

--- a/src/hci/commands/fetchvar_cmd.c
+++ b/src/hci/commands/fetchvar_cmd.c
@@ -21,9 +21,12 @@ FILE_LICENCE ( GPL2_OR_LATER );
 FILE_SECBOOT ( PERMITTED );
 
 #include <stdio.h>
+#include <strings.h>
+#include <errno.h>
 #include <getopt.h>
 #include <ipxe/command.h>
 #include <ipxe/parseopt.h>
+#include <ipxe/http.h>
 #include <usr/fetchvar.h>
 
 /** @file
@@ -33,15 +36,40 @@ FILE_SECBOOT ( PERMITTED );
  */
 
 /** "fetchvar" options */
-struct fetchvar_options {};
+struct fetchvar_options {
+	/** HTTP method name */
+	char *method;
+};
 
 /** "fetchvar" option list */
-static struct option_descriptor fetchvar_opts[] = {};
+static struct option_descriptor fetchvar_opts[] = {
+	OPTION_DESC ( "method", 'm', required_argument,
+		      struct fetchvar_options, method, parse_string ),
+};
 
 /** "fetchvar" command descriptor */
 static struct command_descriptor fetchvar_cmd =
 	COMMAND_DESC ( struct fetchvar_options, fetchvar_opts, 2, 2,
-		       "<setting> <uri>" );
+		       "[--method <method>] <setting> <uri>" );
+
+/**
+ * Parse HTTP method name
+ *
+ * @v name		Method name (e.g. "GET", "PUT")
+ * @ret method		HTTP method, or NULL if not recognised
+ */
+static struct http_method * fetchvar_method ( const char *name ) {
+
+	if ( strcasecmp ( name, "GET" ) == 0 )
+		return &http_get;
+	if ( strcasecmp ( name, "POST" ) == 0 )
+		return &http_post;
+	if ( strcasecmp ( name, "PUT" ) == 0 )
+		return &http_put;
+	if ( strcasecmp ( name, "HEAD" ) == 0 )
+		return &http_head;
+	return NULL;
+}
 
 /**
  * The "fetchvar" command
@@ -52,6 +80,7 @@ static struct command_descriptor fetchvar_cmd =
  */
 static int fetchvar_exec ( int argc, char **argv ) {
 	struct fetchvar_options opts;
+	struct http_method *method = NULL;
 	const char *setting_name;
 	const char *uri_string;
 	int rc;
@@ -60,6 +89,16 @@ static int fetchvar_exec ( int argc, char **argv ) {
 	if ( ( rc = parse_options ( argc, argv, &fetchvar_cmd, &opts ) ) != 0 )
 		return rc;
 
+	/* Parse method (if specified) */
+	if ( opts.method ) {
+		method = fetchvar_method ( opts.method );
+		if ( ! method ) {
+			printf ( "Unsupported HTTP method \"%s\"\n",
+				 opts.method );
+			return -ENOTSUP;
+		}
+	}
+
 	/* Parse setting name */
 	setting_name = argv[optind];
 
@@ -67,7 +106,7 @@ static int fetchvar_exec ( int argc, char **argv ) {
 	uri_string = argv[ optind + 1 ];
 
 	/* Fetch URI and store in setting */
-	if ( ( rc = fetchvar ( uri_string, setting_name ) ) != 0 )
+	if ( ( rc = fetchvar ( uri_string, setting_name, method ) ) != 0 )
 		return rc;
 
 	return 0;

--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -450,6 +450,7 @@ FILE_SECBOOT ( PERMITTED );
 #define ERRFILE_ecdhe		      ( ERRFILE_OTHER | 0x00680000 )
 #define ERRFILE_ecdsa		      ( ERRFILE_OTHER | 0x00690000 )
 #define ERRFILE_crypto_null	      ( ERRFILE_OTHER | 0x006a0000 )
+#define ERRFILE_fetchvar	      ( ERRFILE_OTHER | 0x006b0000 )
 
 /** @} */
 

--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -451,6 +451,7 @@ FILE_SECBOOT ( PERMITTED );
 #define ERRFILE_ecdsa		      ( ERRFILE_OTHER | 0x00690000 )
 #define ERRFILE_crypto_null	      ( ERRFILE_OTHER | 0x006a0000 )
 #define ERRFILE_fetchvar	      ( ERRFILE_OTHER | 0x006b0000 )
+#define ERRFILE_fetchvar_cmd	      ( ERRFILE_OTHER | 0x006c0000 )
 
 /** @} */
 

--- a/src/include/ipxe/http.h
+++ b/src/include/ipxe/http.h
@@ -105,6 +105,7 @@ struct http_method {
 extern struct http_method http_head;
 extern struct http_method http_get;
 extern struct http_method http_post;
+extern struct http_method http_put;
 
 /******************************************************************************
  *

--- a/src/include/usr/fetchvar.h
+++ b/src/include/usr/fetchvar.h
@@ -1,0 +1,15 @@
+#ifndef _USR_FETCHVAR_H
+#define _USR_FETCHVAR_H
+
+/** @file
+ *
+ * Fetch URI to setting
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER );
+FILE_SECBOOT ( PERMITTED );
+
+extern int fetchvar ( const char *uri_string, const char *setting_name );
+
+#endif /* _USR_FETCHVAR_H */

--- a/src/include/usr/fetchvar.h
+++ b/src/include/usr/fetchvar.h
@@ -10,6 +10,9 @@
 FILE_LICENCE ( GPL2_OR_LATER );
 FILE_SECBOOT ( PERMITTED );
 
-extern int fetchvar ( const char *uri_string, const char *setting_name );
+struct http_method;
+
+extern int fetchvar ( const char *uri_string, const char *setting_name,
+		      struct http_method *method );
 
 #endif /* _USR_FETCHVAR_H */

--- a/src/net/tcp/httpcore.c
+++ b/src/net/tcp/httpcore.c
@@ -150,6 +150,11 @@ struct http_method http_post = {
 	.name = "POST",
 };
 
+/** HTTP PUT method */
+struct http_method http_put = {
+	.name = "PUT",
+};
+
 /******************************************************************************
  *
  * Utility functions

--- a/src/net/tcp/httpec2.c
+++ b/src/net/tcp/httpec2.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Huzaifa Ali Zar <huzaifazar@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/**
+ * @file
+ *
+ * Amazon EC2 Instance Metadata Service v2 (IMDSv2) headers
+ *
+ * EC2's metadata service requires IMDSv2 session tokens.  A PUT
+ * request to the token endpoint must include a TTL header, and
+ * subsequent requests must include the resulting token value.
+ *
+ * This mirrors the approach used for Google Compute Engine metadata
+ * in httpgce.c.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <ipxe/http.h>
+#include <ipxe/settings.h>
+
+/** EC2 metadata IPv4 address */
+#define EC2_METADATA_HOST_ADDR "169.254.169.254"
+
+/** Token TTL in seconds (6 hours) */
+#define EC2_TOKEN_TTL "21600"
+
+/** EC2 IMDSv2 token setting */
+static const struct setting ec2token_setting = {
+	.name = "ec2token",
+	.type = &setting_type_string,
+};
+
+/**
+ * Construct HTTP "X-aws-ec2-metadata-token-ttl-seconds" header
+ *
+ * @v http		HTTP transaction
+ * @v buf		Buffer
+ * @v len		Length of buffer
+ * @ret len		Length of header value, or negative error
+ */
+static int
+http_format_ec2_token_ttl ( struct http_transaction *http,
+			    char *buf, size_t len ) {
+
+	/* Skip if not an EC2 metadata request */
+	if ( strcmp ( http->request.host, EC2_METADATA_HOST_ADDR ) != 0 )
+		return 0;
+
+	/* Skip if not a PUT request */
+	if ( http->request.method != &http_put )
+		return 0;
+
+	/* Construct header value */
+	return snprintf ( buf, len, "%s", EC2_TOKEN_TTL );
+}
+
+/** HTTP "X-aws-ec2-metadata-token-ttl-seconds" header */
+struct http_request_header
+http_request_ec2_token_ttl __http_request_header = {
+	.name = "X-aws-ec2-metadata-token-ttl-seconds",
+	.format = http_format_ec2_token_ttl,
+};
+
+/**
+ * Construct HTTP "X-aws-ec2-metadata-token" header
+ *
+ * @v http		HTTP transaction
+ * @v buf		Buffer
+ * @v len		Length of buffer
+ * @ret len		Length of header value, or negative error
+ */
+static int
+http_format_ec2_token ( struct http_transaction *http,
+			char *buf, size_t len ) {
+	int token_len;
+
+	/* Skip if not an EC2 metadata request */
+	if ( strcmp ( http->request.host, EC2_METADATA_HOST_ADDR ) != 0 )
+		return 0;
+
+	/* Skip if this is a PUT request (token acquisition) */
+	if ( http->request.method == &http_put )
+		return 0;
+
+	/* Fetch token from setting */
+	token_len = fetch_string_setting ( NULL, &ec2token_setting,
+					   buf, len );
+	if ( token_len < 1 )
+		return 0;
+
+	return token_len;
+}
+
+/** HTTP "X-aws-ec2-metadata-token" header */
+struct http_request_header
+http_request_ec2_token __http_request_header = {
+	.name = "X-aws-ec2-metadata-token",
+	.format = http_format_ec2_token,
+};

--- a/src/usr/fetchvar.c
+++ b/src/usr/fetchvar.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2026 Huzaifa Ali Zar <huzaifazar@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER );
+FILE_SECBOOT ( PERMITTED );
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <ipxe/xfer.h>
+#include <ipxe/open.h>
+#include <ipxe/iobuf.h>
+#include <ipxe/xferbuf.h>
+#include <ipxe/uri.h>
+#include <ipxe/monojob.h>
+#include <ipxe/settings.h>
+#include <usr/fetchvar.h>
+
+/** @file
+ *
+ * Fetch URI to setting
+ *
+ */
+
+/** Maximum response size (8 kB) */
+#define FETCHVAR_MAX_LEN 8192
+
+/** A fetch-to-variable request */
+struct fetchvar_request {
+	/** Reference count for this object */
+	struct refcnt refcnt;
+
+	/** Job control interface */
+	struct interface job;
+	/** Data transfer interface */
+	struct interface xfer;
+
+	/** Data transfer buffer */
+	struct xfer_buffer buffer;
+
+	/** Setting name */
+	char *setting_name;
+};
+
+/**
+ * Free fetch-to-variable request
+ *
+ * @v refcnt		Reference counter
+ */
+static void fetchvar_free ( struct refcnt *refcnt ) {
+	struct fetchvar_request *fetchvar_req =
+		container_of ( refcnt, struct fetchvar_request, refcnt );
+
+	xferbuf_free ( &fetchvar_req->buffer );
+	free ( fetchvar_req );
+}
+
+/**
+ * Terminate fetch-to-variable request
+ *
+ * @v fetchvar_req	Fetch-to-variable request
+ * @v rc		Reason for termination
+ */
+static void fetchvar_close ( struct fetchvar_request *fetchvar_req, int rc ) {
+	struct xfer_buffer *buffer = &fetchvar_req->buffer;
+	struct settings *settings;
+	struct setting setting;
+	char *value;
+
+	/* Store response in setting on success */
+	if ( rc == 0 ) {
+
+		/* Check size limit */
+		if ( buffer->len > FETCHVAR_MAX_LEN ) {
+			rc = -ENOSPC;
+			goto done;
+		}
+
+		/* Allocate NUL-terminated copy of response */
+		value = zalloc ( buffer->len + 1 /* NUL */ );
+		if ( ! value ) {
+			rc = -ENOMEM;
+			goto done;
+		}
+		memcpy ( value, buffer->data, buffer->len );
+
+		/* Parse setting name */
+		if ( ( rc = parse_setting_name (
+				fetchvar_req->setting_name,
+				autovivify_child_settings,
+				&settings, &setting ) ) != 0 ) {
+			free ( value );
+			goto done;
+		}
+
+		/* Apply default type if necessary */
+		if ( ! setting.type )
+			setting.type = &setting_type_string;
+
+		/* Store value */
+		rc = storef_setting ( settings, &setting, value );
+		free ( value );
+	}
+
+ done:
+	/* Shut down interfaces */
+	intf_shutdown ( &fetchvar_req->xfer, rc );
+	intf_shutdown ( &fetchvar_req->job, rc );
+}
+
+/**
+ * Handle received data
+ *
+ * @v fetchvar_req	Fetch-to-variable request
+ * @v iobuf		Datagram I/O buffer
+ * @v meta		Data transfer metadata
+ * @ret rc		Return status code
+ */
+static int fetchvar_deliver ( struct fetchvar_request *fetchvar_req,
+			      struct io_buffer *iobuf,
+			      struct xfer_metadata *meta ) {
+	int rc;
+
+	/* Add data to buffer */
+	if ( ( rc = xferbuf_deliver ( &fetchvar_req->buffer,
+				      iob_disown ( iobuf ), meta ) ) != 0 )
+		goto err;
+
+	return 0;
+
+ err:
+	fetchvar_close ( fetchvar_req, rc );
+	return rc;
+}
+
+/**
+ * Get underlying data transfer buffer
+ *
+ * @v fetchvar_req	Fetch-to-variable request
+ * @ret xferbuf		Data transfer buffer, or NULL on error
+ */
+static struct xfer_buffer *
+fetchvar_buffer ( struct fetchvar_request *fetchvar_req ) {
+
+	return &fetchvar_req->buffer;
+}
+
+/**
+ * Redirect data transfer interface
+ *
+ * @v fetchvar_req	Fetch-to-variable request
+ * @v type		New location type
+ * @v args		Remaining arguments depend upon location type
+ * @ret rc		Return status code
+ */
+static int fetchvar_vredirect ( struct fetchvar_request *fetchvar_req,
+				int type, va_list args ) {
+	int rc;
+
+	/* Redirect to new location */
+	if ( ( rc = xfer_vreopen ( &fetchvar_req->xfer, type, args ) ) != 0 )
+		goto err;
+
+	return 0;
+
+ err:
+	fetchvar_close ( fetchvar_req, rc );
+	return rc;
+}
+
+/** Fetch-to-variable data transfer interface operations */
+static struct interface_operation fetchvar_xfer_operations[] = {
+	INTF_OP ( xfer_deliver, struct fetchvar_request *, fetchvar_deliver ),
+	INTF_OP ( xfer_buffer, struct fetchvar_request *, fetchvar_buffer ),
+	INTF_OP ( xfer_vredirect, struct fetchvar_request *,
+		  fetchvar_vredirect ),
+	INTF_OP ( intf_close, struct fetchvar_request *, fetchvar_close ),
+};
+
+/** Fetch-to-variable data transfer interface descriptor */
+static struct interface_descriptor fetchvar_xfer_desc =
+	INTF_DESC ( struct fetchvar_request, xfer, fetchvar_xfer_operations );
+
+/** Fetch-to-variable job control interface operations */
+static struct interface_operation fetchvar_job_operations[] = {
+	INTF_OP ( intf_close, struct fetchvar_request *, fetchvar_close ),
+};
+
+/** Fetch-to-variable job control interface descriptor */
+static struct interface_descriptor fetchvar_job_desc =
+	INTF_DESC ( struct fetchvar_request, job, fetchvar_job_operations );
+
+/**
+ * Fetch URI and store response body in setting
+ *
+ * @v uri_string	URI string
+ * @v setting_name	Setting name
+ * @ret rc		Return status code
+ */
+int fetchvar ( const char *uri_string, const char *setting_name ) {
+	struct fetchvar_request *fetchvar_req;
+	struct uri *raw_uri;
+	struct uri *uri;
+	int rc;
+
+	/* Parse URI */
+	raw_uri = parse_uri ( uri_string );
+	if ( ! raw_uri ) {
+		rc = -ENOMEM;
+		goto err_parse_uri;
+	}
+
+	/* Resolve URI */
+	uri = resolve_uri ( cwuri, raw_uri );
+	if ( ! uri ) {
+		rc = -ENOMEM;
+		goto err_resolve_uri;
+	}
+
+	/* Allocate and initialise structure */
+	fetchvar_req = zalloc ( sizeof ( *fetchvar_req ) +
+				strlen ( setting_name ) + 1 /* NUL */ );
+	if ( ! fetchvar_req ) {
+		rc = -ENOMEM;
+		goto err_alloc;
+	}
+	ref_init ( &fetchvar_req->refcnt, fetchvar_free );
+	intf_init ( &fetchvar_req->job, &fetchvar_job_desc,
+		    &fetchvar_req->refcnt );
+	intf_init ( &fetchvar_req->xfer, &fetchvar_xfer_desc,
+		    &fetchvar_req->refcnt );
+	xferbuf_malloc_init ( &fetchvar_req->buffer );
+	fetchvar_req->setting_name = ( ( void * ) ( fetchvar_req + 1 ) );
+	strcpy ( fetchvar_req->setting_name, setting_name );
+
+	/* Open URI */
+	if ( ( rc = xfer_open_uri ( &fetchvar_req->xfer, uri ) ) != 0 )
+		goto err_open;
+
+	/* Attach parent interface, mortalise self, and return */
+	intf_plug_plug ( &fetchvar_req->job, &monojob );
+	ref_put ( &fetchvar_req->refcnt );
+	uri_put ( uri );
+	uri_put ( raw_uri );
+
+	/* Wait for completion */
+	if ( ( rc = monojob_wait ( uri_string, 0 ) ) != 0 ) {
+		printf ( "Could not fetch %s: %s\n",
+			 uri_string, strerror ( rc ) );
+		return rc;
+	}
+
+	return 0;
+
+ err_open:
+	fetchvar_close ( fetchvar_req, rc );
+	ref_put ( &fetchvar_req->refcnt );
+ err_alloc:
+	uri_put ( uri );
+ err_resolve_uri:
+	uri_put ( raw_uri );
+ err_parse_uri:
+	return rc;
+}

--- a/src/usr/fetchvar.c
+++ b/src/usr/fetchvar.c
@@ -31,6 +31,7 @@ FILE_SECBOOT ( PERMITTED );
 #include <ipxe/uri.h>
 #include <ipxe/monojob.h>
 #include <ipxe/settings.h>
+#include <ipxe/http.h>
 #include <usr/fetchvar.h>
 
 /** @file
@@ -212,13 +213,19 @@ static struct interface_descriptor fetchvar_job_desc =
  *
  * @v uri_string	URI string
  * @v setting_name	Setting name
+ * @v method		HTTP method (or NULL for GET)
  * @ret rc		Return status code
  */
-int fetchvar ( const char *uri_string, const char *setting_name ) {
+int fetchvar ( const char *uri_string, const char *setting_name,
+	       struct http_method *method ) {
 	struct fetchvar_request *fetchvar_req;
 	struct uri *raw_uri;
 	struct uri *uri;
 	int rc;
+
+	/* Default to GET */
+	if ( ! method )
+		method = &http_get;
 
 	/* Parse URI */
 	raw_uri = parse_uri ( uri_string );
@@ -250,8 +257,9 @@ int fetchvar ( const char *uri_string, const char *setting_name ) {
 	fetchvar_req->setting_name = ( ( void * ) ( fetchvar_req + 1 ) );
 	strcpy ( fetchvar_req->setting_name, setting_name );
 
-	/* Open URI */
-	if ( ( rc = xfer_open_uri ( &fetchvar_req->xfer, uri ) ) != 0 )
+	/* Open HTTP transaction (method selection requires HTTP) */
+	if ( ( rc = http_open ( &fetchvar_req->xfer, method,
+				uri, NULL, NULL ) ) != 0 )
 		goto err_open;
 
 	/* Attach parent interface, mortalise self, and return */


### PR DESCRIPTION
## Summary

AWS now [defaults new instances to IMDSv2-only](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html), with IMDSv1 disabled. Without this change, iPXE's cloud boot script cannot retrieve user-data on these instances.

This series adds IMDSv2 support to iPXE's cloud boot, allowing the boot script to acquire a session token and use it for subsequent metadata requests.

The implementation uses three small, layered changes:

## Commits

### 1. `fetchvar` command

A new command that fetches a URI and stores the response body in a named setting. This is analogous to `nslookup` (which stores a DNS response in a setting) — we need it because the metadata server returns a raw token string that must be captured for reuse.

```
fetchvar data http://example.com/value
show data
```

### 2. HTTP method override

Adds a `--method` option to `fetchvar` and defines `http_put` in the method table. IMDSv2 requires a PUT request to acquire the session token — without this, `fetchvar` can only do GET.

```
fetchvar --method PUT token http://169.254.169.254/latest/api/token
```

### 3. EC2 metadata headers (`httpec2.c`)

Mirrors the existing `httpgce.c` pattern. Automatically injects:
- `X-aws-ec2-metadata-token-ttl-seconds: 21600` on PUT requests to `169.254.169.254`
- `X-aws-ec2-metadata-token: <value>` on subsequent requests (using the stored setting)

The updated `aws.ipxe` boot script ties it together:
```
fetchvar --method PUT ec2token http://169.254.169.254/latest/api/token
chain -ar http://169.254.169.254/latest/user-data
```

## Design choices

- **IMDSv2 logic lives in the boot script**, not in custom C code
- **`httpec2.c` mirrors `httpgce.c` exactly** — same `__http_request_header` table pattern
- **`fetchvar` and `--method` are generic features** useful beyond EC2

Tested on EC2 instances. Full boot flow working with IMDSv2.
