### PR TITLE
Change default keyboard map to dynamic

### DIFF
--- a/src/config/console.h
+++ b/src/config/console.h
@@ -83,6 +83,12 @@ FILE_SECBOOT ( PERMITTED );
 #define KEYBOARD_MAP	us	/* Default US keyboard map */
 //#define KEYBOARD_MAP	dynamic	/* Runtime selectable keyboard map */
 
+/* Use dynamic keyboard by default on EFI platforms */
+#if defined ( PLATFORM_efi )
+  #undef KEYBOARD_MAP
+  #define KEYBOARD_MAP	dynamic
+#endif
+
 /*****************************************************************************
  *
  * Log levels


### PR DESCRIPTION
Hello,

Until now, I have been building iPXE myself mainly to change the KEYBOARD_MAP setting to dynamic.

With the new automated UEFI Secure Boot signing and release process, I would prefer to use the official signed builds instead of maintaining a custom build.

Would you consider changing the default KEYBOARD_MAP value to dynamic, or providing an official build option that enables it?

Thanks.