### PR TITLE
[crypto] Remove harmless but technically undefined left shift

### DIFF
--- a/src/crypto/x509.c
+++ b/src/crypto/x509.c
@@ -524,7 +524,7 @@ static int x509_parse_key_usage ( struct x509_certificate *cert,
 	if ( len > sizeof ( usage->bits ) )
 		len = sizeof ( usage->bits );
 	for ( i = 0 ; i < len ; i++ ) {
-		usage->bits |= ( *(bytes++) << ( 8 * i ) );
+		usage->bits |= ( ( ( unsigned ) *(bytes++) ) << ( 8 * i ) );
 	}
 	DBGC2 ( cert, "X509 %p key usage is %08x\n", cert, usage->bits );
 


### PR DESCRIPTION
The unsigned 8-bit value from the keyUsage bit string is promoted to a (signed) int before being shifted left by up to 24 bits, which is technically undefined behaviour.

Explicitly cast the dereferenced pointer to an unsigned int before shifting, to inhibit this class of warning.  There is no difference to the resulting object code.