### PR TITLE
[dns] Add redundant explicit check for CNAME validity

### DIFF
--- a/src/net/udp/dns.c
+++ b/src/net/udp/dns.c
@@ -678,7 +678,7 @@ static int dns_xfer_deliver ( struct dns_request *dns,
 	size_t answer_offset;
 	size_t next_offset;
 	size_t rdlength;
-	size_t name_len;
+	int name_len;
 	int rc;
 
 	/* Sanity check */
@@ -816,6 +816,11 @@ static int dns_xfer_deliver ( struct dns_request *dns,
 			       dns, dns_name ( &buf ) );
 			dns->search.offset = dns->search.len;
 			name_len = dns_copy ( &buf, &dns->name );
+			if ( name_len < 0 ) {
+				rc = name_len;
+				dns_done ( dns, rc );
+				goto done;
+			}
 			dns->offset = ( offsetof ( typeof ( dns->buf ), name ) +
 					name_len - 1 /* Strip root label */ );
 			if ( ( rc = dns_question ( dns ) ) != 0 ) {


### PR DESCRIPTION
Passing the invalid length returned from a failed call to dns_copy() in to dns_question() will cause the latter to fail safely, but via a path that is not obviously safe at first glance.

Check the return value from dns_copy() at the point of use, to reduce future review noise.