### PR TITLE
[uhci] Fix descriptor count for zero-length stream transfers

### DIFF
--- a/src/drivers/usb/uhci.c
+++ b/src/drivers/usb/uhci.c
@@ -850,7 +850,9 @@ static int uhci_endpoint_stream ( struct usb_endpoint *ep,
 
 	/* Calculate number of descriptors */
 	len = iob_len ( iobuf );
-	count = ( ( ( len + ring->mtu - 1 ) / ring->mtu ) + ( zlp ? 1 : 0 ) );
+	count = ( ( len + ring->mtu - 1 ) / ring->mtu );
+	if ( zlp || ( count == 0 ) )
+		count++;
 
 	/* Enqueue transfer */
 	if ( ( rc = uhci_enqueue ( ring, iobuf, count ) ) != 0 )
@@ -862,7 +864,7 @@ static int uhci_endpoint_stream ( struct usb_endpoint *ep,
 			( input ? USB_PID_IN : USB_PID_OUT ) );
 
 	/* Describe zero-length packet, if applicable */
-	if ( zlp )
+	if ( len && zlp )
 		uhci_describe ( ring, NULL, 0, USB_PID_OUT );
 
 	/* Sanity check */


### PR DESCRIPTION
The descriptor count for a zero-length stream transfer with no explicit terminating zero-length packet is currently calculated incorrectly as requiring zero descriptors.  This will cause uhci_enqueue() to attempt to allocate a zero-length block of transfer descriptors, which will fail and return -ENOMEM.

There is no internal code path within iPXE that can ever submit a zero-length stream transfer without an explicit terminating zero-length packet.  This condition is reachable only via the EFI_USB_IO_PROTOCOL interface that we expose on UEFI platforms to allow existing firmware drivers to reconnect after we take control of the host controller.

Fix by ensuring that the descriptor count is set to one for a zero-length stream transfer with no explicit terminating zero-length packet, as is already done for EHCI and XHCI.