### PR TITLE
[nbi] Avoid harmless integer overflows in image length checks

### DIFF
--- a/src/arch/x86/image/nbi.c
+++ b/src/arch/x86/image/nbi.c
@@ -171,6 +171,11 @@ static int nbi_process_segments ( struct image *image,
 	sh_off = NBI_LENGTH ( imgheader->length );
 	do {
 		/* Read segment header */
+		if ( ( sh_off + sizeof ( *sh ) ) > image->len ) {
+			DBGC ( image, "NBI %s segheader outside file\n",
+			       image->name );
+			return -ENOEXEC;
+		}
 		sh = ( image->data + sh_off );
 		if ( sh->length == 0 ) {
 			/* Avoid infinite loop? */
@@ -206,7 +211,8 @@ static int nbi_process_segments ( struct image *image,
 		/* Process this segment */
 		filesz = sh->imglength;
 		memsz = sh->memlength;
-		if ( ( offset + filesz ) > image->len ) {
+		if ( ( offset > image->len ) ||
+		     ( filesz > ( image->len - offset ) ) ) {
 			DBGC ( image, "NBI %s segment outside file\n",
 			       image->name );
 			return -ENOEXEC;


### PR DESCRIPTION
Fix the checks against reading beyond the image length when executing an NBI image.

This change has absolutely no security impact: an NBI image will obtain control of the system in ring 0 anyway, and so a "malicious" NBI image with malformed length fields cannot do anything that it would not already be able to do simply by being executed.  However, fixing these harmless integer overflows costs very little and reduces unwanted noise from security reviewers.