### PR TITLE
[crypto] Remove harmless but technically undefined right shift

### DIFF
--- a/src/crypto/asn1.c
+++ b/src/crypto/asn1.c
@@ -385,7 +385,6 @@ int asn1_enter_bits ( struct asn1_cursor *cursor, unsigned int *unused ) {
 	} __attribute__ (( packed )) *bit_string;
 	const uint8_t *last;
 	unsigned int unused_bits;
-	uint8_t unused_mask;
 	int rc;
 
 	/* Enter bit string */
@@ -405,11 +404,10 @@ int asn1_enter_bits ( struct asn1_cursor *cursor, unsigned int *unused ) {
 	unused_bits = bit_string->unused;
 
 	/* Check validity of unused bits */
-	unused_mask = ( 0xff >> ( 8 - unused_bits ) );
 	last = ( cursor->data + cursor->len - 1 );
 	if ( ( unused_bits >= 8 ) ||
 	     ( ( unused_bits > 0 ) && ( cursor->len == 0 ) ) ||
-	     ( ( *last & unused_mask ) != 0 ) ) {
+	     ( ( *last & ( 0xffU >> ( 8 - unused_bits ) ) ) != 0 ) ) {
 		DBGC ( cursor, "ASN1 %p invalid bit string:\n", cursor );
 		DBGC_HDA ( cursor, 0, cursor->data, cursor->len );
 		asn1_invalidate_cursor ( cursor );


### PR DESCRIPTION
Automated reporting tools tend to pick up the right-shift by an attacker-controllable shift amount as a potential defect, since a right-shift by greater than the word size is technically undefined behaviour.

The result of an undefined shift is already ignored by the following range check on the shift amount, and the separate "unused_mask" variable exists only to make the code clearer to read.  Sacrifice this very small improvement in legibility for the sake of reducing future reporting noise.