### PR TITLE
[png] Check for overflow when constructing raw data buffer length

### DIFF
--- a/src/image/png.c
+++ b/src/image/png.c
@@ -179,13 +179,21 @@ static unsigned int png_pixel_len ( struct png_context *png ) {
  *
  * @v png		PNG context
  * @v interlace		Interlace pass
- * @ret scanline_len	Scanline length (including filter byte)
+ * @ret scanline_len	Scanline length (including filter byte), or 0 on error
  */
 static size_t png_scanline_len ( struct png_context *png,
 				 struct png_interlace *interlace ) {
+	size_t bits;
 
-	return ( 1 /* Filter byte */ +
-		 ( ( interlace->width * png->channels * png->depth ) + 7 ) / 8);
+	/* Calculate bit count and check for overflow */
+	bits = ( interlace->width * png->channels * png->depth );
+	assert ( png->channels != 0 );
+	assert ( png->depth != 0 );
+	if ( ( ( bits / png->channels ) / png->depth ) != interlace->width )
+		return 0;
+
+	/* Calculate byte length (cannot overflow) */
+	return ( 1 /* Filter byte */ + ( bits / 8 ) + ( !! ( bits & 7 ) ) );
 }
 
 /**
@@ -200,6 +208,8 @@ static int png_image_header ( struct image *image, struct png_context *png,
 			      size_t len ) {
 	const struct png_image_header *ihdr;
 	struct png_interlace interlace;
+	size_t scanline_len;
+	size_t pass_len;
 	unsigned int pass;
 
 	/* Sanity check */
@@ -273,8 +283,15 @@ static int png_image_header ( struct image *image, struct png_context *png,
 		png_interlace ( png, pass, &interlace );
 		if ( interlace.width == 0 )
 			continue;
-		png->raw.len += ( interlace.height *
-				  png_scanline_len ( png, &interlace ) );
+		scanline_len = png_scanline_len ( png, &interlace );
+		if ( ! scanline_len )
+			return -ERANGE;
+		pass_len = ( interlace.height * scanline_len );
+		if ( ( pass_len / scanline_len ) != interlace.height )
+			return -ERANGE;
+		png->raw.len += pass_len;
+		if ( png->raw.len < pass_len )
+			return -ERANGE;
 	}
 
 	/* Allocate raw data buffer */


### PR DESCRIPTION
Writing to the raw (i.e. decompressed) data buffer is already strictly bounded by its allocated length.  However, reading from the raw data buffer to construct the pixel buffer content is not.  A maliciously formed PNG file can therefore result in undefined external heap memory being read, interpreted, and used to construct the picture shown on screen to the user.

There is no way for this data to subsequently be obtained over the network, though a particularly determined attacker could potentially reconstruct the contents of other image files by capturing the on-screen video output.

Fix by checking for overflow at each stage of constructing the raw buffer length.