### PR TITLE
[feature] Add opt-in live menu filtering for large lists

### DIFF
--- a/src/core/dynui.c
+++ b/src/core/dynui.c
@@ -32,12 +32,116 @@ FILE_SECBOOT ( PERMITTED );
 
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <assert.h>
 #include <ipxe/list.h>
 #include <ipxe/dynui.h>
 
 /** List of all dynamic user interfaces */
 static LIST_HEAD ( dynamic_uis );
+
+/**
+ * Find a bounded case-insensitive substring
+ *
+ * @v haystack		Text to search
+ * @v needle		Text for which to search
+ * @v len		Length of search text
+ * @ret found		Substring was found
+ */
+static int dynui_contains ( const char *haystack, const char *needle,
+			    size_t len ) {
+	const char *candidate;
+	const char *a;
+	const char *b;
+	const char *end = ( needle + len );
+
+	if ( ! len )
+		return 1;
+
+	for ( candidate = haystack ; candidate[0] ; candidate++ ) {
+		for ( a = candidate, b = needle ;
+		      ( b < end ) && a[0] &&
+		      ( tolower ( ( unsigned char ) a[0] ) ==
+			tolower ( ( unsigned char ) b[0] ) ) ; a++, b++ ) {}
+		if ( b == end )
+			return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * Check whether an item is the menu filter compatibility sentinel
+ *
+ * @v item		Dynamic user interface item
+ * @ret is_sentinel	Item is the filter sentinel
+ */
+int dynui_item_is_filter_sentinel ( struct dynamic_item *item ) {
+
+	return ( ( ! item->name ) &&
+		 ( strcmp ( item->text, DYNUI_FILTER_SENTINEL ) == 0 ) );
+}
+
+/**
+ * Check whether a dynamic user interface requests a menu filter
+ *
+ * @v dynui		Dynamic user interface
+ * @ret has_sentinel	User interface contains the filter sentinel
+ */
+int dynui_has_filter_sentinel ( struct dynamic_ui *dynui ) {
+	struct dynamic_item *item;
+
+	list_for_each_entry ( item, &dynui->items, list ) {
+		if ( dynui_item_is_filter_sentinel ( item ) )
+			return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * Check whether a dynamic user interface item matches a query
+ *
+ * @v item		Dynamic user interface item
+ * @v query		Search text
+ * @ret matches		Item matches
+ */
+int dynui_item_matches ( struct dynamic_item *item, const char *query ) {
+	const char *term;
+	size_t len;
+
+	/* Hide the compatibility sentinel on filter-capable clients */
+	if ( dynui_item_is_filter_sentinel ( item ) )
+		return 0;
+
+	/* Ignore leading whitespace */
+	while ( isspace ( ( unsigned char ) query[0] ) )
+		query++;
+
+	/* Preserve the unfiltered menu exactly, including separators */
+	if ( ! query[0] )
+		return 1;
+
+	/* Separators are not searchable values */
+	if ( ! item->name )
+		return 0;
+
+	/* Require every whitespace-separated term to match either field */
+	while ( query[0] ) {
+		term = query;
+		while ( query[0] &&
+			! isspace ( ( unsigned char ) query[0] ) )
+			query++;
+		len = ( query - term );
+		if ( ! ( dynui_contains ( item->name, term, len ) ||
+			 dynui_contains ( item->text, term, len ) ) )
+			return 0;
+		while ( isspace ( ( unsigned char ) query[0] ) )
+			query++;
+	}
+
+	return 1;
+}
 
 /**
  * Create dynamic user interface

--- a/src/hci/tui/menu_ui.c
+++ b/src/hci/tui/menu_ui.c
@@ -31,6 +31,7 @@ FILE_SECBOOT ( PERMITTED );
  */
 
 #include <string.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <curses.h>
 #include <ipxe/keys.h>
@@ -39,19 +40,36 @@ FILE_SECBOOT ( PERMITTED );
 #include <ipxe/ansicol.h>
 #include <ipxe/jumpscroll.h>
 #include <ipxe/dynui.h>
+#include <ipxe/editstring.h>
 
 /* Screen layout */
 #define TITLE_ROW	1U
 #define MENU_ROW	3U
+#define FILTER_MENU_ROW	5U
+#define FILTER_ROW	3U
 #define MENU_COL	1U
-#define MENU_ROWS	( LINES - 2U - MENU_ROW )
 #define MENU_COLS	( COLS - 2U )
 #define MENU_PAD	2U
+#define FILTER_LABEL	"Search: "
 
 /** A menu user interface */
 struct menu_ui {
 	/** Dynamic user interface */
 	struct dynamic_ui *dynui;
+	/** Visible dynamic user interface items */
+	struct dynamic_item **visible;
+	/** Enable interactive filtering */
+	int filter;
+	/** Search field has focus */
+	int filter_focus;
+	/** Search text */
+	char *query;
+	/** Editable search text */
+	struct edit_string edit;
+	/** First row of menu items */
+	unsigned int menu_row;
+	/** Maximum number of visible menu rows */
+	unsigned int menu_rows;
 	/** Jump scroller */
 	struct jump_scroller scroll;
 	/** Remaining timeout (0=indefinite) */
@@ -59,6 +77,114 @@ struct menu_ui {
 	/** Post-activity timeout (0=indefinite) */
 	unsigned long retimeout;
 };
+
+/**
+ * Get visible menu item
+ *
+ * @v ui		Menu user interface
+ * @v index		Visible index
+ * @ret item		Dynamic user interface item, or NULL
+ */
+static struct dynamic_item * menu_item ( struct menu_ui *ui,
+					 unsigned int index ) {
+
+	if ( index >= ui->scroll.count )
+		return NULL;
+
+	return ui->visible[index];
+}
+
+/**
+ * Rebuild visible menu items
+ *
+ * @v ui		Menu user interface
+ * @v preferred		Preferred selected item, or NULL
+ * @ret named_count	Number of selectable items
+ */
+static unsigned int rebuild_menu ( struct menu_ui *ui,
+				   struct dynamic_item *preferred ) {
+	struct dynamic_item *item;
+	const char *query = ( ui->query ? ui->query : "" );
+	unsigned int preferred_index = 0;
+	unsigned int default_index = 0;
+	unsigned int named_count = 0;
+	unsigned int count = 0;
+	int have_preferred = 0;
+
+	list_for_each_entry ( item, &ui->dynui->items, list ) {
+		if ( ! dynui_item_matches ( item, query ) )
+			continue;
+		ui->visible[count] = item;
+		if ( item->name ) {
+			if ( ! named_count )
+				default_index = count;
+			named_count++;
+			if ( item == preferred ) {
+				preferred_index = count;
+				have_preferred = 1;
+			}
+			if ( item->flags & DYNUI_DEFAULT ) {
+				default_index = count;
+			}
+		}
+		count++;
+	}
+
+	ui->scroll.count = count;
+	ui->scroll.first = 0;
+	ui->scroll.current = ( have_preferred ? preferred_index : default_index );
+
+	if ( count && named_count )
+		jump_scroll ( &ui->scroll );
+
+	return named_count;
+}
+
+/**
+ * Draw filter field
+ *
+ * @v ui		Menu user interface
+ */
+static void draw_filter ( struct menu_ui *ui ) {
+	const char *query = ( ui->query ? ui->query : "" );
+	size_t label_len = strlen ( FILTER_LABEL );
+	size_t query_len = strlen ( query );
+	size_t field_cols = ( ( MENU_COLS > ( label_len + 3 ) ) ?
+			      ( MENU_COLS - label_len - 3 ) : 0 );
+	size_t first = 0;
+	size_t shown;
+	char buf[ MENU_COLS + 1 /* NUL */ ];
+
+	if ( ui->edit.cursor > field_cols )
+		first = ( ui->edit.cursor - field_cols );
+	shown = ( query_len - first );
+	if ( shown > field_cols )
+		shown = field_cols;
+
+	memset ( buf, ' ', ( sizeof ( buf ) - 1 ) );
+	buf[ sizeof ( buf ) - 1 ] = '\0';
+	buf[0] = '[';
+	memcpy ( &buf[1], FILTER_LABEL, label_len );
+	memcpy ( &buf[1 + label_len], &query[first], shown );
+	buf[MENU_COLS - 2] = ' ';
+	buf[MENU_COLS - 1] = ']';
+
+	if ( ui->filter_focus ) {
+		color_set ( CPAIR_SELECT, NULL );
+		attron ( A_BOLD );
+	}
+	mvprintw ( FILTER_ROW, MENU_COL, "%s", buf );
+	color_set ( CPAIR_NORMAL, NULL );
+	attroff ( A_BOLD );
+
+	if ( ui->filter_focus ) {
+		curs_set ( 1 );
+		move ( FILTER_ROW,
+		       ( MENU_COL + 1 + label_len + ui->edit.cursor - first ) );
+	} else {
+		curs_set ( 0 );
+	}
+}
 
 /**
  * Draw a numbered menu item
@@ -77,10 +203,10 @@ static void draw_menu_item ( struct menu_ui *ui, unsigned int index ) {
 
 	/* Move to start of row */
 	row_offset = ( index - ui->scroll.first );
-	move ( ( MENU_ROW + row_offset ), MENU_COL );
+	move ( ( ui->menu_row + row_offset ), MENU_COL );
 
 	/* Get menu item */
-	item = dynui_item ( ui->dynui, index );
+	item = menu_item ( ui, index );
 	if ( item ) {
 
 		/* Draw separators in a different colour */
@@ -125,7 +251,7 @@ static void draw_menu_item ( struct menu_ui *ui, unsigned int index ) {
 	}
 
 	/* Move cursor back to start of row */
-	move ( ( MENU_ROW + row_offset ), MENU_COL );
+	move ( ( ui->menu_row + row_offset ), MENU_COL );
 }
 
 /**
@@ -138,15 +264,90 @@ static void draw_menu_items ( struct menu_ui *ui ) {
 
 	/* Draw ellipses before and/or after the list as necessary */
 	color_set ( CPAIR_SEPARATOR, NULL );
-	mvaddstr ( ( MENU_ROW - 1 ), ( MENU_COL + MENU_PAD ),
+	mvaddstr ( ( ui->menu_row - 1 ), ( MENU_COL + MENU_PAD ),
 		   ( jump_scroll_is_first ( &ui->scroll ) ? "   " : "..." ) );
-	mvaddstr ( ( MENU_ROW + MENU_ROWS ), ( MENU_COL + MENU_PAD ),
+	mvaddstr ( ( ui->menu_row + ui->menu_rows ),
+		   ( MENU_COL + MENU_PAD ),
 		   ( jump_scroll_is_last ( &ui->scroll ) ? "   " : "..." ) );
 	color_set ( CPAIR_NORMAL, NULL );
 
 	/* Draw visible items */
-	for ( i = 0 ; i < MENU_ROWS ; i++ )
+	for ( i = 0 ; i < ui->menu_rows ; i++ )
 		draw_menu_item ( ui, ( ui->scroll.first + i ) );
+
+	/* Explain an empty result set */
+	if ( ! ui->scroll.count ) {
+		color_set ( CPAIR_SEPARATOR, NULL );
+		mvaddstr ( ui->menu_row, ( MENU_COL + MENU_PAD ),
+			   "No matching items" );
+		color_set ( CPAIR_NORMAL, NULL );
+	}
+}
+
+/**
+ * Find a visible item by shortcut key
+ *
+ * @v ui		Menu user interface
+ * @v key		Shortcut key
+ * @v index		Starting visible index
+ * @ret item		Matching visible item, or NULL
+ */
+static struct dynamic_item * menu_shortcut ( struct menu_ui *ui, int key,
+					     unsigned int index ) {
+	struct dynamic_item *item;
+	unsigned int i;
+
+	if ( ! key )
+		return NULL;
+
+	for ( i = index ; i < ui->scroll.count ; i++ ) {
+		item = menu_item ( ui, i );
+		if ( key == item->shortcut )
+			return item;
+	}
+	for ( i = 0 ; i < index ; i++ ) {
+		item = menu_item ( ui, i );
+		if ( key == item->shortcut )
+			return item;
+	}
+
+	return NULL;
+}
+
+/**
+ * Find visible index for an item
+ *
+ * @v ui		Menu user interface
+ * @v item		Dynamic user interface item
+ * @ret index		Visible index
+ */
+static unsigned int menu_index ( struct menu_ui *ui,
+				 struct dynamic_item *item ) {
+	unsigned int i;
+
+	for ( i = 0 ; i < ui->scroll.count ; i++ ) {
+		if ( menu_item ( ui, i ) == item )
+			return i;
+	}
+
+	return 0;
+}
+
+/**
+ * Check whether a selectable item precedes the current item
+ *
+ * @v ui		Menu user interface
+ * @ret precedes		A selectable item precedes the current item
+ */
+static int menu_item_precedes ( struct menu_ui *ui ) {
+	unsigned int i;
+
+	for ( i = 0 ; i < ui->scroll.current ; i++ ) {
+		if ( menu_item ( ui, i )->name )
+			return 1;
+	}
+
+	return 0;
 }
 
 /**
@@ -158,10 +359,12 @@ static void draw_menu_items ( struct menu_ui *ui ) {
  */
 static int menu_loop ( struct menu_ui *ui, struct dynamic_item **selected ) {
 	struct dynamic_item *item;
+	unsigned int named_count;
 	unsigned long timeout;
 	unsigned int previous;
 	unsigned int move;
 	int key;
+	int edited;
 	int chosen = 0;
 	int rc = 0;
 
@@ -180,50 +383,106 @@ static int menu_loop ( struct menu_ui *ui, struct dynamic_item **selected ) {
 		key = getkey ( timeout );
 		if ( key < 0 ) {
 			/* Choose default if we finally time out */
-			if ( ui->timeout == 0 )
-				chosen = 1;
+			if ( ui->timeout == 0 ) {
+				/* A filtered menu must be entered explicitly */
+				if ( ui->filter && ui->filter_focus ) {
+					continue;
+				} else if ( ui->scroll.count ) {
+					chosen = 1;
+				} else {
+					rc = -ENOENT;
+				}
+			}
 		} else {
 			/* Reset timeout after activity */
 			ui->timeout = ui->retimeout;
 
-			/* Handle scroll keys */
-			move = jump_scroll_key ( &ui->scroll, key );
-
-			/* Handle other keys */
-			switch ( key ) {
-			case ESC:
-			case CTRL_C:
-				rc = -ECANCELED;
-				break;
-			case CR:
-			case LF:
-				chosen = 1;
-				break;
-			default:
-				item = dynui_shortcut ( ui->dynui, key,
-							ui->scroll.current );
-				if ( item ) {
-					ui->scroll.current = item->index;
-					if ( item->name ) {
-						chosen = 1;
-					} else {
-						move = SCROLL_DOWN;
+			/* Handle search field */
+			if ( ui->filter && ui->filter_focus ) {
+				switch ( key ) {
+				case ESC:
+				case CTRL_C:
+					rc = -ECANCELED;
+					break;
+				case KEY_DOWN:
+				case TAB:
+				case CR:
+				case LF:
+					if ( ui->scroll.count )
+						ui->filter_focus = 0;
+					break;
+				default:
+					edited = edit_string ( &ui->edit, key );
+					if ( edited < 0 ) {
+						rc = edited;
+					} else if ( edited == 0 ) {
+						item = menu_item ( ui,
+								   ui->scroll.current );
+						named_count = rebuild_menu ( ui, item );
+						( void ) named_count;
 					}
+					break;
 				}
-				break;
+			} else {
+				/* Handle scroll keys */
+				if ( ui->scroll.count ) {
+					move = jump_scroll_key ( &ui->scroll, key );
+				} else {
+					move = SCROLL_NONE;
+				}
+
+				/* Up from the first result returns to search */
+				if ( ui->filter && ( key == KEY_UP ) &&
+				     ( ! menu_item_precedes ( ui ) ) ) {
+					ui->filter_focus = 1;
+					move = SCROLL_NONE;
+				}
+
+				/* Handle other keys */
+				switch ( key ) {
+				case ESC:
+				case CTRL_C:
+					rc = -ECANCELED;
+					break;
+				case CR:
+				case LF:
+					chosen = 1;
+					break;
+				default:
+					item = menu_shortcut ( ui, key,
+							       ui->scroll.current );
+					if ( item ) {
+						ui->scroll.current =
+							menu_index ( ui, item );
+						if ( item->name ) {
+							chosen = 1;
+						} else {
+							move = SCROLL_DOWN;
+						}
+					}
+					break;
+				}
 			}
 		}
 
 		/* Move selection, if applicable */
 		while ( move ) {
 			move = jump_scroll_move ( &ui->scroll, move );
-			item = dynui_item ( ui->dynui, ui->scroll.current );
+			item = menu_item ( ui, ui->scroll.current );
 			if ( item->name )
 				break;
 		}
 
-		/* Redraw selection if necessary */
-		if ( ( ui->scroll.current != previous ) || ( timeout != 0 ) ) {
+		/* Redraw */
+		if ( ui->filter ) {
+			if ( ui->scroll.count )
+				jump_scroll ( &ui->scroll );
+			draw_filter ( ui );
+			draw_menu_items ( ui );
+			if ( ui->scroll.count )
+				draw_menu_item ( ui, ui->scroll.current );
+		} else if ( ( ui->scroll.current != previous ) ||
+			    ( timeout != 0 ) ) {
 			draw_menu_item ( ui, previous );
 			if ( jump_scroll ( &ui->scroll ) )
 				draw_menu_items ( ui );
@@ -231,10 +490,12 @@ static int menu_loop ( struct menu_ui *ui, struct dynamic_item **selected ) {
 		}
 
 		/* Record selection */
-		item = dynui_item ( ui->dynui, ui->scroll.current );
-		assert ( item != NULL );
-		assert ( item->name != NULL );
-		*selected = item;
+		if ( ui->scroll.count ) {
+			item = menu_item ( ui, ui->scroll.current );
+			assert ( item != NULL );
+			assert ( item->name != NULL );
+			*selected = item;
+		}
 
 	} while ( ( rc == 0 ) && ! chosen );
 
@@ -254,6 +515,7 @@ int show_menu ( struct dynamic_ui *dynui, unsigned long timeout,
 		unsigned long retimeout, const char *select,
 		struct dynamic_item **selected ) {
 	struct dynamic_item *item;
+	struct dynamic_item *preferred = NULL;
 	struct menu_ui ui;
 	char buf[ MENU_COLS + 1 /* NUL */ ];
 	int named_count = 0;
@@ -262,32 +524,46 @@ int show_menu ( struct dynamic_ui *dynui, unsigned long timeout,
 	/* Initialise UI */
 	memset ( &ui, 0, sizeof ( ui ) );
 	ui.dynui = dynui;
-	ui.scroll.rows = MENU_ROWS;
+	ui.filter = dynui_has_filter_sentinel ( dynui );
+	ui.filter_focus = ui.filter;
+	ui.menu_row = ( ui.filter ? FILTER_MENU_ROW : MENU_ROW );
+	ui.menu_rows = ( LINES - 2U - ui.menu_row );
+	ui.scroll.rows = ui.menu_rows;
 	ui.timeout = timeout;
 	ui.retimeout = retimeout;
+	ui.visible = calloc ( dynui->count, sizeof ( ui.visible[0] ) );
+	if ( ! ui.visible ) {
+		rc = -ENOMEM;
+		goto err_visible;
+	}
+	ui.query = strdup ( "" );
+	if ( ! ui.query ) {
+		rc = -ENOMEM;
+		goto err_query;
+	}
+	init_editstring ( &ui.edit, &ui.query );
 
 	list_for_each_entry ( item, &dynui->items, list ) {
 		if ( item->name ) {
-			if ( ! named_count )
-				ui.scroll.current = ui.scroll.count;
 			named_count++;
 			if ( select ) {
 				if ( strcmp ( select, item->name ) == 0 )
-					ui.scroll.current = ui.scroll.count;
+					preferred = item;
 			} else {
 				if ( item->flags & DYNUI_DEFAULT )
-					ui.scroll.current = ui.scroll.count;
+					preferred = item;
 			}
 		}
-		ui.scroll.count++;
 	}
 	if ( ! named_count ) {
 		/* Menus with no named items cannot be selected from,
 		 * and will seriously confuse the navigation logic.
 		 * Refuse to display any such menus.
 		 */
-		return -ENOENT;
+		rc = -ENOENT;
+		goto err_no_items;
 	}
+	rebuild_menu ( &ui, preferred );
 
 	/* Initialise screen */
 	initscr();
@@ -302,15 +578,27 @@ int show_menu ( struct dynamic_ui *dynui, unsigned long timeout,
 	mvprintw ( TITLE_ROW, ( ( COLS - strlen ( buf ) ) / 2 ), "%s", buf );
 	attroff ( A_BOLD );
 	jump_scroll ( &ui.scroll );
+	if ( ui.filter )
+		draw_filter ( &ui );
 	draw_menu_items ( &ui );
 	draw_menu_item ( &ui, ui.scroll.current );
 
 	/* Enter main loop */
 	rc = menu_loop ( &ui, selected );
-	assert ( *selected );
+	if ( rc == 0 )
+		assert ( *selected );
 
 	/* Clear screen */
 	endwin();
 
+	free ( ui.query );
+	free ( ui.visible );
+	return rc;
+
+ err_no_items:
+	free ( ui.query );
+ err_query:
+	free ( ui.visible );
+ err_visible:
 	return rc;
 }

--- a/src/include/ipxe/dynui.h
+++ b/src/include/ipxe/dynui.h
@@ -48,6 +48,10 @@ struct dynamic_item {
 /** Dynamic user interface item represents a secret */
 #define DYNUI_SECRET 0x0002
 
+/** Compatibility sentinel requesting an interactive menu filter */
+#define DYNUI_FILTER_SENTINEL \
+	"filter-enabled This version of iPXE does not support filters, entire list shown"
+
 extern struct dynamic_ui * create_dynui ( const char *name, const char *title );
 extern struct dynamic_item * add_dynui_item ( struct dynamic_ui *dynui,
 					      const char *name,
@@ -60,6 +64,10 @@ extern struct dynamic_item * dynui_item ( struct dynamic_ui *dynui,
 					  unsigned int index );
 extern struct dynamic_item * dynui_shortcut ( struct dynamic_ui *dynui,
 					      int key, unsigned int index );
+extern int dynui_item_is_filter_sentinel ( struct dynamic_item *item );
+extern int dynui_has_filter_sentinel ( struct dynamic_ui *dynui );
+extern int dynui_item_matches ( struct dynamic_item *item,
+				const char *query );
 extern int show_menu ( struct dynamic_ui *dynui, unsigned long timeout,
 		       unsigned long retimeout, const char *select,
 		       struct dynamic_item **selected );

--- a/src/tests/dynui_test.c
+++ b/src/tests/dynui_test.c
@@ -1,0 +1,89 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** @file
+ *
+ * Dynamic user interface tests
+ *
+ */
+
+/* Forcibly enable assertions */
+#undef NDEBUG
+
+#include <ipxe/dynui.h>
+#include <ipxe/test.h>
+
+/** Perform dynamic user interface self-tests */
+static void dynui_test_exec ( void ) {
+	struct dynamic_ui marked = { 0 };
+	struct dynamic_item named = {
+		.name = "42",
+		.text = "Linux Workstations",
+	};
+	struct dynamic_item separator = {
+		.name = NULL,
+		.text = "Available host groups",
+	};
+	struct dynamic_item sentinel = {
+		.name = NULL,
+		.text = DYNUI_FILTER_SENTINEL,
+	};
+
+	/* The exact gap sentinel enables filtering and is hidden by new clients */
+	INIT_LIST_HEAD ( &marked.items );
+	INIT_LIST_HEAD ( &sentinel.list );
+	list_add_tail ( &sentinel.list, &marked.items );
+	ok ( dynui_item_is_filter_sentinel ( &sentinel ) );
+	ok ( ! dynui_item_is_filter_sentinel ( &separator ) );
+	ok ( dynui_has_filter_sentinel ( &marked ) );
+	ok ( ! dynui_item_matches ( &sentinel, "" ) );
+	ok ( ! dynui_item_matches ( &sentinel, "filter" ) );
+
+	/* Empty search retains the original menu structure */
+	ok ( dynui_item_matches ( &named, "" ) );
+	ok ( dynui_item_matches ( &separator, "" ) );
+	ok ( dynui_item_matches ( &named, "  \t " ) );
+	ok ( dynui_item_matches ( &separator, "  \t " ) );
+
+	/* Search is a case-insensitive substring of value or label */
+	ok ( dynui_item_matches ( &named, "42" ) );
+	ok ( dynui_item_matches ( &named, "work" ) );
+	ok ( dynui_item_matches ( &named, "LINUX" ) );
+	ok ( ! dynui_item_matches ( &named, "server" ) );
+
+	/* Whitespace-separated terms are combined using AND */
+	ok ( dynui_item_matches ( &named, "linux work" ) );
+	ok ( dynui_item_matches ( &named, "42 work" ) );
+	ok ( dynui_item_matches ( &named, "  WORK   42  " ) );
+	ok ( ! dynui_item_matches ( &named, "linux server" ) );
+	ok ( ! dynui_item_matches ( &named, "42 server" ) );
+
+	/* Separators are not searchable values */
+	ok ( ! dynui_item_matches ( &separator, "host" ) );
+}
+
+/** Dynamic user interface self-test */
+struct self_test dynui_test __self_test = {
+	.name = "dynui",
+	.exec = dynui_test_exec,
+};

--- a/src/tests/tests.c
+++ b/src/tests/tests.c
@@ -85,6 +85,7 @@ REQUIRE_OBJECT ( des_test );
 REQUIRE_OBJECT ( mschapv2_test );
 REQUIRE_OBJECT ( uuid_test );
 REQUIRE_OBJECT ( editstring_test );
+REQUIRE_OBJECT ( dynui_test );
 REQUIRE_OBJECT ( p256_test );
 REQUIRE_OBJECT ( p384_test );
 REQUIRE_OBJECT ( efi_siglist_test );


### PR DESCRIPTION
This patch will add (when a specific list item is created example list below) a filter search dialog box will appear to filter long lists of items. it's simple and assumed keywords are AND (no OR functionality) non-matching items in the list are hidden. navigation is the same with arrow keys to select any visible item.

To trigger the search dialog, the first item must be exactly:
```
item --gap filter-enabled This version of iPXE does not support filters, entire list shown
```

We added this due to very long lists of auto generated items during an iPXE host imaging process (like hostgroup or partition layouts sourced from RH Satellite Server). this can be used for any list.

Also designed to be backwards compatible with older or stock ipxe builds. the item is ignored by older ipxe (tested back to 1.0.0) and otherwise functions normally with a standard pick list.

Example
```
#!ipxe

menu Select a profile
item --gap filter-enabled This version of iPXE does not support filters, entire list shown
item cedar-db-8 Cedar Database - Linux 8 - Standard
item amber-web-9 Amber Web - Linux 9 - Thin
item quartz-dev-8 Quartz Development - Linux 8 - Thin
item birch-app-9 Birch Application - Linux 9 - Standard
item cobalt-db-9 Cobalt Database - Linux 9 - Thin
item maple-web-8 Maple Web - Linux 8 - Standard

choose --default amber-web-9 profile || exit
echo Selected: ${profile}
```
