### PR TITLE
[dhcp] Reject underlength DHCP packets

### DIFF
--- a/src/net/dhcppkt.c
+++ b/src/net/dhcppkt.c
@@ -300,11 +300,18 @@ static struct settings_operations dhcppkt_settings_operations = {
  */
 void dhcppkt_init ( struct dhcp_packet *dhcppkt, struct dhcphdr *data,
 		    size_t len ) {
+
+	/* Sanity check */
+	assert ( len >= sizeof ( *data ) );
+
+	/* Initialise packet */
 	ref_init ( &dhcppkt->refcnt, NULL );
 	dhcppkt->dhcphdr = data;
 	dhcpopt_init ( &dhcppkt->options, &dhcppkt->dhcphdr->options,
 		       ( len - offsetof ( struct dhcphdr, options ) ),
 		       dhcpopt_no_realloc );
+
+	/* Initialise settings content */
 	settings_init ( &dhcppkt->settings, &dhcppkt_settings_operations,
 			&dhcppkt->refcnt, NULL );
 }

--- a/src/net/udp/dhcp.c
+++ b/src/net/udp/dhcp.c
@@ -1223,6 +1223,11 @@ static int dhcp_deliver ( struct dhcp_session *dhcp,
 	 * waste a relatively scarce fully-aligned I/O buffer.
 	 */
 	data_len = iob_len ( iobuf );
+	if ( data_len < sizeof ( *dhcphdr ) ) {
+		DBGC ( dhcp, "DHCP %p received underlength packet\n", dhcp );
+		rc = -EINVAL;
+		goto err_dhcphdr;
+	}
 	dhcppkt = zalloc ( sizeof ( *dhcppkt ) + data_len );
 	if ( ! dhcppkt ) {
 		rc = -ENOMEM;
@@ -1275,6 +1280,7 @@ static int dhcp_deliver ( struct dhcp_session *dhcp,
  err_xid:
 	dhcppkt_put ( dhcppkt );
  err_alloc_dhcppkt:
+ err_dhcphdr:
  err_no_src:
 	free_iob ( iobuf );
 	return rc;


### PR DESCRIPTION
Reject underlength DHCP packets before calling dhcppkt_init(), which takes a struct dhcphdr pointer and so may legitimately assume that the structure is complete (i.e. that the length is at least large enough to contain a struct dhcphdr).

Do not modify the dhcppkt_init() parameters to pass the options length rather than the total length.  This alternative approach would make it impossible to pass an invalid length: the check in dhcp_deliver() would then become a check for integer underflow, which would be more obviously necessary.  However, all callers of dhcppkt_init() have the total length more readily available than the options length, and callers such as cachedhcp_record() deal with fixed-size structures such as EFI_PXE_BASE_CODE_PACKET and so do not have to worry about potential underlength packets.