### PR TITLE
[lacp] Fix stripping of trailing padding

### DIFF
--- a/src/net/eth_slow.c
+++ b/src/net/eth_slow.c
@@ -293,7 +293,7 @@ static int eth_slow_rx ( struct io_buffer *iobuf,
 	}
 
 	/* Strip any trailing padding */
-	iob_unput ( iobuf, ( sizeof ( *eth_slow ) - iob_len ( iobuf ) ) );
+	iob_unput ( iobuf, ( iob_len ( iobuf ) - sizeof ( *eth_slow ) ) );
 
 	/* Handle according to subtype */
 	switch ( eth_slow->header.subtype ) {


### PR DESCRIPTION
The iob_unput() to strip any trailing padding is currently sign reversed, causing the buffer to be extended rather than truncated.

This can result in uninitialised data within the receive I/O buffer being passed to the LACP or marker receive handlers and subsequently echoed back to the sender.

Fix by reversing the subtraction.