### PR TITLE
Fixes an issue where the GNU-stack section declaration explicitly stated a type that conflicted with newer GNU BinUtils

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1042,7 +1042,7 @@ endif
 # Device ID tables (using IDs from ROM definition file)
 #
 define obj_pci_id_asm
-	.section ".note.GNU-stack", "", $(ASM_TCHAR)progbits
+	.section ".note.GNU-stack"
 	.section ".pci_devlist.$(1)", "a", $(ASM_TCHAR)progbits
 	.globl pci_devlist_$(1)
 pci_devlist_$(1):

--- a/src/arch/arm32/core/pmccntr.S
+++ b/src/arch/arm32/core/pmccntr.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.text
 	.arm
 

--- a/src/arch/arm32/core/setjmp.S
+++ b/src/arch/arm32/core/setjmp.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.text
 	.arm
 

--- a/src/arch/arm32/libgcc/lldivmod.S
+++ b/src/arch/arm32/libgcc/lldivmod.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.thumb
 
 /**

--- a/src/arch/arm32/libgcc/llshift.S
+++ b/src/arch/arm32/libgcc/llshift.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.arm
 
 /**

--- a/src/arch/arm64/core/setjmp.S
+++ b/src/arch/arm64/core/setjmp.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.text
 
 	/* Must match jmp_buf structure layout */

--- a/src/arch/i386/core/gdbidt.S
+++ b/src/arch/i386/core/gdbidt.S
@@ -11,7 +11,7 @@ FILE_SECBOOT ( FORBIDDEN );
  * Interrupt handlers
  ****************************************************************************
  */
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.section ".text", "ax", @progbits
 	.code32
 

--- a/src/arch/i386/core/setjmp.S
+++ b/src/arch/i386/core/setjmp.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 	.code32
 	.arch i386

--- a/src/arch/i386/tests/gdbstub_test.S
+++ b/src/arch/i386/tests/gdbstub_test.S
@@ -1,4 +1,4 @@
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code32
 	.arch i386
 

--- a/src/arch/loong64/core/loong64_tcpip.S
+++ b/src/arch/loong64/core/loong64_tcpip.S
@@ -30,7 +30,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /**

--- a/src/arch/loong64/core/setjmp.S
+++ b/src/arch/loong64/core/setjmp.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", %progbits
+	.section ".note.GNU-stack"
 	.text
 /*
    int setjmp(jmp_buf env);

--- a/src/arch/riscv/core/riscv_strings.S
+++ b/src/arch/riscv/core/riscv_strings.S
@@ -30,7 +30,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /**

--- a/src/arch/riscv/core/riscv_tcpip.S
+++ b/src/arch/riscv/core/riscv_tcpip.S
@@ -30,7 +30,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /**

--- a/src/arch/riscv/core/setjmp.S
+++ b/src/arch/riscv/core/setjmp.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	/* Must match jmp_buf structure layout */

--- a/src/arch/riscv/core/stack.S
+++ b/src/arch/riscv/core/stack.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 #define STACK_ALIGN 16

--- a/src/arch/riscv/prefix/libprefix.S
+++ b/src/arch/riscv/prefix/libprefix.S
@@ -32,7 +32,7 @@
 #include <config/serial.h>
 #include <config/fault.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	/* Link-time base address of _prefix

--- a/src/arch/riscv/prefix/lkrnprefix.S
+++ b/src/arch/riscv/prefix/lkrnprefix.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	/* Layout of kernel header */

--- a/src/arch/riscv/prefix/sbiprefix.S
+++ b/src/arch/riscv/prefix/sbiprefix.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /* Page size */

--- a/src/arch/riscv32/core/riscv32_byteswap.S
+++ b/src/arch/riscv32/core/riscv32_byteswap.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	.section ".text.riscv_swap", "ax", @progbits

--- a/src/arch/riscv32/libgcc/llshift.S
+++ b/src/arch/riscv32/libgcc/llshift.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /**

--- a/src/arch/riscv64/core/riscv64_byteswap.S
+++ b/src/arch/riscv64/core/riscv64_byteswap.S
@@ -30,7 +30,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	.section ".text.riscv_swap", "ax", @progbits

--- a/src/arch/s390x/core/setjmp.S
+++ b/src/arch/s390x/core/setjmp.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /*

--- a/src/arch/x86/core/mpcall.S
+++ b/src/arch/x86/core/mpcall.S
@@ -29,7 +29,7 @@
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /* Selectively assemble code for 32-bit/64-bit builds */

--- a/src/arch/x86/core/patch_cf.S
+++ b/src/arch/x86/core/patch_cf.S
@@ -22,7 +22,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/core/stack.S
+++ b/src/arch/x86/core/stack.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 
 #ifdef __x86_64__
 #define STACK_SIZE 8192

--- a/src/arch/x86/core/stack16.S
+++ b/src/arch/x86/core/stack16.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 
 /****************************************************************************
  * Internal stack

--- a/src/arch/x86/core/ucode_mp.S
+++ b/src/arch/x86/core/ucode_mp.S
@@ -29,7 +29,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 /* Selectively assemble code for 32-bit/64-bit builds */

--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -10,7 +10,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 #define PIC1_ICR 0x20
 #define PIC2_ICR 0xa0
 	
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/interface/pcbios/e820mangler.S
+++ b/src/arch/x86/interface/pcbios/e820mangler.S
@@ -23,7 +23,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/interface/pxe/pxe_entry.S
+++ b/src/arch/x86/interface/pxe/pxe_entry.S
@@ -26,7 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/interface/syslinux/com32_wrapper.S
+++ b/src/arch/x86/interface/syslinux/com32_wrapper.S
@@ -21,7 +21,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 
 #include "librm.h"
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 
 	.code32

--- a/src/arch/x86/prefix/bootpart.S
+++ b/src/arch/x86/prefix/bootpart.S
@@ -5,7 +5,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define STACK_SEG 	0x0200
 #define STACK_SIZE	0x2000
 	
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/dskprefix.S
+++ b/src/arch/x86/prefix/dskprefix.S
@@ -24,7 +24,7 @@ FILE_LICENCE ( GPL2_ONLY )
 
 .equ	SYSSEG, 0x1000			/* system loaded at SYSSEG<<4 */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.org	0
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/exeprefix.S
+++ b/src/arch/x86/prefix/exeprefix.S
@@ -36,7 +36,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PSP_CMDLINE_LEN 0x80
 #define PSP_CMDLINE_START 0x81
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/hdprefix.S
+++ b/src/arch/x86/prefix/hdprefix.S
@@ -2,7 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/libprefix.S
+++ b/src/arch/x86/prefix/libprefix.S
@@ -26,7 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -4,7 +4,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define BZI_LOAD_HIGH_ADDR 0x100000
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/mbr.S
+++ b/src/arch/x86/prefix/mbr.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/mromprefix.S
+++ b/src/arch/x86/prefix/mromprefix.S
@@ -41,7 +41,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define _pcirom_start _mrom_start
 #include "pciromprefix.S"
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/prefix/nbiprefix.S
+++ b/src/arch/x86/prefix/nbiprefix.S
@@ -2,7 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/nullprefix.S
+++ b/src/arch/x86/prefix/nullprefix.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.org	0
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/pxeprefix.S
+++ b/src/arch/x86/prefix/pxeprefix.S
@@ -12,7 +12,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define PXE_HACK_EB54			0x0001
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -8,7 +8,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/romprefix.S
+++ b/src/arch/x86/prefix/romprefix.S
@@ -54,7 +54,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BUSTYPE "PCIR"
 #endif
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/undiloader.S
+++ b/src/arch/x86/prefix/undiloader.S
@@ -2,7 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -43,7 +43,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  ****************************************************************************
  */
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code32
 	.arch i386
 	.section ".prefix.lib", "ax", @progbits

--- a/src/arch/x86/prefix/usbdisk.S
+++ b/src/arch/x86/prefix/usbdisk.S
@@ -3,7 +3,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <ipxe/disklog.h>
 #include <config/console.h>
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/transitions/liba20.S
+++ b/src/arch/x86/transitions/liba20.S
@@ -24,7 +24,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 

--- a/src/arch/x86/transitions/libkir.S
+++ b/src/arch/x86/transitions/libkir.S
@@ -31,7 +31,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 /* Breakpoint for when debugging under bochs */
 #define BOCHSBP xchgw %bx, %bx
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.code16
 	.arch i386
 	.section ".text16", "awx", @progbits

--- a/src/arch/x86/transitions/librm.S
+++ b/src/arch/x86/transitions/librm.S
@@ -92,7 +92,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define if64 if 0
 #endif
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 
 /****************************************************************************
  * Global descriptor table

--- a/src/arch/x86_64/core/gdbidt.S
+++ b/src/arch/x86_64/core/gdbidt.S
@@ -39,7 +39,7 @@ FILE_SECBOOT ( FORBIDDEN );
 #define SIGFPE 8
 #define SIGSTKFLT 16
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.section ".text.gdbmach_interrupt", "ax", @progbits
 	.code64
 

--- a/src/arch/x86_64/core/setjmp.S
+++ b/src/arch/x86_64/core/setjmp.S
@@ -1,6 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
-	.section ".note.GNU-stack", "", @progbits
+	.section ".note.GNU-stack"
 	.text
 	.code64
 


### PR DESCRIPTION
This addresses issue #1842 

BinUtils has historically defined the special .note.GNU-stack section as a 'progbits' type. However, since 2.46 they have changed it to be of type 'note'.

These lines in the iPXE code had intended to ensure the stack was defined as non-executable. That is the default configuration for the .note.GNU-stack section - so explicitly placing the empty flags and the type (previously progbits) was not necessary. However, in the past, it had no ill effect to define them.

With the newer BinUtils, since the built-in type has changed to 'note', when these lines are encountered by gas, they throw a warning that it's ignoring the attempt to change the type, as well as a warning for using the incorrect type. These warnings are generally benign, since the assembler just ignores them - however, iPXE is built with warnings as errors, so the build is stopped.

There is not a way to silence this specific warning in gas. It either treats all warnings as errors or no warning as errors. Thus, the approach taken with this PR is to omit the explicit declaration of flags and type for the .note.GNU-stack section in all of the assembly files. This will allow the 'default' of the runtime gas to be used without conflict or warning. Since the default flags are non-executable, this change should have no ill effect and maintain both forward and backward compatibility.