### PR TITLE
[usb] Guard against invalid descriptor lengths in USB configurations

### DIFF
--- a/src/drivers/bus/cdc.c
+++ b/src/drivers/bus/cdc.c
@@ -46,9 +46,9 @@ cdc_union_descriptor ( struct usb_configuration_descriptor *config,
 		       struct usb_interface_descriptor *interface ) {
 	struct cdc_union_descriptor *desc;
 
-	for_each_interface_descriptor ( desc, config, interface ) {
-		if ( ( desc->header.type == USB_CS_INTERFACE_DESCRIPTOR ) &&
-		     ( desc->subtype == CDC_SUBTYPE_UNION ) )
+	for_each_interface_descriptor ( desc, config, interface,
+					USB_CS_INTERFACE_DESCRIPTOR ) {
+		if ( desc->subtype == CDC_SUBTYPE_UNION )
 			return desc;
 	}
 	return NULL;

--- a/src/drivers/bus/usb.c
+++ b/src/drivers/bus/usb.c
@@ -123,10 +123,9 @@ usb_interface_association_descriptor ( struct usb_configuration_descriptor
 	struct usb_interface_association_descriptor *desc;
 
 	/* Find a matching interface association descriptor */
-	for_each_config_descriptor ( desc, config ) {
-		if ( ( desc->header.type ==
-		       USB_INTERFACE_ASSOCIATION_DESCRIPTOR ) &&
-		     ( desc->first == first ) )
+	for_each_config_descriptor ( desc, config,
+				     USB_INTERFACE_ASSOCIATION_DESCRIPTOR ) {
+		if ( desc->first == first )
 			return desc;
 	}
 	return NULL;
@@ -146,9 +145,8 @@ usb_interface_descriptor ( struct usb_configuration_descriptor *config,
 	struct usb_interface_descriptor *desc;
 
 	/* Find a matching interface descriptor */
-	for_each_config_descriptor ( desc, config ) {
-		if ( ( desc->header.type == USB_INTERFACE_DESCRIPTOR ) &&
-		     ( desc->interface == interface ) &&
+	for_each_config_descriptor ( desc, config, USB_INTERFACE_DESCRIPTOR ) {
+		if ( ( desc->interface == interface ) &&
 		     ( desc->alternate == alternate ) )
 			return desc;
 	}
@@ -173,9 +171,9 @@ usb_endpoint_descriptor ( struct usb_configuration_descriptor *config,
 	unsigned int direction = ( type & USB_DIR_IN );
 
 	/* Find a matching endpoint descriptor */
-	for_each_interface_descriptor ( desc, config, interface ) {
-		if ( ( desc->header.type == USB_ENDPOINT_DESCRIPTOR ) &&
-		     ( ( desc->attributes &
+	for_each_interface_descriptor ( desc, config, interface,
+					USB_ENDPOINT_DESCRIPTOR ) {
+		if ( ( ( desc->attributes &
 			 USB_ENDPOINT_ATTR_TYPE_MASK ) == attributes ) &&
 		     ( ( desc->endpoint & USB_DIR_IN ) == direction ) &&
 		     ( index-- == 0 ) )
@@ -201,7 +199,8 @@ usb_endpoint_companion_descriptor ( struct usb_configuration_descriptor *config,
 			       struct usb_endpoint_companion_descriptor,
 			       header );
 	return ( ( usb_is_within_config ( config, &descx->header ) &&
-		   descx->header.type == USB_ENDPOINT_COMPANION_DESCRIPTOR )
+		   ( descx->header.len >= sizeof ( *descx ) ) &&
+		   ( descx->header.type == USB_ENDPOINT_COMPANION_DESCRIPTOR ) )
 		 ? descx : NULL );
 }
 

--- a/src/drivers/net/ecm.c
+++ b/src/drivers/net/ecm.c
@@ -72,9 +72,9 @@ ecm_ethernet_descriptor ( struct usb_configuration_descriptor *config,
 			  struct usb_interface_descriptor *interface ) {
 	struct ecm_ethernet_descriptor *desc;
 
-	for_each_interface_descriptor ( desc, config, interface ) {
-		if ( ( desc->header.type == USB_CS_INTERFACE_DESCRIPTOR ) &&
-		     ( desc->subtype == CDC_SUBTYPE_ETHERNET ) )
+	for_each_interface_descriptor ( desc, config, interface,
+					USB_CS_INTERFACE_DESCRIPTOR ) {
+		if ( desc->subtype == CDC_SUBTYPE_ETHERNET )
 			return desc;
 	}
 	return NULL;

--- a/src/drivers/usb/usbio.c
+++ b/src/drivers/usb/usbio.c
@@ -134,18 +134,12 @@ static int usbio_interface ( struct usbio_device *usbio,
 
 	/* Iterate over all interface descriptors looking for a match */
 	config = usbio->config;
-	for_each_config_descriptor ( interface, config ) {
-
-		/* Skip non-interface descriptors */
-		if ( interface->header.type != USB_INTERFACE_DESCRIPTOR )
-			continue;
+	for_each_config_descriptor ( interface, config,
+				     USB_INTERFACE_DESCRIPTOR ) {
 
 		/* Iterate over all endpoint descriptors looking for a match */
-		for_each_interface_descriptor ( endpoint, config, interface ) {
-
-			/* Skip non-endpoint descriptors */
-			if ( endpoint->header.type != USB_ENDPOINT_DESCRIPTOR )
-				continue;
+		for_each_interface_descriptor ( endpoint, config, interface,
+						USB_ENDPOINT_DESCRIPTOR ) {
 
 			/* Check endpoint address */
 			if ( endpoint->endpoint != ep->address )

--- a/src/include/ipxe/usb.h
+++ b/src/include/ipxe/usb.h
@@ -383,22 +383,32 @@ usb_is_within_config ( struct usb_configuration_descriptor *config,
 }
 
 /** Iterate over all configuration descriptors */
-#define for_each_config_descriptor( desc, config )			   \
+#define for_each_config_descriptor( desc, config, typeval )		   \
 	for ( desc = container_of ( &(config)->header,			   \
 				    typeof ( *desc ), header ) ;	   \
-	      usb_is_within_config ( (config), &desc->header ) ;	   \
+	      ( usb_is_within_config ( (config), &desc->header ) &&	   \
+		( desc->header.len >= sizeof ( desc->header ) ) ) ;	   \
 	      desc = container_of ( usb_next_descriptor ( &desc->header ), \
-				    typeof ( *desc ), header ) )
+				    typeof ( *desc ), header ) )	   \
+		if ( ( desc->header.len < sizeof ( *desc ) ) ||		   \
+		     ( desc->header.type != (typeval) ) )		   \
+			continue;					   \
+		else
 
 /** Iterate over all configuration descriptors within an interface descriptor */
-#define for_each_interface_descriptor( desc, config, interface )	   \
+#define for_each_interface_descriptor( desc, config, interface, typeval )  \
 	for ( desc = container_of ( usb_next_descriptor ( &(interface)->   \
 							  header ),	   \
 				    typeof ( *desc ), header ) ;	   \
 	      ( usb_is_within_config ( (config), &desc->header ) &&	   \
+		( desc->header.len >= sizeof ( desc->header ) ) &&	   \
 		( desc->header.type != USB_INTERFACE_DESCRIPTOR ) ) ;	   \
 	      desc = container_of ( usb_next_descriptor ( &desc->header ), \
-				    typeof ( *desc ), header ) )
+				    typeof ( *desc ), header ) )	   \
+		if ( ( desc->header.len < sizeof ( *desc ) ) ||		   \
+		     ( desc->header.type != (typeval) ) )		   \
+			continue;					   \
+		else
 
 /** A USB endpoint */
 struct usb_endpoint {

--- a/src/interface/efi/efi_usb.c
+++ b/src/interface/efi/efi_usb.c
@@ -109,9 +109,9 @@ static int efi_usb_mtu ( struct efi_usb_interface *usbintf,
 	}
 
 	/* Locate and copy cached endpoint descriptor */
-	for_each_interface_descriptor ( desc, usbdev->config, interface ) {
-		if ( ( desc->header.type == USB_ENDPOINT_DESCRIPTOR ) &&
-		     ( desc->endpoint == endpoint ) )
+	for_each_interface_descriptor ( desc, usbdev->config, interface,
+					USB_ENDPOINT_DESCRIPTOR ) {
+		if ( desc->endpoint == endpoint )
 			return USB_ENDPOINT_MTU ( le16_to_cpu ( desc->sizes ) );
 	}
 
@@ -932,9 +932,9 @@ efi_usb_get_endpoint_descriptor ( EFI_USB_IO_PROTOCOL *usbio, UINT8 index,
 	}
 
 	/* Locate and copy cached endpoint descriptor */
-	for_each_interface_descriptor ( desc, usbdev->config, interface ) {
-		if ( ( desc->header.type == USB_ENDPOINT_DESCRIPTOR ) &&
-		     ( index-- == 0 ) ) {
+	for_each_interface_descriptor ( desc, usbdev->config, interface,
+					USB_ENDPOINT_DESCRIPTOR ) {
+		if ( index-- == 0 ) {
 			memcpy ( efidesc, desc, sizeof ( *efidesc ) );
 			return 0;
 		}


### PR DESCRIPTION
A malicious USB device is out of scope for our threat model, but we already sanity check other descriptor fields, so we should also check that the reported length of a descriptor contained within a USB device configuration is adequate for the claimed descriptor type.

Update the two descriptor iterators to skip over descriptors that are shorter than the length required to contain the iterator type, so that the loop body can assume that it is safe to dereference any field within the iterator structure.  Simplify the call sites by integrating the descriptor type check into the iterator itself, since it fits very naturally alongside the length check.

Guard against infinite loops by ignoring any descriptors with a length field that is too short to contain the descriptor header itself.

Validate the descriptor length in usb_endpoint_companion_descriptor(), which is the only standalone use of usb_next_descriptor() outside of the two iterators.