### PR TITLE
[ipv6] Use correct length when checking for truncated packets

### DIFF
--- a/src/net/ipv6.c
+++ b/src/net/ipv6.c
@@ -691,7 +691,7 @@ static int ipv6_rx ( struct io_buffer *iobuf, struct net_device *netdev,
 	}
 
 	/* Truncate packet to specified length */
-	len = ntohs ( iphdr->len );
+	len = ( sizeof ( *iphdr ) + ntohs ( iphdr->len ) );
 	if ( len > iob_len ( iobuf ) ) {
 		DBGC ( ipv6col ( &iphdr->src ), "IPv6 length too long at %zd "
 		       "bytes (packet is %zd bytes)\n", len, iob_len ( iobuf ));
@@ -699,7 +699,7 @@ static int ipv6_rx ( struct io_buffer *iobuf, struct net_device *netdev,
 		rc = -EINVAL_LEN;
 		goto err_other;
 	}
-	iob_unput ( iobuf, ( iob_len ( iobuf ) - len - sizeof ( *iphdr ) ) );
+	iob_unput ( iobuf, ( iob_len ( iobuf ) - len ) );
 	hdrlen = sizeof ( *iphdr );
 
 	/* Print IPv6 header for debugging */


### PR DESCRIPTION
The IPv6 header length field contains the payload length (excluding the length of the IPv6 header itself).  The IPv6 packet parser calculates the length of the received packet correctly, but wrongly uses the payload length (rather than the full packet length) when checking for truncated packets.

Fix by calculating the packet length exactly once and using it for both purposes.