### PR TITLE
[aqc1xx] Fix operation behind an IOMMU and RX buffer leak on close

### DIFF
--- a/src/drivers/net/marvell/aqc1xx.c
+++ b/src/drivers/net/marvell/aqc1xx.c
@@ -528,8 +528,10 @@ static int atl_probe ( struct pci_device *pci ) {
 		goto err_ioremap;
 	}
 
-	 /* Configure DMA */
+	/* Configure DMA */
 	nic->dma = &pci->dma;
+	dma_set_mask_64bit ( nic->dma );
+	netdev->dma = nic->dma;
 
 	/* Reset the NIC */
 	if ( ( rc = nic->hw_ops->reset ( nic ) ) != 0 )

--- a/src/drivers/net/marvell/aqc1xx.c
+++ b/src/drivers/net/marvell/aqc1xx.c
@@ -262,6 +262,7 @@ err_tx_alloc:
 */
 static void atl_close ( struct net_device *netdev ) {
 	struct atl_nic *nic = netdev->priv;
+	unsigned int i;
 
 	nic->hw_ops->stop ( nic );
 	/* rpb global ctrl */
@@ -282,6 +283,13 @@ static void atl_close ( struct net_device *netdev ) {
 
 	atl_ring_free ( &nic->tx_ring );
 	atl_ring_free ( &nic->rx_ring );
+
+	/* Discard any outstanding receive I/O buffers */
+	for ( i = 0 ; i < ATL_RING_SIZE ; i++ ) {
+		if ( nic->iobufs[i] )
+			free_rx_iob ( nic->iobufs[i] );
+		nic->iobufs[i] = NULL;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Two fixes for the aqc1xx driver, found while bringing up aqc1xx
adapters on a host with the IOMMU (Intel VT-d) enabled.

## Changes

- **Set netdev->dma for operation with an IOMMU** — the driver never set
  `netdev->dma`, so transmit buffers were left unmapped for DMA. Without an
  IOMMU this happened to work (physical address == device address), but with
  an IOMMU the unmapped DMA access faults and stalls the receive path: no
  packets are received and DHCP fails. Setting `netdev->dma` and a 64-bit DMA
  mask maps the buffers through the firmware IOMMU, matching the other iPXE
  drivers.

- **Free outstanding receive I/O buffers on close** — `atl_close()` freed the
  descriptor rings but left the posted receive I/O buffers allocated, leaking
  them and tripping an assertion on the next open. These are now freed in
  `atl_close()`.

## Testing

Verified on AQC113 with VT-d enabled: the adapter now receives packets
and completes DHCP, and repeated open/close cycles no longer leak buffers or
assert.