### PR TITLE
[iphone] Fix debug printing of received log messages

### DIFF
--- a/src/drivers/net/iphone.c
+++ b/src/drivers/net/iphone.c
@@ -776,7 +776,7 @@ static void imux_rx_log ( struct imux *imux, struct imux_header *hdr,
 	 * then shuffle the message down within the buffer and append
 	 * a NUL terminator.
 	 */
-	msg_len = ( len - sizeof ( *hdr ) );
+	msg_len = ( len - sizeof ( *log ) );
 	level = log->level;
 	tmp = ( ( void * ) &log->level );
 	memmove ( tmp, &log->msg, msg_len );


### PR DESCRIPTION
The log message length is calculated incorrectly, causing the first byte after the I/O buffer data to be both read and written (with a fixed zero value).  A log message of precisely 4079 bytes will therefore result in a zero byte being written outside the I/O buffer's heap allocation.

Fix by using the correct length for the log message.