### PR TITLE
[tls] Guarantee that receive data buffer list is non-empty

### DIFF
--- a/src/net/tls.c
+++ b/src/net/tls.c
@@ -3632,7 +3632,7 @@ static int tls_newdata_process_header ( struct tls_connection *tls ) {
 
 	/* Allocate data buffers now that we know the length */
 	assert ( list_empty ( &tls->rx.data ) );
-	while ( remaining ) {
+	do {
 
 		/* Calculate fragment length.  Ensure that no block is
 		 * smaller than TLS_RX_MIN_BUFSIZE (by increasing the
@@ -3673,7 +3673,9 @@ static int tls_newdata_process_header ( struct tls_connection *tls ) {
 
 		/* Add I/O buffer to list */
 		list_add_tail ( &iobuf->list, &tls->rx.data );
-	}
+
+	} while ( remaining );
+	assert ( ! list_empty ( &tls->rx.data ) );
 
 	/* Move to data state */
 	tls->rx.state = TLS_RX_DATA;


### PR DESCRIPTION
Since commit 72db146 ("[tls] Split received records over multiple I/O buffers"), receive record processing has worked by allocating an I/O buffer list with exactly enough combined tailroom to hold the incoming record.

A zero-length record is not permitted by the protocol (and is impossible when a non-plaintext cipher is in use due to the extra space reserved at the start of the buffer list to accommodate the IV), but would currently result in an empty I/O buffer list.

Fix by ensuring that at least one buffer is always allocated even for a zero total length.