### PR TITLE
[elf] Avoid harmless integer overflows in image length checks

### DIFF
--- a/src/image/elf.c
+++ b/src/image/elf.c
@@ -99,7 +99,8 @@ static int elf_segment ( struct image *image, const Elf_Ehdr *ehdr,
 		return 0;
 
 	/* Check segment lies within image */
-	if ( ( phdr->p_offset + phdr->p_filesz ) > image->len ) {
+	if ( ( image->len < phdr->p_offset ) ||
+	     ( ( image->len - phdr->p_offset ) < phdr->p_filesz ) ) {
 		DBGC ( image, "ELF %s segment outside image\n", image->name );
 		return -ENOEXEC;
 	}


### PR DESCRIPTION
Fix the checks against reading beyond the image length when executing an ELF image.

As with the equivalent commit 979c86f ("[nbi] Avoid harmless integer overflows in image length checks"), this change has absolutely no security impact: an ELF image will obtain control of the system in ring 0 anyway, and so a "malicious" ELF image with malformed length fields cannot do anything that it would not already be able to do simply by being executed.  However, fixing these harmless integer overflows costs very little and reduces unwanted noise from security reviewers.