### PR TITLE
The test for the --divide flag for gas was faulty.

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -390,7 +390,7 @@ WORKAROUND_CFLAGS += $(WNUSI_FLAGS)
 # comment markers.  Specifying --divide will work around this problem,
 # but isn't available on older gas versions.
 #
-DIVIDE_TEST = $(AS) --divide /dev/null -o /dev/null 2>/dev/null
+DIVIDE_TEST = $(AS) --divide -o /dev/null </dev/null 2>/dev/null
 DIVIDE_FLAGS := $(shell $(DIVIDE_TEST) && $(ECHO) '--divide')
 WORKAROUND_ASFLAGS += $(DIVIDE_FLAGS)
 


### PR DESCRIPTION
The test for the --divide flag for gas was faulty.

Previously it used /dev/null as both the input file and output file, causing gas to always error with:
> Fatal error: The input '/dev/null' and output '/dev/null' files are the same

This change still uses /dev/null, but runs it through stdin so gas doesn't assume it's the same file, but still successfully tests whether the divide flag is available.

This issue has been silent on Linux builds, as it seems the Linux configurations of gas don't consider the '/' character for comments anyway. So, whether the '--divide' flag is used or not doesn't change the behavior at all. However, I did observe this issue in a FreeBSD environment where the '--divide' flag becomes necessary. While exploring possible fixes, I found it had already been attempted with this 'DIVIDE_TEST' declaration, but found it has not been working.