### PR TITLE
[ucode] Remove harmless read beyond end of malformed equivalence table

### DIFF
--- a/src/arch/x86/image/ucode.c
+++ b/src/arch/x86/image/ucode.c
@@ -539,7 +539,8 @@ static int ucode_parse_amd ( struct image *image, size_t start,
 	/* Count number of equivalence table entries */
 	offset = sizeof ( *hdr );
 	equiv = ( image->data + start + offset );
-	for ( count = 0 ; offset < ( sizeof ( *hdr ) + hdr->len ) ;
+	for ( count = 0 ;
+	      ( offset + sizeof ( *equiv ) ) <= ( sizeof ( *hdr ) + hdr->len );
 	      count++, offset += sizeof ( *equiv ) ) {
 		if ( ! equiv[count].signature )
 			break;


### PR DESCRIPTION
If the AMD microcode equivalence table is malformed and is not an exact multiple of the entry size, then we may read up to two bytes beyond the end of the allocated image.

The small out-of-bounds read is harmless since the immediately following code will reject any image with fewer than eight bytes remaining after the equivalence table (or will harmlessly return immediately if the out-of-bounds read value was 0x00000000 and no previous equivalence table entries were present).

Fix by adjusting the loop condition to ignore partial equivalence table entries.