### PR TITLE
[crypto] Guard against mutation of certificate chain during validation

### DIFF
--- a/src/crypto/x509.c
+++ b/src/crypto/x509.c
@@ -1696,6 +1696,26 @@ int x509_append_raw ( struct x509_chain *chain, const void *data,
 }
 
 /**
+ * Find link containing X.509 certificate
+ *
+ * @v chain		X.509 certificate chain
+ * @v cert		X.509 certificate
+ * @ret link		Link containing certificate, or NULL if not found
+ */
+struct x509_link * x509_link ( struct x509_chain *chain,
+			       struct x509_certificate *cert ) {
+	struct x509_link *link;
+
+	/* Find link in chain */
+	list_for_each_entry ( link, &chain->links, list ) {
+		if ( link->cert == cert )
+			return link;
+	}
+
+	return NULL;
+}
+
+/**
  * Truncate X.509 certificate chain
  *
  * @v chain		X.509 certificate chain

--- a/src/include/ipxe/x509.h
+++ b/src/include/ipxe/x509.h
@@ -435,6 +435,8 @@ extern int x509_append ( struct x509_chain *chain,
 			 struct x509_certificate *cert );
 extern int x509_append_raw ( struct x509_chain *chain, const void *data,
 			     size_t len );
+extern struct x509_link * x509_link ( struct x509_chain *chain,
+				      struct x509_certificate *cert );
 extern void x509_truncate ( struct x509_chain *chain, struct x509_link *link );
 extern struct x509_certificate * x509_find ( struct x509_chain *store,
 					     const struct asn1_cursor *raw );

--- a/src/net/validator.c
+++ b/src/net/validator.c
@@ -57,8 +57,15 @@ struct validator;
 struct validator_action {
 	/** Name */
 	const char *name;
-	/** Action to take upon completed transfer */
-	void ( * done ) ( struct validator *validator, int rc );
+	/**
+	 * Action to take upon completed transfer
+	 *
+	 * @v validator		Certificate validator
+	 * @v cert		Certificate upon which action was taken
+	 * @v rc		Reason for completion
+	 */
+	void ( * done ) ( struct validator *validator,
+			  struct x509_certificate *cert, int rc );
 };
 
 /** A certificate validator */
@@ -118,15 +125,8 @@ struct validator {
 
 	/** Current action */
 	const struct validator_action *action;
-	/** Current certificate (for progress reporting)
-	 *
-	 * This will always be present within the certificate chain
-	 * and so this pointer does not hold a reference to the
-	 * certificate.
-	 */
+	/** Current certificate */
 	struct x509_certificate *cert;
-	/** Current link within certificate chain */
-	struct x509_link *link;
 };
 
 /**
@@ -158,6 +158,7 @@ static void validator_free ( struct refcnt *refcnt ) {
 	x509_chain_put ( validator->chain );
 	ocsp_put ( validator->ocsp );
 	xferbuf_free ( &validator->buffer );
+	x509_put ( validator->cert );
 	free ( validator );
 }
 
@@ -195,6 +196,7 @@ static int validator_progress ( struct validator *validator,
 
 	/* Report current action, if applicable */
 	if ( validator->action ) {
+		assert ( validator->cert != NULL );
 		snprintf ( progress->message, sizeof ( progress->message ),
 			   "%s %s", validator->action->name,
 			   x509_name ( validator->cert ) );
@@ -234,13 +236,15 @@ static const char crosscert_default[] = CROSSCERT;
  * Append cross-signing certificates to certificate chain
  *
  * @v validator		Certificate validator
+ * @v cert		Cross-signed certificate
  * @v rc		Completion status code
  * @ret rc		Return status code
  */
-static void validator_append ( struct validator *validator, int rc ) {
+static void validator_append ( struct validator *validator,
+			       struct x509_certificate *cert, int rc ) {
 	struct asn1_cursor cursor;
 	struct x509_chain *certs;
-	struct x509_certificate *cert;
+	struct x509_certificate *last;
 	struct x509_link *link;
 	struct x509_link *prev;
 
@@ -249,7 +253,7 @@ static void validator_append ( struct validator *validator, int rc ) {
 		DBGC ( validator, "VALIDATOR %p \"%s\" could not download ",
 		       validator, validator_name ( validator ) );
 		DBGC ( validator, "\"%s\" cross-signature: %s\n",
-		       x509_name ( validator->cert ), strerror ( rc ) );
+		       x509_name ( cert ), strerror ( rc ) );
 		/* If the overall validation is going to fail, then we
 		 * will end up attempting multiple downloads for
 		 * non-existent cross-signed certificates as we work
@@ -262,8 +266,7 @@ static void validator_append ( struct validator *validator, int rc ) {
 	}
 	DBGC ( validator, "VALIDATOR %p \"%s\" downloaded ",
 	       validator, validator_name ( validator ) );
-	DBGC ( validator, "\"%s\" cross-signature\n",
-	       x509_name ( validator->cert ) );
+	DBGC ( validator, "\"%s\" cross-signature\n", x509_name ( cert ) );
 
 	/* Allocate certificate list */
 	certs = x509_alloc_chain();
@@ -296,17 +299,26 @@ static void validator_append ( struct validator *validator, int rc ) {
 			DBGC_HDA ( validator, 0, cursor.data, cursor.len );
 			goto err_append_raw;
 		}
-		cert = x509_last ( certs );
+		last = x509_last ( certs );
 		DBGC ( validator, "VALIDATOR %p \"%s\" found certificate ",
 		       validator, validator_name ( validator ) );
-		DBGC ( validator, "%s\n", x509_name ( cert ) );
+		DBGC ( validator, "%s\n", x509_name ( last ) );
 
 		/* Move to next certificate */
 		asn1_skip_any ( &cursor );
 	}
 
+	/* Locate cross-signed certificate within chain */
+	link = x509_link ( validator->chain, cert );
+	if ( ! link ) {
+		DBGC ( validator, "VALIDATOR %p \"%s\" lost \"%s\"\n",
+		       validator, validator_name ( validator ),
+		       x509_name ( cert ) );
+		rc = -ENOENT;
+		goto err_link;
+	}
+
 	/* Truncate existing certificate chain at current link */
-	link = validator->link;
 	assert ( link->flags & X509_LINK_FL_CROSSED );
 	x509_truncate ( validator->chain, link );
 
@@ -335,6 +347,7 @@ static void validator_append ( struct validator *validator, int rc ) {
 	rc = 0;
 
  err_auto_append:
+ err_link:
  err_append_raw:
  err_certificateset:
 	x509_chain_put ( certs );
@@ -402,8 +415,7 @@ static int validator_start_download ( struct validator *validator,
 
 	/* Set completion handler */
 	validator->action = &validator_crosscert;
-	validator->cert = cert;
-	validator->link = link;
+	validator->cert = x509_get ( cert );
 
 	/* Open URI */
 	if ( ( rc = xfer_open_uri_string ( &validator->xfer,
@@ -423,6 +435,9 @@ static int validator_start_download ( struct validator *validator,
 
 	intf_restart ( &validator->xfer, rc );
  err_open_uri_string:
+	x509_put ( validator->cert );
+	validator->cert = NULL;
+	validator->action = NULL;
 	free ( uri_string );
  err_alloc_uri_string:
  err_check_uri_string:
@@ -441,9 +456,12 @@ static int validator_start_download ( struct validator *validator,
  * Validate OCSP response
  *
  * @v validator		Certificate validator
+ * @v cert		Checked certificate
  * @v rc		Completion status code
  */
-static void validator_ocsp_validate ( struct validator *validator, int rc ) {
+static void validator_ocsp_validate ( struct validator *validator,
+				      struct x509_certificate *cert,
+				      int rc ) {
 	const void *data = validator->buffer.data;
 	size_t len = validator->buffer.len;
 	time_t now;
@@ -476,7 +494,7 @@ static void validator_ocsp_validate ( struct validator *validator, int rc ) {
 	/* Success */
 	DBGC ( validator, "VALIDATOR %p \"%s\" checked ",
 	       validator, validator_name ( validator ) );
-	DBGC ( validator, "\"%s\" via OCSP\n", x509_name ( validator->cert ) );
+	DBGC ( validator, "\"%s\" via OCSP\n", x509_name ( cert ) );
 
  err_validate:
  err_response:
@@ -517,7 +535,7 @@ static int validator_start_ocsp ( struct validator *validator,
 
 	/* Set completion handler */
 	validator->action = &validator_ocsp;
-	validator->cert = cert;
+	validator->cert = x509_get ( cert );
 
 	/* Open URI */
 	uri_string = validator->ocsp->uri_string;
@@ -537,6 +555,9 @@ static int validator_start_ocsp ( struct validator *validator,
 
 	intf_restart ( &validator->xfer, rc );
  err_open:
+	x509_put ( validator->cert );
+	validator->cert = NULL;
+	validator->action = NULL;
 	ocsp_put ( validator->ocsp );
 	validator->ocsp = NULL;
  err_check:
@@ -557,15 +578,29 @@ static int validator_start_ocsp ( struct validator *validator,
  * @v rc		Reason for close
  */
 static void validator_xfer_close ( struct validator *validator, int rc ) {
+	const struct validator_action *action;
+	struct x509_certificate *cert;
 
 	/* Close data transfer interface */
 	intf_restart ( &validator->xfer, rc );
 	DBGC2 ( validator, "VALIDATOR %p \"%s\" transfer complete\n",
 		validator, validator_name ( validator ) );
 
+	/* Clear current action */
+	action = validator->action;
+	validator->action = NULL;
+	assert ( action != NULL );
+
+	/* Take temporary ownership of the current certificate */
+	cert = validator->cert;
+	validator->cert = NULL;
+	assert ( cert != NULL );
+
 	/* Process completed download */
-	assert ( validator->action != NULL );
-	validator->action->done ( validator, rc );
+	action->done ( validator, cert, rc );
+
+	/* Drop temporary reference to certificate */
+	x509_put ( cert );
 
 	/* Free downloaded data */
 	xferbuf_free ( &validator->buffer );

--- a/src/tests/x509_test.c
+++ b/src/tests/x509_test.c
@@ -1354,6 +1354,14 @@ static void x509_test_exec ( void ) {
 	x509_validate_chain_fail_ok ( &useless_chain, test_ca_expired,
 				      &empty_store, &test_root );
 
+	/* Check link finding */
+	link = x509_link ( server_chain.chain, server_crt.cert );
+	ok ( link->cert == server_crt.cert );
+	link = x509_link ( server_chain.chain, intermediate_crt.cert );
+	ok ( link->cert == intermediate_crt.cert );
+	link = x509_link ( server_chain.chain, ecserver_crt.cert );
+	ok ( link == NULL );
+
 	/* Check chain truncation */
 	link = list_last_entry ( &server_chain.chain->links,
 				 struct x509_link, list );


### PR DESCRIPTION
Certificate chains are reference-counted structures, and both the TLS connection and the validator hold a reference to the same certificate chain while validation is in progress.  The TLS connection will not mutate the chain during this time: if a second (illegal) Certificate record were to arrive then it would drop its reference to the existing chain (leaving the validator as the sole possessor) before creating a new chain to hold the received certificates.

The validator currently holds two pointers that could be invalidated if a future code change were to cause the chain to be externally mutatated while validation is in progress:

  - a pointer to the current certificate (for OCSP or cross-signed downloads) that does not hold its own reference and relies upon the chain's reference to keep the certificate pointer valid

  - a pointer to the current link within the certificate chain

Guard against this class of potential future code changes by promoting the certificate pointer to hold its own reference to the certificate so that it is guaranteed to remain valid, deleting the stored pointer to the current link completely, and adding a function x509_link() that is used to locate the certificate link by traversing the chain.