### PR TITLE
[ipv4] Remove harmless but technically undefined left shift

### DIFF
--- a/src/net/ipv4.c
+++ b/src/net/ipv4.c
@@ -167,8 +167,9 @@ static int ipv4_add_static ( struct net_device *netdev, struct in_addr address,
 		remaining--;
 		masklen = ( ( width + 7 ) / 8 );
 
-		/* Check remaining length */
-		if ( ( masklen + sizeof ( gateway ) ) > remaining ) {
+		/* Check remaining length and mask validity */
+		if ( ( ( masklen + sizeof ( gateway ) ) > remaining ) ||
+		     ( width > 32 ) ) {
 			DBGC ( netdev, "IPv4 invalid static route:\n" );
 			DBGC_HDA ( netdev, 0, routes, len );
 			return -EINVAL;


### PR DESCRIPTION
A DHCP static route option is capable of encoding an invalid subnet mask width of greater than 32 bits.  This leads to a technically undefined left shift when calculating the 32-bit subnet mask.

There is no security impact of this undefined shift: the only possible outcome is that the subnet mask for the improperly defined static route ends up holding an invalid value.

Fix by checking the range before performing the shift, to eliminate future reporting noise.