### PR TITLE
[efi] Install duplicate SNP protocols onto dedicated device handle

### DIFF
--- a/src/image/efi_image.c
+++ b/src/image/efi_image.c
@@ -261,6 +261,20 @@ static int efi_image_exec ( struct image *image ) {
 	DBGC ( image, "EFIIMAGE %s device is %s\n",
 	       image->name, efi_handle_name ( device ) );
 
+	/* Install duplicate SNP protocols, if applicable */
+	if ( ( snpdev != NULL ) &&
+	     ( ( efirc = bs->InstallMultipleProtocolInterfaces (
+			&device,
+			&efi_simple_network_protocol_guid, &snpdev->snp,
+			&efi_nii_protocol_guid, &snpdev->nii,
+			&efi_nii31_protocol_guid, &snpdev->nii,
+			NULL ) ) != 0 ) ) {
+		rc = -EEFI ( efirc );
+		DBGC ( image, "EFIIMAGE %s could not duplicate %s: %s\n",
+		       image->name, netdev->name, strerror ( rc ) );
+		goto err_snp_install;
+	}
+
 	/* Add as a child of the parent device */
 	if ( ( parent != NULL ) &&
 	     ( rc = efi_child_add ( parent, device ) ) != 0 ) {
@@ -461,6 +475,15 @@ static int efi_image_exec ( struct image *image ) {
 	if ( parent )
 		efi_child_del ( parent, device );
  err_child_add:
+	if ( snpdev ) {
+		bs->UninstallMultipleProtocolInterfaces (
+			device,
+			&efi_simple_network_protocol_guid, &snpdev->snp,
+			&efi_nii_protocol_guid, &snpdev->nii,
+			&efi_nii31_protocol_guid, &snpdev->nii,
+			NULL );
+	}
+ err_snp_install:
 	bs->UninstallMultipleProtocolInterfaces (
 			device,
 			&efi_device_path_protocol_guid, devpath,


### PR DESCRIPTION
Commit 5a17d8d ("[efi] Install protocols onto a dedicated device handle") changed the behaviour for image execution to install the per-image protocols (EFI_SIMPLE_FILE_SYSTEM_PROTOCOL etc) onto a dedicated child device handle, instead of directly onto the parent SNP device handle.  The commit message mentions that if UEFI executables are found that rely upon the SNP protocols being present on the loaded image's device handle (rather than on a parent of that handle), then it may be necessary to install copies of EFI_SIMPLE_NETWORK_PROTOCOL and others onto the child handle.

Testing shows that WDS apparently does require these protocols to be present on the loaded image's device handle.  Install copies of the SNP and NII protocols onto the child handle to support this.

Fixes: #1716 

Debugged-by: Alexander Perlis <alexanderperlis@gmail.com>