### PR TITLE
[crypto] Treat high tag numbers as invalid

### DIFF
--- a/src/crypto/asn1.c
+++ b/src/crypto/asn1.c
@@ -151,6 +151,10 @@ FILE_SECBOOT ( PERMITTED );
 	__einfo_error ( EINFO_ENOTSUP_ALGORITHM )
 #define EINFO_ENOTSUP_ALGORITHM \
 	__einfo_uniqify ( EINFO_ENOTSUP, 0x01, "Unsupported algorithm" )
+#define ENOTSUP_HIGH \
+	__einfo_error ( EINFO_ENOTSUP_HIGH )
+#define EINFO_ENOTSUP_HIGH \
+	__einfo_uniqify ( EINFO_ENOTSUP, 0x02, "Unsupported high tag number" )
 #define ENOTTY_ALGORITHM \
 	__einfo_error ( EINFO_ENOTTY_ALGORITHM )
 #define EINFO_ENOTTY_ALGORITHM \
@@ -183,6 +187,14 @@ static int asn1_start ( struct asn1_cursor *cursor, unsigned int type ) {
 			DBGC ( cursor, "ASN1 %p too short\n", cursor );
 		asn1_invalidate_cursor ( cursor );
 		return -EINVAL_ASN1_EMPTY;
+	}
+
+	/* Refuse to handle multi-byte tags */
+	if ( ( asn1_type ( cursor ) & ASN1_HIGH ) == ASN1_HIGH ) {
+		DBGC ( cursor, "ASN1 %p has unsupported high tag number\n",
+		       cursor );
+		asn1_invalidate_cursor ( cursor );
+		return -ENOTSUP_HIGH;
 	}
 
 	/* Check the tag byte */

--- a/src/include/ipxe/asn1.h
+++ b/src/include/ipxe/asn1.h
@@ -86,6 +86,9 @@ struct asn1_builder_header {
 /** ASN.1 generalized time */
 #define ASN1_GENERALIZED_TIME 0x18
 
+/** ASN.1 high tag number */
+#define ASN1_HIGH 0x1f
+
 /** ASN.1 sequence */
 #define ASN1_SEQUENCE 0x30
 


### PR DESCRIPTION
ASN.1 allows for multi-byte tag numbers by setting the low five bits of the first tag byte to 0x1f.  No tag that we need to handle has this format, and the existing checks for specific tag numbers will already fail to match against such a tag (treating it as a normal single-byte tag number).

Refuse to parse any tag with a high tag number format, to guard against future bugs that could arise because the tag length would be calculated incorrectly.