### PR TITLE
[xfer] Do not attempt to find an opener for a null URI scheme

### DIFF
--- a/src/core/open.c
+++ b/src/core/open.c
@@ -77,6 +77,14 @@ int xfer_open_uri ( struct interface *intf, struct uri *uri ) {
 		goto err_resolve_uri;
 	}
 
+	/* Check that URI has a scheme */
+	if ( ! uri_is_absolute ( resolved_uri ) ) {
+		DBGC ( INTF_COL ( intf ), "INTF " INTF_FMT " attempted to open "
+		       "non-absolute URI\n", INTF_DBG ( intf ) );
+		rc = -ENOTSUP;
+		goto err_absolute;
+	}
+
 	/* Find opener which supports this URI scheme */
 	opener = xfer_uri_opener ( resolved_uri->scheme );
 	if ( ! opener ) {
@@ -98,6 +106,7 @@ int xfer_open_uri ( struct interface *intf, struct uri *uri ) {
 
  err_open:
  err_opener:
+ err_absolute:
 	uri_put ( resolved_uri );
  err_resolve_uri:
 	return rc;


### PR DESCRIPTION
With no current working URI, even a fully resolved URI may not have a scheme.  Attempting to open such a URI will currently result in xfer_uri_opener() calling strcasecmp() with a null pointer.  On a system that guards against null pointer dereferences, this will result in a segfault (or the equivalent, such as a Synchronous Exception on arm64 UEFI).

Fix by checking that the URI is absolute (i.e. has a scheme) before calling xfer_uri_opener(), as is already done elsewhere.

Fixes: #1754 

Reported-by: Matt Fleming <matt@readmodwrite.com>