### PR TITLE
[virtio] Ignore capabilities that describe inaccessible PCI BARs

### DIFF
--- a/src/drivers/bus/virtio.c
+++ b/src/drivers/bus/virtio.c
@@ -409,6 +409,13 @@ static int virtio_pci_cap ( struct virtio_device *virtio,
 		if ( reg > PCI_BASE_ADDRESS_5 )
 			continue;
 
+		/* Check BAR accessibility */
+		if ( ! pci_bar_start ( pci, reg ) ) {
+			DBGC ( virtio, "VIRTIO %s capability type %d BAR%d is "
+			       "not usable\n", virtio->name, type, cap->bar );
+			continue;
+		}
+
 		/* Success */
 		cap->pos = pos;
 		return 0;


### PR DESCRIPTION
In some configurations, newer versions of QEMU will end up placing the modern interface's BAR4 above 4GB, rendering it inaccessible in a 32-bit build of iPXE.  iPXE will currently detect the existence of the modern interface and attempt to use it, but fail at the point of attempting to map the PCI BARs.

Fix by ignoring any virtio capabilities that describe an inaccessible PCI BAR, and so allowing iPXE to fall back to using the legacy interface if the modern interface's BAR cannot be used.

Fixes: #1738 

Reported-by: Jan ONDREJ (SAL) <ondrejj@salstar.sk>