### PR TITLE
[crypto] Avoid false positive warnings about mutating static state

### DIFF
--- a/src/crypto/ocsp.c
+++ b/src/crypto/ocsp.c
@@ -481,7 +481,7 @@ static int ocsp_parse_responder_id ( struct ocsp_check *ocsp,
  */
 static int ocsp_parse_cert_id ( struct ocsp_check *ocsp,
 				const struct asn1_cursor *raw ) {
-	static struct asn1_cursor algorithm = {
+	struct asn1_cursor algorithm = {
 		.data = ocsp_algorithm_id,
 		.len = sizeof ( ocsp_algorithm_id ),
 	};


### PR DESCRIPTION
iPXE is single-threaded by design, but automated tools still tend to erroneously report the mutation of static state as being unsafe, especially when that mutation happens within cryptographic code.

At the cost of six bytes in the 32-bit BIOS binary, allocate the reference algorithm ASN.1 cursor on the stack to eliminate this class of false positive warning.