### PR TITLE
[hermon] Add missing write barrier after initiating reset

### DIFF
--- a/src/drivers/infiniband/hermon.c
+++ b/src/drivers/infiniband/hermon.c
@@ -2843,6 +2843,7 @@ static int hermon_reset ( struct hermon *hermon ) {
 	pci_backup ( pci, &backup, PCI_CONFIG_BACKUP_ALL, backup_exclude );
 	writel ( HERMON_RESET_MAGIC,
 		 ( hermon->config + HERMON_RESET_OFFSET ) );
+	wmb();
 
 	/* Wait until device starts responding to configuration cycles */
 	for ( i = 0 ; i < HERMON_RESET_MAX_WAIT_MS ; i++ ) {


### PR DESCRIPTION
Ensure that the reset register write does not get reordered behind the first PCI configuration space read that checks to see if the reset has completed.

Fixes: #1751

Debugged-by: Jaroslav Svoboda <multi.flexi@seznam.cz>
Tested-by: Jaroslav Svoboda <multi.flexi@seznam.cz>