### PR TITLE
[mime] Fix the use of MIME images without an explicit encoding

### DIFF
--- a/src/image/mime.c
+++ b/src/image/mime.c
@@ -180,7 +180,6 @@ static int mime_parse ( struct image *image, const char *text,
 
 	/* Initialise headers */
 	memset ( headers, 0, sizeof ( *headers ) );
-	headers->encoding = "7bit";
 
 	/* Parse headers until reaching empty-line separator */
 	for ( line = text ; ; line = next ) {
@@ -295,6 +294,7 @@ static int mime_decode_base64 ( struct image *image,
 /** MIME encodings */
 static const struct mime_encoding mime_encodings[] = {
 	{
+		/* Default encoding */
 		.name = "7bit",
 		.decode = mime_decode_identity,
 	},
@@ -315,13 +315,17 @@ static const struct mime_encoding mime_encodings[] = {
 /**
  * Identify MIME encoding
  *
- * @v name		Encoding
+ * @v name		Encoding name, or NULL to use default
  * @ret encoding	MIME encoding, or NULL if not recognised
  */
 static const struct mime_encoding * mime_encoding ( const char *name ) {
 	const struct mime_encoding *encoding;
 	size_t len;
 	unsigned int i;
+
+	/* Use default encoding if no name specified */
+	if ( ! name )
+		return &mime_encodings[0];
 
 	/* Identify MIME encoding */
 	for ( i = 0 ; i < ( sizeof ( mime_encodings ) /

--- a/src/tests/mime_test.c
+++ b/src/tests/mime_test.c
@@ -81,6 +81,16 @@ ARCHIVE_TEST ( multipart, &mime_image_type, "user-data", NULL, "user-data",
 		   "IyFpcHhlCgplY2hvIEhlbGxvIHdvcmxkCnNoZWxsCg==\r\n"
 		   "\r\n" ) );
 
+/** No explicit encoding */
+ARCHIVE_TEST ( no_encoding, &mime_image_type, "noenc.mime", NULL, "noenc",
+	TEXTFILE ( "Content-Type: text/x-ipxe; charset=\"utf-8\"\r\n"
+		   "MIME-Version: 1.0\r\n"
+		   "\r\n"
+		   "#!ipxe\r\n"
+		   "echo Default encoding\r\n" ),
+	TEXTFILE ( "#!ipxe\r\n"
+		   "echo Default encoding\r\n" ) );
+
 /**
  * Perform mime self-test
  *
@@ -89,6 +99,7 @@ static void mime_test_exec ( void ) {
 
 	archive_ok ( &hello_world );
 	archive_ok ( &multipart );
+	archive_ok ( &no_encoding );
 }
 
 /** MIME self-test */


### PR DESCRIPTION
The Content-Transfer-Encoding header is optional: if not present then the default "7bit" encoding should be assumed.  iPXE already includes logic to set a default encoding name, but the default encoding name then fails to match against any entries in the known encodings list since it is terminated with a NUL (rather than with the semicolon or whitespace character that would terminate the encoding name found within a Content-Transfer-Encoding header).

Fix by removing the default encoding name and instead treating a NULL encoding name as indicating that the default encoding should be used, and add a test case that omits the Content-Transfer-Encoding header.

Fixes: #1756 

Reported-by: Huzaifa Ali Zar <zar@amazon.com>